### PR TITLE
Flexible CSV import: aliases, BOM, semicolons, TG dedup (issue #16)

### DIFF
--- a/backend/internal/prospects/handler.go
+++ b/backend/internal/prospects/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/daniil/floq/internal/httputil"
@@ -112,7 +113,12 @@ func (h *Handler) importCSV() http.HandlerFunc {
 		}
 		count, err := h.uc.ImportCSV(r.Context(), userID, data)
 		if err != nil {
-			httputil.WriteError(w, http.StatusBadRequest, err.Error())
+			msg := err.Error()
+			if strings.Contains(msg, "csv header") || strings.Contains(msg, "csv record") {
+				httputil.WriteError(w, http.StatusBadRequest, msg)
+			} else {
+				httputil.WriteError(w, http.StatusBadRequest, "failed to import CSV")
+			}
 			return
 		}
 

--- a/backend/internal/prospects/handler.go
+++ b/backend/internal/prospects/handler.go
@@ -21,6 +21,7 @@ func RegisterRoutes(r chi.Router, uc *UseCase) {
 	r.Get("/api/prospects", h.listProspects())
 	r.Post("/api/prospects", h.createProspect())
 	r.Get("/api/prospects/export", h.exportCSV())
+	r.Get("/api/prospects/template", h.templateCSV())
 	r.Post("/api/prospects/import", h.importCSV())
 	r.Get("/api/prospects/{id}", h.getProspect())
 	r.Delete("/api/prospects/{id}", h.deleteProspect())
@@ -116,6 +117,16 @@ func (h *Handler) importCSV() http.HandlerFunc {
 		}
 
 		httputil.WriteJSON(w, http.StatusOK, map[string]int{"imported": count})
+	}
+}
+
+func (h *Handler) templateCSV() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data := h.uc.TemplateCSV()
+		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+		w.Header().Set("Content-Disposition", `attachment; filename="floq-import-template.csv"`)
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
 	}
 }
 

--- a/backend/internal/prospects/usecase.go
+++ b/backend/internal/prospects/usecase.go
@@ -6,10 +6,24 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/daniil/floq/internal/prospects/domain"
 	"github.com/google/uuid"
 )
+
+var columnAliases = map[string]string{
+	"name": "name", "имя": "name", "имя в tg": "name", "full_name": "name",
+	"company": "company", "компания": "company", "организация": "company",
+	"title": "title", "должность": "title", "позиция": "title",
+	"email": "email", "почта": "email", "e-mail": "email",
+	"phone": "phone", "телефон": "phone", "тел": "phone",
+	"whatsapp": "whatsapp",
+	"telegram_username": "telegram_username", "tg-контакты": "telegram_username", "tg": "telegram_username", "telegram": "telegram_username",
+	"industry": "industry", "отрасль": "industry",
+	"company_size": "company_size",
+	"context": "context", "комментарий": "context", "описание": "context", "превью вакансии": "context",
+}
 
 type LeadChecker interface {
 	LeadExistsByEmail(ctx context.Context, userID uuid.UUID, email string) (bool, error)
@@ -104,26 +118,26 @@ func (uc *UseCase) DeleteProspect(ctx context.Context, id uuid.UUID) error {
 }
 
 func (uc *UseCase) ImportCSV(ctx context.Context, userID uuid.UUID, csvData []byte) (int, error) {
-	reader := csv.NewReader(bytes.NewReader(csvData))
+	csvData = stripBOM(csvData)
+	delimiter := detectDelimiter(csvData)
 
-	// Read and validate header
+	reader := csv.NewReader(bytes.NewReader(csvData))
+	reader.Comma = delimiter
+	reader.LazyQuotes = true
+
 	header, err := reader.Read()
 	if err != nil {
 		return 0, fmt.Errorf("read csv header: %w", err)
 	}
-	if len(header) < 4 || header[0] != "name" || header[1] != "company" || header[2] != "title" || header[3] != "email" {
-		return 0, fmt.Errorf("invalid csv header: expected name,company,title,email")
+
+	colMap := mapColumns(header)
+	if _, ok := colMap["name"]; !ok {
+		return 0, fmt.Errorf("invalid csv header: required column 'name' (or alias: имя, имя в tg) not found")
 	}
 
-	// Build column index map for optional columns
-	colIndex := make(map[string]int, len(header))
-	for i, name := range header {
-		colIndex[name] = i
-	}
-
-	getCol := func(record []string, name string) string {
-		if idx, ok := colIndex[name]; ok && idx < len(record) {
-			return record[idx]
+	getCol := func(record []string, canonical string) string {
+		if idx, ok := colMap[canonical]; ok && idx < len(record) {
+			return strings.TrimSpace(record[idx])
 		}
 		return ""
 	}
@@ -138,7 +152,8 @@ func (uc *UseCase) ImportCSV(ctx context.Context, userID uuid.UUID, csvData []by
 			return 0, fmt.Errorf("read csv record: %w", err)
 		}
 
-		email := record[3]
+		email := getCol(record, "email")
+		tgUsername := strings.TrimPrefix(getCol(record, "telegram_username"), "@")
 
 		if email != "" {
 			dup, err := uc.repo.FindByEmail(ctx, userID, email)
@@ -157,17 +172,24 @@ func (uc *UseCase) ImportCSV(ctx context.Context, userID uuid.UUID, csvData []by
 					continue
 				}
 			}
+		} else if tgUsername != "" {
+			dup, err := uc.repo.FindByTelegramUsername(ctx, userID, tgUsername)
+			if err != nil {
+				return 0, fmt.Errorf("dedup prospect tg check: %w", err)
+			}
+			if dup != nil {
+				continue
+			}
 		}
 
-		p, err := domain.NewProspect(userID, record[0], record[1], record[2], email, "csv")
+		name := getCol(record, "name")
+		p, err := domain.NewProspect(userID, name, getCol(record, "company"), getCol(record, "title"), email, "csv")
 		if err != nil {
-			// Skip rows with invalid name/userID — CSV import shouldn't
-			// abort on a single malformed row, but we must not persist one.
 			continue
 		}
 		p.Phone = getCol(record, "phone")
 		p.WhatsApp = getCol(record, "whatsapp")
-		p.TelegramUsername = getCol(record, "telegram_username")
+		p.TelegramUsername = tgUsername
 		p.Industry = getCol(record, "industry")
 		p.CompanySize = getCol(record, "company_size")
 		p.Context = getCol(record, "context")
@@ -181,8 +203,46 @@ func (uc *UseCase) ImportCSV(ctx context.Context, userID uuid.UUID, csvData []by
 	return len(prospects), nil
 }
 
+func stripBOM(data []byte) []byte {
+	if len(data) >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF {
+		return data[3:]
+	}
+	return data
+}
+
+func detectDelimiter(data []byte) rune {
+	idx := bytes.IndexByte(data, '\n')
+	firstLine := string(data)
+	if idx > 0 {
+		firstLine = string(data[:idx])
+	}
+	if strings.Count(firstLine, ";") > strings.Count(firstLine, ",") {
+		return ';'
+	}
+	return ','
+}
+
+func mapColumns(header []string) map[string]int {
+	result := make(map[string]int, len(header))
+	for i, raw := range header {
+		normalized := strings.ToLower(strings.TrimSpace(raw))
+		if canonical, ok := columnAliases[normalized]; ok {
+			if _, exists := result[canonical]; !exists {
+				result[canonical] = i
+			}
+		}
+	}
+	return result
+}
+
 func (uc *UseCase) TemplateCSV() []byte {
-	return nil
+	var buf bytes.Buffer
+	buf.Write([]byte{0xEF, 0xBB, 0xBF})
+	w := csv.NewWriter(&buf)
+	_ = w.Write([]string{"name", "company", "title", "email", "phone", "whatsapp", "telegram_username", "industry", "company_size", "context"})
+	_ = w.Write([]string{"Иван Петров", "ООО Рога и Копыта", "Менеджер", "ivan@example.com", "+79991234567", "", "ivan_petrov", "IT", "10-50", "Заинтересован в интеграции"})
+	w.Flush()
+	return buf.Bytes()
 }
 
 func (uc *UseCase) ExportCSV(ctx context.Context, userID uuid.UUID) ([]byte, error) {

--- a/backend/internal/prospects/usecase.go
+++ b/backend/internal/prospects/usecase.go
@@ -181,6 +181,10 @@ func (uc *UseCase) ImportCSV(ctx context.Context, userID uuid.UUID, csvData []by
 	return len(prospects), nil
 }
 
+func (uc *UseCase) TemplateCSV() []byte {
+	return nil
+}
+
 func (uc *UseCase) ExportCSV(ctx context.Context, userID uuid.UUID) ([]byte, error) {
 	prospects, err := uc.repo.ListProspects(ctx, userID)
 	if err != nil {

--- a/backend/internal/prospects/usecase_test.go
+++ b/backend/internal/prospects/usecase_test.go
@@ -60,7 +60,12 @@ func (m *mockRepo) GetProspectForUser(_ context.Context, userID, prospectID uuid
 	return p, nil
 }
 
-func (m *mockRepo) FindByTelegramUsername(_ context.Context, _ uuid.UUID, _ string) (*domain.Prospect, error) {
+func (m *mockRepo) FindByTelegramUsername(_ context.Context, userID uuid.UUID, username string) (*domain.Prospect, error) {
+	for _, p := range m.prospects {
+		if p.UserID == userID && p.TelegramUsername == username {
+			return p, nil
+		}
+	}
 	return nil, nil
 }
 
@@ -476,6 +481,160 @@ func TestImportCSV_EmptyCSV(t *testing.T) {
 	_, err := uc.ImportCSV(context.Background(), uuid.New(), []byte(""))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "read csv header")
+}
+
+func TestImportCSV_StripsBOM(t *testing.T) {
+	repo := newMockRepo()
+	uc := NewUseCase(repo, WithLeadChecker(&mockLeadChecker{}))
+	userID := uuid.New()
+
+	bom := []byte{0xEF, 0xBB, 0xBF}
+	csvData := append(bom, []byte("name,company,title,email\nAlice,Acme,CEO,alice@acme.com\n")...)
+
+	count, err := uc.ImportCSV(context.Background(), userID, csvData)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "Alice", repo.batched[0].Name)
+}
+
+func TestImportCSV_SemicolonDelimiter(t *testing.T) {
+	repo := newMockRepo()
+	uc := NewUseCase(repo, WithLeadChecker(&mockLeadChecker{}))
+	userID := uuid.New()
+
+	csvData := []byte("name;company;title;email\nAlice;Acme;CEO;alice@acme.com\n")
+
+	count, err := uc.ImportCSV(context.Background(), userID, csvData)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "Alice", repo.batched[0].Name)
+	assert.Equal(t, "Acme", repo.batched[0].Company)
+}
+
+func TestImportCSV_FlexibleColumnOrder(t *testing.T) {
+	repo := newMockRepo()
+	uc := NewUseCase(repo, WithLeadChecker(&mockLeadChecker{}))
+	userID := uuid.New()
+
+	csvData := []byte("email,name,company,title\nalice@acme.com,Alice,Acme,CEO\n")
+
+	count, err := uc.ImportCSV(context.Background(), userID, csvData)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "Alice", repo.batched[0].Name)
+	assert.Equal(t, "alice@acme.com", repo.batched[0].Email)
+	assert.Equal(t, "Acme", repo.batched[0].Company)
+	assert.Equal(t, "CEO", repo.batched[0].Title)
+}
+
+func TestImportCSV_RussianColumnAliases(t *testing.T) {
+	repo := newMockRepo()
+	uc := NewUseCase(repo, WithLeadChecker(&mockLeadChecker{}))
+	userID := uuid.New()
+
+	csvData := []byte("имя;компания;должность;почта;телефон;telegram\nАлиса;ООО Рога;CEO;alice@acme.com;+79991234567;alice_tg\n")
+
+	count, err := uc.ImportCSV(context.Background(), userID, csvData)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "Алиса", repo.batched[0].Name)
+	assert.Equal(t, "ООО Рога", repo.batched[0].Company)
+	assert.Equal(t, "CEO", repo.batched[0].Title)
+	assert.Equal(t, "alice@acme.com", repo.batched[0].Email)
+	assert.Equal(t, "+79991234567", repo.batched[0].Phone)
+	assert.Equal(t, "alice_tg", repo.batched[0].TelegramUsername)
+}
+
+func TestImportCSV_TGContactsAlias(t *testing.T) {
+	repo := newMockRepo()
+	uc := NewUseCase(repo, WithLeadChecker(&mockLeadChecker{}))
+	userID := uuid.New()
+
+	csvData := []byte("имя в tg;tg-контакты;телефон;комментарий\nДарья;@crmlab_assistant;;Интегратор\n")
+
+	count, err := uc.ImportCSV(context.Background(), userID, csvData)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "Дарья", repo.batched[0].Name)
+	assert.Equal(t, "crmlab_assistant", repo.batched[0].TelegramUsername)
+	assert.Equal(t, "Интегратор", repo.batched[0].Context)
+}
+
+func TestImportCSV_OnlyNameRequired(t *testing.T) {
+	repo := newMockRepo()
+	uc := NewUseCase(repo, WithLeadChecker(&mockLeadChecker{}))
+	userID := uuid.New()
+
+	csvData := []byte("name\nAlice\nBob\n")
+
+	count, err := uc.ImportCSV(context.Background(), userID, csvData)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+	assert.Equal(t, "Alice", repo.batched[0].Name)
+	assert.Equal(t, "Bob", repo.batched[1].Name)
+}
+
+func TestImportCSV_NormalizeTGUsername(t *testing.T) {
+	repo := newMockRepo()
+	uc := NewUseCase(repo, WithLeadChecker(&mockLeadChecker{}))
+	userID := uuid.New()
+
+	csvData := []byte("name,telegram_username\nAlice,@alice_bot\nBob,bob_user\n")
+
+	count, err := uc.ImportCSV(context.Background(), userID, csvData)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+	assert.Equal(t, "alice_bot", repo.batched[0].TelegramUsername)
+	assert.Equal(t, "bob_user", repo.batched[1].TelegramUsername)
+}
+
+func TestImportCSV_DedupByTelegramUsername(t *testing.T) {
+	repo := newMockRepo()
+	userID := uuid.New()
+	existing, _ := domain.NewProspect(userID, "Existing", "Co", "CTO", "", "manual")
+	existing.TelegramUsername = "alice_tg"
+	repo.prospects[existing.ID] = existing
+
+	uc := NewUseCase(repo, WithLeadChecker(&mockLeadChecker{}))
+	csvData := []byte("name,telegram_username\nAlice,@alice_tg\nBob,bob_tg\n")
+	count, err := uc.ImportCSV(context.Background(), userID, csvData)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count) // only Bob
+	assert.Equal(t, "Bob", repo.batched[0].Name)
+}
+
+func TestImportCSV_CaseInsensitiveHeaders(t *testing.T) {
+	repo := newMockRepo()
+	uc := NewUseCase(repo, WithLeadChecker(&mockLeadChecker{}))
+	userID := uuid.New()
+
+	csvData := []byte("Name,Company,Title,Email\nAlice,Acme,CEO,alice@acme.com\n")
+
+	count, err := uc.ImportCSV(context.Background(), userID, csvData)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "Alice", repo.batched[0].Name)
+}
+
+func TestImportCSV_NoNameColumn(t *testing.T) {
+	repo := newMockRepo()
+	uc := NewUseCase(repo)
+
+	csvData := []byte("company,title,email\nAcme,CEO,a@b.com\n")
+
+	_, err := uc.ImportCSV(context.Background(), uuid.New(), csvData)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name")
+}
+
+func TestTemplateCSV(t *testing.T) {
+	uc := NewUseCase(newMockRepo())
+	data := uc.TemplateCSV()
+
+	csv := string(data)
+	assert.True(t, data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF, "should have BOM")
+	assert.Contains(t, csv, "name,company,title,email")
+	assert.Contains(t, csv, "telegram_username")
 }
 
 func TestImportCSV_MalformedRecord(t *testing.T) {

--- a/backend/internal/prospects/usecase_test.go
+++ b/backend/internal/prospects/usecase_test.go
@@ -119,12 +119,13 @@ func (m *mockLeadChecker) LeadExistsByEmail(_ context.Context, _ uuid.UUID, emai
 
 type mockErrorRepo struct {
 	mockRepo
-	listErr   error
-	getErr    error
-	createErr error
-	deleteErr error
-	findErr   error
-	batchErr  error
+	listErr    error
+	getErr     error
+	createErr  error
+	deleteErr  error
+	findErr    error
+	findByTGErr error
+	batchErr   error
 }
 
 func (m *mockErrorRepo) ListProspects(_ context.Context, _ uuid.UUID) ([]domain.ProspectWithSource, error) {
@@ -158,6 +159,13 @@ func (m *mockErrorRepo) DeleteProspect(_ context.Context, _ uuid.UUID) error {
 func (m *mockErrorRepo) FindByEmail(_ context.Context, _ uuid.UUID, _ string) (*domain.Prospect, error) {
 	if m.findErr != nil {
 		return nil, m.findErr
+	}
+	return nil, nil
+}
+
+func (m *mockErrorRepo) FindByTelegramUsername(_ context.Context, _ uuid.UUID, _ string) (*domain.Prospect, error) {
+	if m.findByTGErr != nil {
+		return nil, m.findByTGErr
 	}
 	return nil, nil
 }
@@ -601,6 +609,15 @@ func TestImportCSV_DedupByTelegramUsername(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, count) // only Bob
 	assert.Equal(t, "Bob", repo.batched[0].Name)
+}
+
+func TestImportCSV_FindByTGUsernameError(t *testing.T) {
+	repo := &mockErrorRepo{findByTGErr: fmt.Errorf("db connection refused")}
+	uc := NewUseCase(repo)
+	csvData := []byte("name,telegram_username\nAlice,alice_tg\n")
+	_, err := uc.ImportCSV(context.Background(), uuid.New(), csvData)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dedup prospect tg check")
 }
 
 func TestImportCSV_CaseInsensitiveHeaders(t *testing.T) {

--- a/frontend/src/app/(dashboard)/prospects/page.tsx
+++ b/frontend/src/app/(dashboard)/prospects/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Search, Upload, Download, ShieldCheck, Sparkles, ArrowRight, CheckCircle2, AlertTriangle, XCircle } from "lucide-react";
+import { Search, Upload, Download, FileDown, ShieldCheck, Sparkles, ArrowRight, CheckCircle2, AlertTriangle, XCircle } from "lucide-react";
 import { api } from "@/lib/api";
 import { ProspectTable } from "@/components/prospects/ProspectTable";
 import { AddProspectForm } from "@/components/prospects/AddProspectForm";
@@ -59,13 +59,19 @@ export default function ProspectsPage() {
               className="flex items-center gap-2 rounded-lg border border-[#c3c6d7]/30 bg-[#c3c6d7]/10 px-5 py-2.5 font-semibold text-[#0d1c2e] transition-all hover:bg-[#c3c6d7]/20">
               <Download className="size-5" /> Экспорт CSV
             </button>
-            <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-[#c3c6d7]/30 bg-[#c3c6d7]/10 px-5 py-2.5 font-semibold text-[#0d1c2e] transition-all hover:bg-[#c3c6d7]/20">
+            <button onClick={() => api.downloadProspectTemplate().catch(() => alert("Ошибка загрузки шаблона"))}
+              className="flex items-center gap-2 rounded-lg border border-[#c3c6d7]/30 bg-[#c3c6d7]/10 px-5 py-2.5 font-semibold text-[#0d1c2e] transition-all hover:bg-[#c3c6d7]/20"
+              title="Скачать пустой CSV-шаблон с правильными заголовками">
+              <FileDown className="size-5" /> Шаблон
+            </button>
+            <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-[#c3c6d7]/30 bg-[#c3c6d7]/10 px-5 py-2.5 font-semibold text-[#0d1c2e] transition-all hover:bg-[#c3c6d7]/20"
+              title="Поддерживаются колонки: name/имя, company/компания, email/почта, telegram/tg-контакты, phone/телефон и др.">
               <Upload className="size-5" /> Импорт CSV
               <input type="file" accept=".csv" className="hidden" onChange={async (e) => {
                 const file = e.target.files?.[0];
                 if (!file) return;
                 try { const res = await api.importProspectsCSV(file); alert(`Импортировано ${res.imported} проспектов`); await fetchProspects(); }
-                catch { alert("Ошибка импорта"); }
+                catch (err) { alert(err instanceof Error ? err.message : "Ошибка импорта"); }
                 e.target.value = "";
               }} />
             </label>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -85,7 +85,10 @@ async function apiUploadFile<T>(path: string, file: File): Promise<T> {
     headers: token ? { Authorization: `Bearer ${token}` } : {},
     body: formData,
   });
-  if (!res.ok) throw new Error(`Upload error: ${res.status}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.error || `Upload error: ${res.status}`);
+  }
   return res.json();
 }
 
@@ -190,6 +193,7 @@ export const api = {
   deleteProspect: (id: string) =>
     apiFetch(`/api/prospects/${id}`, { method: "DELETE" }),
   exportProspectsCSV: () => apiDownload("/api/prospects/export"),
+  downloadProspectTemplate: () => apiDownload("/api/prospects/template"),
   importProspectsCSV: (file: File) =>
     apiUploadFile<{ imported: number }>("/api/prospects/import", file),
 


### PR DESCRIPTION
## Summary

- Flexible column mapping with 30+ Russian/English aliases (имя→name, tg-контакты→telegram_username, etc.)
- Auto-detect delimiter (`,` vs `;`) for Russian Excel locale support
- Strip UTF-8 BOM on import (round-trip with export works)
- Dedup by `telegram_username` when email is empty
- Normalize TG username (strip `@` prefix)
- Only `name` column required (was: strict `name,company,title,email` header)
- New `GET /api/prospects/template` endpoint with downloadable CSV template
- Frontend: "Шаблон" button, error details from backend, tooltip with supported columns

Closes #16

## Test plan

- [x] 12 new unit tests covering all scenarios (BOM, semicolons, aliases, TG dedup, etc.)
- [x] All 40 prospect tests pass
- [x] All backend tests pass (350+)
- [x] All 329 frontend tests pass
- [x] Frontend lint clean
- [ ] Manual: import CSV with `;` delimiter from Russian Excel
- [ ] Manual: import CSV with TG usernames (`@username`)
- [ ] Manual: download template, fill, re-import