### PR TITLE
feat(inbox): HITL approval gate for booking-link auto-reply (closes P0-3)

### DIFF
--- a/backend/cmd/server/adapters.go
+++ b/backend/cmd/server/adapters.go
@@ -17,6 +17,13 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// Compile-time check that *leads.UseCase satisfies the structural
+// port inbox.LeadOwnershipChecker. Pinned here so a future signature
+// drift on leads.UseCase.OwnsLead breaks the build at the wiring
+// edge instead of silently breaking the structural conformance
+// inbox.RegisterPendingReplyRoutes relies on.
+var _ inbox.LeadOwnershipChecker = (*leads.UseCase)(nil)
+
 // --- LeadChecker adapter (prospects → leads boundary) ---
 
 type leadCheckerAdapter struct {

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -253,6 +253,13 @@ func main() {
 			// Set the telegram sender on the leads use case
 			leadsUC.SetSender(leads.NewTelegramSender(tgBot.Bot()))
 		}
+	} else {
+		// No Telegram token = no bot = no dispatcher. The HITL routes
+		// are still registered so the operator UI doesn't 404, but
+		// any Approve call will surface ErrPendingReplyDispatcher
+		// NotConfigured at runtime. Emit a startup warning so the
+		// silent-500-on-approve failure mode is visible in logs.
+		log.Println("WARN: telegram token not configured; HITL approve route will return 500 (dispatcher not wired)")
 	}
 
 	// 9. Email IMAP poller (reads settings from DB, falls back to .env).

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -129,6 +129,13 @@ func main() {
 	sourcesRepo := sources.NewRepository(pool)
 	sequencesRepo := sequences.NewRepository(pool)
 	identityRepo := leads.NewIdentityRepository(pool)
+	pendingReplyRepo := inbox.NewPendingReplyRepository(pool)
+	// pendingReplyUC is constructed early (dispatcher nil) so the
+	// protected route registration below can reference it. The
+	// dispatcher is injected after the Telegram bot is up (see the
+	// "telegram inbox bot" block) — this breaks the
+	// bot -> usecase -> dispatcher -> bot cycle.
+	pendingReplyUC := inbox.NewPendingReplyUseCase(pendingReplyRepo, nil)
 
 	// 4. Adapters
 	leadsAI := leads.NewAIAdapter(aiClient)
@@ -185,6 +192,7 @@ func main() {
 		parser.RegisterRoutes(r, cfg.TwoGISAPIKey, httpClient)
 		settings.RegisterRoutes(r, settingsUC, buildAITester(cfg, httpClient), buildSMTPTester(proxyDialer), buildResendTester(httpClient), buildUsageCounter(leadsRepo))
 		chat.RegisterRoutes(r, chat.NewHandler(chat.NewRepository(pool), newChatAIAdapter(aiClient)))
+		inbox.RegisterPendingReplyRoutes(r, pendingReplyUC, leadsUC)
 		tgOpts := []tgclient.Option{}
 		if proxyDialer != nil {
 			tgOpts = append(tgOpts, tgclient.WithDialer(proxyDialer))
@@ -231,6 +239,16 @@ func main() {
 		if err != nil {
 			log.Printf("telegram bot init failed: %v", err)
 		} else {
+			// Wire HITL approval: dispatcher uses the bot to deliver
+			// approved replies, and the bot uses the usecase to enqueue
+			// new proposals. Order matters — SetDispatcher MUST happen
+			// before SetPendingProposer so that any inbound message
+			// arriving in the gap between bot start and approval flow
+			// being fully wired finds at worst a missing dispatcher
+			// error (logged) rather than a partially-initialised cycle.
+			dispatcher := newTelegramReplyDispatcher(tgBot.Bot(), leadsRepo, inboxLeadAdapter)
+			pendingReplyUC.SetDispatcher(dispatcher)
+			tgBot.SetPendingProposer(pendingReplyUC)
 			go tgBot.Start(ctx)
 			// Set the telegram sender on the leads use case
 			leadsUC.SetSender(leads.NewTelegramSender(tgBot.Bot()))

--- a/backend/cmd/server/reply_dispatcher.go
+++ b/backend/cmd/server/reply_dispatcher.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/daniil/floq/internal/inbox"
+	leadsdomain "github.com/daniil/floq/internal/leads/domain"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/google/uuid"
+)
+
+// Compile-time check that *telegramReplyDispatcher satisfies the inbox
+// ReplyDispatcher port.
+var _ inbox.ReplyDispatcher = (*telegramReplyDispatcher)(nil)
+
+// telegramBotSender narrows the Telegram bot API surface to just the
+// Send method. The full *tgbotapi.BotAPI satisfies this interface,
+// and the test suite can substitute a recorder without standing up
+// the real client.
+type telegramBotSender interface {
+	Send(c tgbotapi.Chattable) (tgbotapi.Message, error)
+}
+
+// leadChatIDFetcher narrows leadsdomain.Repository to the single
+// lookup the dispatcher needs (the lead's TelegramChatID, which is
+// stored on Lead, not derivable from a pending reply alone).
+type leadChatIDFetcher interface {
+	GetLead(ctx context.Context, id uuid.UUID) (*leadsdomain.Lead, error)
+}
+
+// inboxMessageWriter narrows inbox.LeadRepository to the single
+// CreateMessage call the dispatcher makes for outbound history.
+type inboxMessageWriter interface {
+	CreateMessage(ctx context.Context, msg *inbox.InboxMessage) error
+}
+
+// telegramReplyDispatcher delivers an approved PendingReply to the
+// customer through the Telegram Bot API and records the outbound
+// message in the inbox history so the operator UI shows the full
+// thread. Currently only the telegram channel is wired; email
+// dispatch will land alongside the email auto-reply work that
+// extends PendingReplyKind beyond booking_link.
+type telegramReplyDispatcher struct {
+	bot       telegramBotSender
+	leads     leadChatIDFetcher
+	inboxRepo inboxMessageWriter
+}
+
+func newTelegramReplyDispatcher(bot telegramBotSender, leads leadChatIDFetcher, inboxRepo inboxMessageWriter) *telegramReplyDispatcher {
+	return &telegramReplyDispatcher{bot: bot, leads: leads, inboxRepo: inboxRepo}
+}
+
+// Dispatch sends the reply via the Telegram Bot API and, only on a
+// successful send, writes the outbound message into the inbox history.
+// Ordering matters: persisting before sending would risk the UI
+// showing a "sent" row for a message that never left the server; the
+// reverse risks history loss for a message the customer did receive,
+// which we accept as a smaller and more recoverable failure mode.
+func (d *telegramReplyDispatcher) Dispatch(ctx context.Context, pr *inbox.PendingReply) error {
+	if pr.Channel != inbox.ChannelTelegram {
+		return fmt.Errorf("telegram dispatcher: unsupported channel %q", pr.Channel)
+	}
+	lead, err := d.leads.GetLead(ctx, pr.LeadID)
+	if err != nil {
+		return fmt.Errorf("fetch lead for dispatch: %w", err)
+	}
+	if lead == nil {
+		return fmt.Errorf("telegram dispatcher: lead %s not found", pr.LeadID)
+	}
+	if lead.TelegramChatID == nil {
+		return fmt.Errorf("telegram dispatcher: lead %s has no telegram_chat_id", pr.LeadID)
+	}
+	msg := tgbotapi.NewMessage(*lead.TelegramChatID, pr.Body)
+	if _, err := d.bot.Send(msg); err != nil {
+		return fmt.Errorf("telegram send: %w", err)
+	}
+	outMsg := inbox.NewInboxMessage(pr.LeadID, inbox.DirectionOutbound, pr.Body)
+	if err := d.inboxRepo.CreateMessage(ctx, outMsg); err != nil {
+		return fmt.Errorf("persist outbound message: %w", err)
+	}
+	return nil
+}

--- a/backend/cmd/server/reply_dispatcher_test.go
+++ b/backend/cmd/server/reply_dispatcher_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/daniil/floq/internal/inbox"
+	leadsdomain "github.com/daniil/floq/internal/leads/domain"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/google/uuid"
+)
+
+// --- fakes ---
+
+type fakeBotSender struct {
+	mu       sync.Mutex
+	sent     []tgbotapi.Chattable
+	failWith error
+}
+
+func (f *fakeBotSender) Send(c tgbotapi.Chattable) (tgbotapi.Message, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sent = append(f.sent, c)
+	if f.failWith != nil {
+		return tgbotapi.Message{}, f.failWith
+	}
+	return tgbotapi.Message{MessageID: 42}, nil
+}
+
+func (f *fakeBotSender) sentCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.sent)
+}
+
+type fakeLeadFetcher struct {
+	leads  map[uuid.UUID]*leadsdomain.Lead
+	getErr error
+}
+
+func (f *fakeLeadFetcher) GetLead(_ context.Context, id uuid.UUID) (*leadsdomain.Lead, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.leads[id], nil
+}
+
+type fakeInboxMessageWriter struct {
+	mu      sync.Mutex
+	written []*inbox.InboxMessage
+	failErr error
+}
+
+func (f *fakeInboxMessageWriter) CreateMessage(_ context.Context, msg *inbox.InboxMessage) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.written = append(f.written, msg)
+	if f.failErr != nil {
+		return f.failErr
+	}
+	return nil
+}
+
+func (f *fakeInboxMessageWriter) writtenCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.written)
+}
+
+// --- helpers ---
+
+func newPendingReplyT(t *testing.T, leadID uuid.UUID, channel inbox.Channel) *inbox.PendingReply {
+	t.Helper()
+	pr, err := inbox.NewPendingReply(uuid.New(), leadID, channel, inbox.PendingReplyKindBookingLink, "hi")
+	if err != nil {
+		t.Fatalf("fixture build: %v", err)
+	}
+	return pr
+}
+
+func leadWithChat(id uuid.UUID, chatID int64) *leadsdomain.Lead {
+	return &leadsdomain.Lead{ID: id, TelegramChatID: &chatID}
+}
+
+// --- Dispatch ---
+
+func TestTelegramReplyDispatcher_HappyPath_SendsAndPersists(t *testing.T) {
+	leadID := uuid.New()
+	bot := &fakeBotSender{}
+	leads := &fakeLeadFetcher{leads: map[uuid.UUID]*leadsdomain.Lead{leadID: leadWithChat(leadID, 12345)}}
+	writer := &fakeInboxMessageWriter{}
+
+	d := newTelegramReplyDispatcher(bot, leads, writer)
+	pr := newPendingReplyT(t, leadID, inbox.ChannelTelegram)
+
+	if err := d.Dispatch(context.Background(), pr); err != nil {
+		t.Fatalf("Dispatch error: %v", err)
+	}
+
+	if bot.sentCount() != 1 {
+		t.Errorf("bot.Send calls = %d, want 1", bot.sentCount())
+	}
+	if writer.writtenCount() != 1 {
+		t.Errorf("CreateMessage calls = %d, want 1 (outbound history)", writer.writtenCount())
+	}
+	if got := writer.written[0]; got.Direction != inbox.DirectionOutbound || got.LeadID != leadID || got.Body != pr.Body {
+		t.Errorf("written message = %+v, want outbound for lead %v with body %q", got, leadID, pr.Body)
+	}
+	if msg, ok := bot.sent[0].(tgbotapi.MessageConfig); !ok || msg.ChatID != 12345 || msg.Text != pr.Body {
+		t.Errorf("bot received = %+v, want chat=12345 body=%q", bot.sent[0], pr.Body)
+	}
+}
+
+func TestTelegramReplyDispatcher_RejectsNonTelegramChannel(t *testing.T) {
+	d := newTelegramReplyDispatcher(&fakeBotSender{}, &fakeLeadFetcher{}, &fakeInboxMessageWriter{})
+	pr := newPendingReplyT(t, uuid.New(), inbox.ChannelEmail)
+
+	err := d.Dispatch(context.Background(), pr)
+	if err == nil {
+		t.Fatal("Dispatch must reject non-telegram channels until per-channel routing is added")
+	}
+}
+
+func TestTelegramReplyDispatcher_LeadNotFoundReturnsError(t *testing.T) {
+	bot := &fakeBotSender{}
+	leads := &fakeLeadFetcher{leads: map[uuid.UUID]*leadsdomain.Lead{}} // empty
+	writer := &fakeInboxMessageWriter{}
+
+	d := newTelegramReplyDispatcher(bot, leads, writer)
+	pr := newPendingReplyT(t, uuid.New(), inbox.ChannelTelegram)
+
+	if err := d.Dispatch(context.Background(), pr); err == nil {
+		t.Fatal("Dispatch must error when lead is missing")
+	}
+	if bot.sentCount() != 0 {
+		t.Error("must NOT call bot.Send when lead lookup yields nothing")
+	}
+	if writer.writtenCount() != 0 {
+		t.Error("must NOT persist outbound message when lead lookup yields nothing")
+	}
+}
+
+func TestTelegramReplyDispatcher_LeadWithoutChatIDReturnsError(t *testing.T) {
+	leadID := uuid.New()
+	bot := &fakeBotSender{}
+	leads := &fakeLeadFetcher{leads: map[uuid.UUID]*leadsdomain.Lead{leadID: {ID: leadID /* TelegramChatID nil */}}}
+	writer := &fakeInboxMessageWriter{}
+
+	d := newTelegramReplyDispatcher(bot, leads, writer)
+	pr := newPendingReplyT(t, leadID, inbox.ChannelTelegram)
+
+	if err := d.Dispatch(context.Background(), pr); err == nil {
+		t.Fatal("Dispatch must error when lead has no TelegramChatID")
+	}
+	if bot.sentCount() != 0 {
+		t.Error("must NOT call bot.Send when no chat id")
+	}
+}
+
+func TestTelegramReplyDispatcher_LeadFetchErrorPropagates(t *testing.T) {
+	bot := &fakeBotSender{}
+	leads := &fakeLeadFetcher{getErr: errors.New("db down")}
+	writer := &fakeInboxMessageWriter{}
+
+	d := newTelegramReplyDispatcher(bot, leads, writer)
+	pr := newPendingReplyT(t, uuid.New(), inbox.ChannelTelegram)
+
+	err := d.Dispatch(context.Background(), pr)
+	if err == nil || !errors.Is(err, leads.getErr) {
+		t.Fatalf("want wrapped fetch error, got %v", err)
+	}
+	if bot.sentCount() != 0 {
+		t.Error("must NOT send when lead lookup fails")
+	}
+}
+
+func TestTelegramReplyDispatcher_BotSendErrorSkipsPersist(t *testing.T) {
+	leadID := uuid.New()
+	bot := &fakeBotSender{failWith: errors.New("telegram 500")}
+	leads := &fakeLeadFetcher{leads: map[uuid.UUID]*leadsdomain.Lead{leadID: leadWithChat(leadID, 99)}}
+	writer := &fakeInboxMessageWriter{}
+
+	d := newTelegramReplyDispatcher(bot, leads, writer)
+	pr := newPendingReplyT(t, leadID, inbox.ChannelTelegram)
+
+	err := d.Dispatch(context.Background(), pr)
+	if err == nil || !errors.Is(err, bot.failWith) {
+		t.Fatalf("want wrapped bot error, got %v", err)
+	}
+	if writer.writtenCount() != 0 {
+		t.Error("CreateMessage must NOT run after a failed bot.Send — otherwise UI would show a sent message that never reached the customer")
+	}
+}
+
+func TestTelegramReplyDispatcher_PersistErrorReturnsErrorAfterSendSucceeds(t *testing.T) {
+	leadID := uuid.New()
+	bot := &fakeBotSender{}
+	leads := &fakeLeadFetcher{leads: map[uuid.UUID]*leadsdomain.Lead{leadID: leadWithChat(leadID, 1)}}
+	writer := &fakeInboxMessageWriter{failErr: errors.New("db boom")}
+
+	d := newTelegramReplyDispatcher(bot, leads, writer)
+	pr := newPendingReplyT(t, leadID, inbox.ChannelTelegram)
+
+	err := d.Dispatch(context.Background(), pr)
+	if err == nil {
+		t.Fatal("Dispatch must surface persist failure")
+	}
+	if bot.sentCount() != 1 {
+		t.Error("send already happened — count must still be 1")
+	}
+}

--- a/backend/internal/inbox/handler.go
+++ b/backend/internal/inbox/handler.go
@@ -1,0 +1,171 @@
+package inbox
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/daniil/floq/internal/httputil"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// PendingReplyUseCaseAPI is the narrow port the HTTP handler needs from
+// the usecase. Keeping it as a small interface (instead of taking the
+// concrete *PendingReplyUseCase) means the handler test suite can
+// stand up without any persistence backend.
+type PendingReplyUseCaseAPI interface {
+	ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error)
+	Approve(ctx context.Context, userID, id uuid.UUID) error
+	Reject(ctx context.Context, userID, id uuid.UUID) error
+}
+
+// LeadOwnershipChecker is the narrow port the handler needs to gate
+// lead-scoped routes. The composition root adapts leads.UseCase.OwnsLead
+// to this interface so inbox stays free of leads-package imports on
+// the handler edge.
+type LeadOwnershipChecker interface {
+	OwnsLead(ctx context.Context, userID, leadID uuid.UUID) (bool, error)
+}
+
+// pendingReplyHandler binds the usecase and ownership checker to the
+// HTTP layer.
+type pendingReplyHandler struct {
+	uc    PendingReplyUseCaseAPI
+	leads LeadOwnershipChecker
+}
+
+// RegisterPendingReplyRoutes wires the HITL approval HTTP surface onto
+// the given chi router. The set is intentionally narrow:
+//   - GET  /api/leads/{id}/pending-replies   — operator queue per lead
+//   - POST /api/pending-replies/{id}/approve — approve + dispatch
+//   - POST /api/pending-replies/{id}/reject  — terminal reject
+//
+// A future POST /api/leads/{id}/pending-replies could let operators
+// propose a draft manually; for now only the inbox auto-draft path
+// (Telegram booking link) feeds the queue.
+func RegisterPendingReplyRoutes(r chi.Router, uc PendingReplyUseCaseAPI, leads LeadOwnershipChecker) {
+	h := &pendingReplyHandler{uc: uc, leads: leads}
+	r.Get("/api/leads/{id}/pending-replies", h.listByLead())
+	r.Post("/api/pending-replies/{id}/approve", h.approve())
+	r.Post("/api/pending-replies/{id}/reject", h.reject())
+}
+
+func (h *pendingReplyHandler) listByLead() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := httputil.UserIDFromContext(r.Context())
+		if !ok {
+			httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		leadID, err := httputil.ParseIDParam(r, "id")
+		if err != nil {
+			httputil.WriteError(w, http.StatusBadRequest, "invalid lead id")
+			return
+		}
+		owned, err := h.leads.OwnsLead(r.Context(), userID, leadID)
+		if err != nil {
+			httputil.WriteError(w, http.StatusInternalServerError, "failed to authorize lead")
+			return
+		}
+		if !owned {
+			httputil.WriteError(w, http.StatusNotFound, "lead not found")
+			return
+		}
+		rows, err := h.uc.ListByLead(r.Context(), userID, leadID)
+		if err != nil {
+			httputil.WriteError(w, http.StatusInternalServerError, "failed to list pending replies")
+			return
+		}
+		httputil.WriteJSON(w, http.StatusOK, pendingRepliesToResponse(rows))
+	}
+}
+
+func (h *pendingReplyHandler) approve() http.HandlerFunc {
+	return h.decide(func(uc PendingReplyUseCaseAPI, ctx context.Context, userID, id uuid.UUID) error {
+		return uc.Approve(ctx, userID, id)
+	})
+}
+
+func (h *pendingReplyHandler) reject() http.HandlerFunc {
+	return h.decide(func(uc PendingReplyUseCaseAPI, ctx context.Context, userID, id uuid.UUID) error {
+		return uc.Reject(ctx, userID, id)
+	})
+}
+
+// decide is the shared shape of Approve and Reject: parse auth, parse
+// id, delegate, map sentinel errors to HTTP codes, 204 on success.
+func (h *pendingReplyHandler) decide(op func(uc PendingReplyUseCaseAPI, ctx context.Context, userID, id uuid.UUID) error) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := httputil.UserIDFromContext(r.Context())
+		if !ok {
+			httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		id, err := httputil.ParseIDParam(r, "id")
+		if err != nil {
+			httputil.WriteError(w, http.StatusBadRequest, "invalid pending reply id")
+			return
+		}
+		if err := op(h.uc, r.Context(), userID, id); err != nil {
+			switch {
+			case errors.Is(err, ErrPendingReplyNotFound):
+				httputil.WriteError(w, http.StatusNotFound, "pending reply not found")
+			case errors.Is(err, ErrPendingReplyAlreadyDecided):
+				httputil.WriteError(w, http.StatusConflict, "pending reply already decided")
+			default:
+				httputil.WriteError(w, http.StatusInternalServerError, "failed to process pending reply")
+			}
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// --- DTO ---
+
+// PendingReplyResponse is the wire-shape returned to the frontend. It
+// is intentionally separate from the domain entity so transport-layer
+// concerns (JSON tags, timestamp formatting) do not bleed into the
+// inbox package surface.
+type PendingReplyResponse struct {
+	ID        string  `json:"id"`
+	LeadID    string  `json:"lead_id"`
+	Channel   string  `json:"channel"`
+	Kind      string  `json:"kind"`
+	Body      string  `json:"body"`
+	Status    string  `json:"status"`
+	CreatedAt string  `json:"created_at"`
+	DecidedAt *string `json:"decided_at,omitempty"`
+	SentAt    *string `json:"sent_at,omitempty"`
+}
+
+func pendingReplyToResponse(pr *PendingReply) PendingReplyResponse {
+	resp := PendingReplyResponse{
+		ID:        pr.ID.String(),
+		LeadID:    pr.LeadID.String(),
+		Channel:   string(pr.Channel),
+		Kind:      string(pr.Kind),
+		Body:      pr.Body,
+		Status:    string(pr.Status),
+		CreatedAt: pr.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if pr.DecidedAt != nil {
+		s := pr.DecidedAt.UTC().Format(time.RFC3339)
+		resp.DecidedAt = &s
+	}
+	if pr.SentAt != nil {
+		s := pr.SentAt.UTC().Format(time.RFC3339)
+		resp.SentAt = &s
+	}
+	return resp
+}
+
+func pendingRepliesToResponse(rows []*PendingReply) []PendingReplyResponse {
+	out := make([]PendingReplyResponse, 0, len(rows))
+	for _, pr := range rows {
+		out = append(out, pendingReplyToResponse(pr))
+	}
+	return out
+}

--- a/backend/internal/inbox/handler.go
+++ b/backend/internal/inbox/handler.go
@@ -3,6 +3,7 @@ package inbox
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -115,6 +116,14 @@ func (h *pendingReplyHandler) decide(op func(uc PendingReplyUseCaseAPI, ctx cont
 			case errors.Is(err, ErrPendingReplyAlreadyDecided):
 				httputil.WriteError(w, http.StatusConflict, "pending reply already decided")
 			default:
+				// 500-class errors carry production-actionable
+				// detail (dispatcher misconfig, telegram 5xx,
+				// db hiccup); log before answering so the
+				// operator-visible 500 has a trail to follow.
+				slog.ErrorContext(r.Context(), "pending reply decide failed",
+					slog.String("pending_reply_id", id.String()),
+					slog.String("user_id", userID.String()),
+					slog.Any("err", err))
 				httputil.WriteError(w, http.StatusInternalServerError, "failed to process pending reply")
 			}
 			return

--- a/backend/internal/inbox/handler_test.go
+++ b/backend/internal/inbox/handler_test.go
@@ -1,0 +1,345 @@
+package inbox
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/daniil/floq/internal/httputil"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// --- fakes ---
+
+type fakePendingReplyUseCase struct {
+	mu sync.Mutex
+
+	listFn    func(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error)
+	approveFn func(ctx context.Context, userID, id uuid.UUID) error
+	rejectFn  func(ctx context.Context, userID, id uuid.UUID) error
+}
+
+func (f *fakePendingReplyUseCase) ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error) {
+	if f.listFn != nil {
+		return f.listFn(ctx, userID, leadID)
+	}
+	return nil, nil
+}
+
+func (f *fakePendingReplyUseCase) Approve(ctx context.Context, userID, id uuid.UUID) error {
+	if f.approveFn != nil {
+		return f.approveFn(ctx, userID, id)
+	}
+	return nil
+}
+
+func (f *fakePendingReplyUseCase) Reject(ctx context.Context, userID, id uuid.UUID) error {
+	if f.rejectFn != nil {
+		return f.rejectFn(ctx, userID, id)
+	}
+	return nil
+}
+
+type fakeLeadOwnership struct {
+	owned map[uuid.UUID]bool
+	err   error
+}
+
+func (f *fakeLeadOwnership) OwnsLead(_ context.Context, _ uuid.UUID, leadID uuid.UUID) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.owned[leadID], nil
+}
+
+// --- helpers ---
+
+func newTestServer(uc PendingReplyUseCaseAPI, leads LeadOwnershipChecker) http.Handler {
+	r := chi.NewRouter()
+	RegisterPendingReplyRoutes(r, uc, leads)
+	return r
+}
+
+func authedRequest(t *testing.T, method, path string, userID uuid.UUID) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	req = req.WithContext(httputil.WithUserID(req.Context(), userID))
+	return req
+}
+
+// --- GET /api/leads/{id}/pending-replies ---
+
+func TestHandler_ListByLead_HappyPath(t *testing.T) {
+	userID := uuid.New()
+	leadID := uuid.New()
+	pr, err := NewPendingReply(userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "first")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	uc := &fakePendingReplyUseCase{
+		listFn: func(_ context.Context, u, l uuid.UUID) ([]*PendingReply, error) {
+			if u != userID || l != leadID {
+				t.Errorf("usecase received wrong ids: u=%v l=%v", u, l)
+			}
+			return []*PendingReply{pr}, nil
+		},
+	}
+	leads := &fakeLeadOwnership{owned: map[uuid.UUID]bool{leadID: true}}
+
+	srv := newTestServer(uc, leads)
+	req := authedRequest(t, http.MethodGet, "/api/leads/"+leadID.String()+"/pending-replies", userID)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	var got []map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("response len = %d, want 1", len(got))
+	}
+	if got[0]["id"] != pr.ID.String() {
+		t.Errorf("id = %v, want %v", got[0]["id"], pr.ID)
+	}
+	if got[0]["status"] != "pending" {
+		t.Errorf("status field = %v, want pending", got[0]["status"])
+	}
+	if got[0]["body"] != "first" {
+		t.Errorf("body field = %v", got[0]["body"])
+	}
+}
+
+func TestHandler_ListByLead_EmptyReturnsJSONArrayNotNull(t *testing.T) {
+	userID := uuid.New()
+	leadID := uuid.New()
+	uc := &fakePendingReplyUseCase{
+		listFn: func(_ context.Context, _, _ uuid.UUID) ([]*PendingReply, error) {
+			return nil, nil
+		},
+	}
+	leads := &fakeLeadOwnership{owned: map[uuid.UUID]bool{leadID: true}}
+
+	srv := newTestServer(uc, leads)
+	req := authedRequest(t, http.MethodGet, "/api/leads/"+leadID.String()+"/pending-replies", userID)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := strings.TrimSpace(rec.Body.String())
+	if body != "[]" {
+		t.Errorf("empty list body = %q, want %q (must not be JSON null)", body, "[]")
+	}
+}
+
+func TestHandler_ListByLead_NoUserReturns401(t *testing.T) {
+	srv := newTestServer(&fakePendingReplyUseCase{}, &fakeLeadOwnership{})
+	req := httptest.NewRequest(http.MethodGet, "/api/leads/"+uuid.New().String()+"/pending-replies", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestHandler_ListByLead_InvalidLeadIDReturns400(t *testing.T) {
+	srv := newTestServer(&fakePendingReplyUseCase{}, &fakeLeadOwnership{})
+	req := authedRequest(t, http.MethodGet, "/api/leads/not-a-uuid/pending-replies", uuid.New())
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandler_ListByLead_CrossTenantReturns404(t *testing.T) {
+	userID := uuid.New()
+	leadID := uuid.New() // not owned by userID
+	uc := &fakePendingReplyUseCase{
+		listFn: func(_ context.Context, _, _ uuid.UUID) ([]*PendingReply, error) {
+			t.Fatal("usecase must NOT be called when lead is not owned")
+			return nil, nil
+		},
+	}
+	leads := &fakeLeadOwnership{owned: map[uuid.UUID]bool{}}
+
+	srv := newTestServer(uc, leads)
+	req := authedRequest(t, http.MethodGet, "/api/leads/"+leadID.String()+"/pending-replies", userID)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (uniform — no info leak)", rec.Code)
+	}
+}
+
+// --- POST /api/pending-replies/{id}/approve ---
+
+func TestHandler_Approve_HappyPath_Returns204(t *testing.T) {
+	userID := uuid.New()
+	prID := uuid.New()
+	uc := &fakePendingReplyUseCase{
+		approveFn: func(_ context.Context, u, id uuid.UUID) error {
+			if u != userID || id != prID {
+				t.Errorf("approve got u=%v id=%v want u=%v id=%v", u, id, userID, prID)
+			}
+			return nil
+		},
+	}
+
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+	req := authedRequest(t, http.MethodPost, "/api/pending-replies/"+prID.String()+"/approve", userID)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+}
+
+func TestHandler_Approve_NotFoundReturns404(t *testing.T) {
+	uc := &fakePendingReplyUseCase{
+		approveFn: func(_ context.Context, _, _ uuid.UUID) error {
+			return ErrPendingReplyNotFound
+		},
+	}
+
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+	req := authedRequest(t, http.MethodPost, "/api/pending-replies/"+uuid.New().String()+"/approve", uuid.New())
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandler_Approve_AlreadyDecidedReturns409(t *testing.T) {
+	uc := &fakePendingReplyUseCase{
+		approveFn: func(_ context.Context, _, _ uuid.UUID) error {
+			return ErrPendingReplyAlreadyDecided
+		},
+	}
+
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+	req := authedRequest(t, http.MethodPost, "/api/pending-replies/"+uuid.New().String()+"/approve", uuid.New())
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+}
+
+func TestHandler_Approve_DispatcherErrorReturns500(t *testing.T) {
+	uc := &fakePendingReplyUseCase{
+		approveFn: func(_ context.Context, _, _ uuid.UUID) error {
+			return errors.New("dispatch boom")
+		},
+	}
+
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+	req := authedRequest(t, http.MethodPost, "/api/pending-replies/"+uuid.New().String()+"/approve", uuid.New())
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+func TestHandler_Approve_NoUserReturns401(t *testing.T) {
+	srv := newTestServer(&fakePendingReplyUseCase{}, &fakeLeadOwnership{})
+	req := httptest.NewRequest(http.MethodPost, "/api/pending-replies/"+uuid.New().String()+"/approve", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestHandler_Approve_InvalidIDReturns400(t *testing.T) {
+	srv := newTestServer(&fakePendingReplyUseCase{}, &fakeLeadOwnership{})
+	req := authedRequest(t, http.MethodPost, "/api/pending-replies/not-a-uuid/approve", uuid.New())
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// --- POST /api/pending-replies/{id}/reject ---
+
+func TestHandler_Reject_HappyPath_Returns204(t *testing.T) {
+	userID := uuid.New()
+	prID := uuid.New()
+	uc := &fakePendingReplyUseCase{
+		rejectFn: func(_ context.Context, u, id uuid.UUID) error {
+			if u != userID || id != prID {
+				t.Errorf("reject got u=%v id=%v want u=%v id=%v", u, id, userID, prID)
+			}
+			return nil
+		},
+	}
+
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+	req := authedRequest(t, http.MethodPost, "/api/pending-replies/"+prID.String()+"/reject", userID)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+}
+
+func TestHandler_Reject_NotFoundAlreadyDecidedAuthAndInvalidID(t *testing.T) {
+	cases := []struct {
+		name       string
+		ucErr      error
+		userID     uuid.UUID
+		pathID     string
+		wantStatus int
+	}{
+		{name: "not found -> 404", ucErr: ErrPendingReplyNotFound, userID: uuid.New(), pathID: uuid.New().String(), wantStatus: http.StatusNotFound},
+		{name: "already decided -> 409", ucErr: ErrPendingReplyAlreadyDecided, userID: uuid.New(), pathID: uuid.New().String(), wantStatus: http.StatusConflict},
+		{name: "internal -> 500", ucErr: errors.New("boom"), userID: uuid.New(), pathID: uuid.New().String(), wantStatus: http.StatusInternalServerError},
+		{name: "no user -> 401", ucErr: nil, userID: uuid.Nil, pathID: uuid.New().String(), wantStatus: http.StatusUnauthorized},
+		{name: "invalid id -> 400", ucErr: nil, userID: uuid.New(), pathID: "not-a-uuid", wantStatus: http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			uc := &fakePendingReplyUseCase{
+				rejectFn: func(_ context.Context, _, _ uuid.UUID) error { return tc.ucErr },
+			}
+			srv := newTestServer(uc, &fakeLeadOwnership{})
+
+			path := "/api/pending-replies/" + tc.pathID + "/reject"
+			var req *http.Request
+			if tc.userID == uuid.Nil {
+				req = httptest.NewRequest(http.MethodPost, path, nil)
+			} else {
+				req = authedRequest(t, http.MethodPost, path, tc.userID)
+			}
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d, body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}

--- a/backend/internal/inbox/pending_reply.go
+++ b/backend/internal/inbox/pending_reply.go
@@ -1,0 +1,136 @@
+package inbox
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// PendingReplyKind enumerates the categories of inbox-originated outbound
+// replies that require human-in-the-loop approval before delivery. Each new
+// auto-generated reply path that touches a customer-visible channel SHOULD
+// add a new kind and route through the PendingReply workflow rather than
+// sending directly.
+type PendingReplyKind string
+
+const (
+	// PendingReplyKindBookingLink is an auto-drafted reply that contains a
+	// calendar booking link, triggered when an inbound message looks like
+	// the lead is ready to schedule a call. Misfires here would leak a
+	// booking URL to a lead who never asked — hence the approval gate.
+	PendingReplyKindBookingLink PendingReplyKind = "booking_link"
+)
+
+// IsValid reports whether the kind matches a known PendingReplyKind value.
+func (k PendingReplyKind) IsValid() bool {
+	switch k {
+	case PendingReplyKindBookingLink:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the underlying string for logging / persistence.
+func (k PendingReplyKind) String() string { return string(k) }
+
+// PendingReplyStatus tracks the lifecycle of a draft reply through the HITL
+// approval workflow.
+type PendingReplyStatus string
+
+const (
+	PendingReplyStatusPending  PendingReplyStatus = "pending"
+	PendingReplyStatusApproved PendingReplyStatus = "approved"
+	PendingReplyStatusSent     PendingReplyStatus = "sent"
+	PendingReplyStatusRejected PendingReplyStatus = "rejected"
+)
+
+// IsValid reports whether the status is one of the known values.
+func (s PendingReplyStatus) IsValid() bool {
+	switch s {
+	case PendingReplyStatusPending, PendingReplyStatusApproved, PendingReplyStatusSent, PendingReplyStatusRejected:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the underlying string for logging / persistence.
+func (s PendingReplyStatus) String() string { return string(s) }
+
+// pendingReplyTransitions encodes the legal state machine. The operator
+// approves or rejects a pending draft; an approved draft becomes sent once
+// the dispatcher confirms delivery. Rejected and sent are terminal.
+var pendingReplyTransitions = map[PendingReplyStatus][]PendingReplyStatus{
+	PendingReplyStatusPending:  {PendingReplyStatusApproved, PendingReplyStatusRejected},
+	PendingReplyStatusApproved: {PendingReplyStatusSent},
+}
+
+// CanTransitionTo reports whether target is a legal next state for s.
+func (s PendingReplyStatus) CanTransitionTo(target PendingReplyStatus) bool {
+	return slices.Contains(pendingReplyTransitions[s], target)
+}
+
+// --- Sentinels ---
+
+var (
+	ErrPendingReplyMissingUser      = errors.New("pending reply: user id is required")
+	ErrPendingReplyMissingLead      = errors.New("pending reply: lead id is required")
+	ErrPendingReplyInvalidChannel   = errors.New("pending reply: invalid channel")
+	ErrPendingReplyInvalidKind      = errors.New("pending reply: invalid kind")
+	ErrPendingReplyEmptyBody        = errors.New("pending reply: body is required")
+	ErrPendingReplyInvalidTransition = errors.New("pending reply: invalid status transition")
+)
+
+// PendingReply is an inbox-originated outbound message awaiting human
+// approval before being delivered to the lead. It is the aggregate root for
+// the HITL (human-in-the-loop) gate that protects auto-drafted replies from
+// reaching customers without explicit operator consent.
+type PendingReply struct {
+	ID        uuid.UUID
+	UserID    uuid.UUID
+	LeadID    uuid.UUID
+	Channel   Channel
+	Kind      PendingReplyKind
+	Body      string
+	Status    PendingReplyStatus
+	CreatedAt time.Time
+	DecidedAt *time.Time
+	SentAt    *time.Time
+}
+
+// NewPendingReply constructs a PendingReply in the Pending status with a
+// generated ID and timestamp, enforcing required invariants. Body is trimmed
+// of surrounding whitespace; an entirely whitespace-only body is rejected.
+func NewPendingReply(userID, leadID uuid.UUID, channel Channel, kind PendingReplyKind, body string) (*PendingReply, error) {
+	if userID == uuid.Nil {
+		return nil, ErrPendingReplyMissingUser
+	}
+	if leadID == uuid.Nil {
+		return nil, ErrPendingReplyMissingLead
+	}
+	if channel != ChannelTelegram && channel != ChannelEmail {
+		return nil, fmt.Errorf("%w: %q", ErrPendingReplyInvalidChannel, channel)
+	}
+	if !kind.IsValid() {
+		return nil, fmt.Errorf("%w: %q", ErrPendingReplyInvalidKind, kind)
+	}
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" {
+		return nil, ErrPendingReplyEmptyBody
+	}
+	return &PendingReply{
+		ID:        uuid.New(),
+		UserID:    userID,
+		LeadID:    leadID,
+		Channel:   channel,
+		Kind:      kind,
+		Body:      trimmed,
+		Status:    PendingReplyStatusPending,
+		CreatedAt: time.Now().UTC(),
+	}, nil
+}

--- a/backend/internal/inbox/pending_reply.go
+++ b/backend/internal/inbox/pending_reply.go
@@ -103,6 +103,56 @@ type PendingReply struct {
 	SentAt    *time.Time
 }
 
+// TransitionTo validates and applies a status change, rejecting transitions
+// that violate the PendingReply state machine. Callers should prefer the
+// dedicated Approve / Reject / MarkSent methods, which also stamp the
+// relevant timestamp atomically with the status change.
+func (p *PendingReply) TransitionTo(target PendingReplyStatus) error {
+	if !target.IsValid() {
+		return fmt.Errorf("%w: unknown target %q", ErrPendingReplyInvalidTransition, target)
+	}
+	if !p.Status.CanTransitionTo(target) {
+		return fmt.Errorf("%w: %q -> %q", ErrPendingReplyInvalidTransition, p.Status, target)
+	}
+	p.Status = target
+	return nil
+}
+
+// Approve moves a pending reply into the Approved status and stamps
+// DecidedAt. Use this when the operator confirms the draft should be sent;
+// the actual delivery is a separate step (MarkSent) so that a failed send
+// does not leave the entity in an inconsistent state.
+func (p *PendingReply) Approve(at time.Time) error {
+	if err := p.TransitionTo(PendingReplyStatusApproved); err != nil {
+		return err
+	}
+	t := at
+	p.DecidedAt = &t
+	return nil
+}
+
+// Reject moves a pending reply into the terminal Rejected status and stamps
+// DecidedAt. The draft body is preserved for audit / future reference.
+func (p *PendingReply) Reject(at time.Time) error {
+	if err := p.TransitionTo(PendingReplyStatusRejected); err != nil {
+		return err
+	}
+	t := at
+	p.DecidedAt = &t
+	return nil
+}
+
+// MarkSent moves an approved reply into the terminal Sent status and
+// records when delivery succeeded. Only valid from Approved.
+func (p *PendingReply) MarkSent(at time.Time) error {
+	if err := p.TransitionTo(PendingReplyStatusSent); err != nil {
+		return err
+	}
+	t := at
+	p.SentAt = &t
+	return nil
+}
+
 // NewPendingReply constructs a PendingReply in the Pending status with a
 // generated ID and timestamp, enforcing required invariants. Body is trimmed
 // of surrounding whitespace; an entirely whitespace-only body is rejected.

--- a/backend/internal/inbox/pending_reply_repository.go
+++ b/backend/internal/inbox/pending_reply_repository.go
@@ -103,12 +103,12 @@ func (r *PendingReplyRepo) ListByLead(ctx context.Context, userID, leadID uuid.U
 // somebody else's row even if the caller forgets to re-check ownership.
 // Body, channel, kind and created_at are immutable after Save by
 // contract — the entity exposes no setters for them.
-func (r *PendingReplyRepo) Update(ctx context.Context, pr *PendingReply) error {
+func (r *PendingReplyRepo) Update(ctx context.Context, pr *PendingReply, expectedStatus PendingReplyStatus) error {
 	tag, err := r.q(ctx).Exec(ctx,
 		`UPDATE pending_replies
 		 SET status = $1, decided_at = $2, sent_at = $3
-		 WHERE id = $4 AND user_id = $5`,
-		string(pr.Status), pr.DecidedAt, pr.SentAt, pr.ID, pr.UserID)
+		 WHERE id = $4 AND user_id = $5 AND status = $6`,
+		string(pr.Status), pr.DecidedAt, pr.SentAt, pr.ID, pr.UserID, string(expectedStatus))
 	if err != nil {
 		return fmt.Errorf("update pending reply: %w", err)
 	}

--- a/backend/internal/inbox/pending_reply_repository.go
+++ b/backend/internal/inbox/pending_reply_repository.go
@@ -1,0 +1,119 @@
+package inbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/daniil/floq/internal/db"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Compile-time check that *PendingReplyRepo satisfies the port.
+var _ PendingReplyRepository = (*PendingReplyRepo)(nil)
+
+// PendingReplyRepo is the pgx-backed implementation of
+// PendingReplyRepository. All queries are scoped by user_id so the
+// repository itself cannot leak cross-tenant rows even if the caller
+// forgets to check.
+type PendingReplyRepo struct {
+	pool *pgxpool.Pool
+}
+
+// NewPendingReplyRepository wires the SQL-backed implementation.
+func NewPendingReplyRepository(pool *pgxpool.Pool) *PendingReplyRepo {
+	return &PendingReplyRepo{pool: pool}
+}
+
+// q returns the Querier bound to the current context (a pgx.Tx when
+// the caller wrapped the call in db.TxManager.WithTx, otherwise the
+// pool) — mirrors the pattern used by leads.Repository and
+// leads.IdentityRepository.
+func (r *PendingReplyRepo) q(ctx context.Context) db.Querier {
+	return db.ConnFromCtx(ctx, r.pool)
+}
+
+const pendingReplyColumns = `id, user_id, lead_id, channel, kind, body, status, created_at, decided_at, sent_at`
+
+func (r *PendingReplyRepo) Save(ctx context.Context, pr *PendingReply) error {
+	_, err := r.q(ctx).Exec(ctx,
+		`INSERT INTO pending_replies (`+pendingReplyColumns+`)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		pr.ID, pr.UserID, pr.LeadID, string(pr.Channel), string(pr.Kind), pr.Body,
+		string(pr.Status), pr.CreatedAt, pr.DecidedAt, pr.SentAt)
+	if err != nil {
+		return fmt.Errorf("save pending reply: %w", err)
+	}
+	return nil
+}
+
+func (r *PendingReplyRepo) GetByID(ctx context.Context, userID, id uuid.UUID) (*PendingReply, error) {
+	var pr PendingReply
+	var channel, kind, status string
+	err := r.q(ctx).QueryRow(ctx,
+		`SELECT `+pendingReplyColumns+`
+		 FROM pending_replies
+		 WHERE id = $1 AND user_id = $2`,
+		id, userID).
+		Scan(&pr.ID, &pr.UserID, &pr.LeadID, &channel, &kind, &pr.Body, &status,
+			&pr.CreatedAt, &pr.DecidedAt, &pr.SentAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get pending reply by id: %w", err)
+	}
+	pr.Channel = Channel(channel)
+	pr.Kind = PendingReplyKind(kind)
+	pr.Status = PendingReplyStatus(status)
+	return &pr, nil
+}
+
+func (r *PendingReplyRepo) ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error) {
+	rows, err := r.q(ctx).Query(ctx,
+		`SELECT `+pendingReplyColumns+`
+		 FROM pending_replies
+		 WHERE user_id = $1 AND lead_id = $2
+		 ORDER BY created_at DESC`,
+		userID, leadID)
+	if err != nil {
+		return nil, fmt.Errorf("list pending replies by lead: %w", err)
+	}
+	defer rows.Close()
+	out := make([]*PendingReply, 0)
+	for rows.Next() {
+		var pr PendingReply
+		var channel, kind, status string
+		if err := rows.Scan(&pr.ID, &pr.UserID, &pr.LeadID, &channel, &kind, &pr.Body, &status,
+			&pr.CreatedAt, &pr.DecidedAt, &pr.SentAt); err != nil {
+			return nil, fmt.Errorf("scan pending reply: %w", err)
+		}
+		pr.Channel = Channel(channel)
+		pr.Kind = PendingReplyKind(kind)
+		pr.Status = PendingReplyStatus(status)
+		out = append(out, &pr)
+	}
+	return out, rows.Err()
+}
+
+// Update persists status, decided_at and sent_at for an existing row.
+// Scoped by user_id and id to prevent a malformed entity from updating
+// somebody else's row even if the caller forgets to re-check ownership.
+// Body, channel, kind and created_at are immutable after Save by
+// contract — the entity exposes no setters for them.
+func (r *PendingReplyRepo) Update(ctx context.Context, pr *PendingReply) error {
+	tag, err := r.q(ctx).Exec(ctx,
+		`UPDATE pending_replies
+		 SET status = $1, decided_at = $2, sent_at = $3
+		 WHERE id = $4 AND user_id = $5`,
+		string(pr.Status), pr.DecidedAt, pr.SentAt, pr.ID, pr.UserID)
+	if err != nil {
+		return fmt.Errorf("update pending reply: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("update pending reply: row not found or not owned")
+	}
+	return nil
+}

--- a/backend/internal/inbox/pending_reply_repository.go
+++ b/backend/internal/inbox/pending_reply_repository.go
@@ -113,7 +113,10 @@ func (r *PendingReplyRepo) Update(ctx context.Context, pr *PendingReply) error {
 		return fmt.Errorf("update pending reply: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("update pending reply: row not found or not owned")
+		// Either the row never existed, was deleted, or belongs to
+		// another tenant — all three are indistinguishable on
+		// purpose so callers cannot leak existence cross-tenant.
+		return ErrPendingReplyNotFound
 	}
 	return nil
 }

--- a/backend/internal/inbox/pending_reply_repository_test.go
+++ b/backend/internal/inbox/pending_reply_repository_test.go
@@ -123,6 +123,49 @@ func TestPendingReplyRepository_ListByLead_ScopedByUser(t *testing.T) {
 	assert.Empty(t, cross, "cross-tenant ListByLead must return empty")
 }
 
+func TestPendingReplyRepository_Update_RowMissingReturnsNotFoundSentinel(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	// Construct an entity that was never persisted: Update must
+	// surface ErrPendingReplyNotFound so the usecase layer can map
+	// it to a uniform 404 (or to ErrPendingReplyAlreadyDecided once
+	// the WHERE clause adds the status filter for optimistic lock).
+	pr, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "ghost")
+	require.NoError(t, err)
+	require.NoError(t, pr.Approve(time.Now().UTC()))
+
+	err = repo.Update(ctx, pr)
+	require.Error(t, err)
+	require.ErrorIs(t, err, inbox.ErrPendingReplyNotFound,
+		"Update must return ErrPendingReplyNotFound for a missing row, not a bare error")
+}
+
+func TestPendingReplyRepository_Update_CrossTenantReturnsNotFoundSentinel(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userA := testutil.SeedUser(t, pool)
+	userB := testutil.SeedUser(t, pool)
+	leadA := seedLeadForUser(t, pool, userA)
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	pr, err := inbox.NewPendingReply(userA, leadA, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "owned by A")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, pr))
+
+	// userB attempting an Update on userA's row must NOT silently
+	// no-op; it must surface ErrPendingReplyNotFound (same observable
+	// as a missing row — uniform 404 contract).
+	stolen := *pr
+	stolen.UserID = userB
+	require.NoError(t, stolen.Reject(time.Now().UTC()))
+	err = repo.Update(ctx, &stolen)
+	require.ErrorIs(t, err, inbox.ErrPendingReplyNotFound)
+}
+
 func TestPendingReplyRepository_Update_PersistsStatusAndTimestamps(t *testing.T) {
 	pool := testutil.TestDB(t)
 	userID := testutil.SeedUser(t, pool)

--- a/backend/internal/inbox/pending_reply_repository_test.go
+++ b/backend/internal/inbox/pending_reply_repository_test.go
@@ -138,7 +138,7 @@ func TestPendingReplyRepository_Update_RowMissingReturnsNotFoundSentinel(t *test
 	require.NoError(t, err)
 	require.NoError(t, pr.Approve(time.Now().UTC()))
 
-	err = repo.Update(ctx, pr)
+	err = repo.Update(ctx, pr, inbox.PendingReplyStatusPending)
 	require.Error(t, err)
 	require.ErrorIs(t, err, inbox.ErrPendingReplyNotFound,
 		"Update must return ErrPendingReplyNotFound for a missing row, not a bare error")
@@ -162,7 +162,7 @@ func TestPendingReplyRepository_Update_CrossTenantReturnsNotFoundSentinel(t *tes
 	stolen := *pr
 	stolen.UserID = userB
 	require.NoError(t, stolen.Reject(time.Now().UTC()))
-	err = repo.Update(ctx, &stolen)
+	err = repo.Update(ctx, &stolen, inbox.PendingReplyStatusPending)
 	require.ErrorIs(t, err, inbox.ErrPendingReplyNotFound)
 }
 
@@ -207,7 +207,7 @@ func TestPendingReplyRepository_Update_PersistsStatusAndTimestamps(t *testing.T)
 
 	decidedAt := time.Now().UTC().Truncate(time.Microsecond)
 	require.NoError(t, pr.Approve(decidedAt))
-	require.NoError(t, repo.Update(ctx, pr))
+	require.NoError(t, repo.Update(ctx, pr, inbox.PendingReplyStatusPending))
 
 	got, err := repo.GetByID(ctx, userID, pr.ID)
 	require.NoError(t, err)
@@ -219,7 +219,7 @@ func TestPendingReplyRepository_Update_PersistsStatusAndTimestamps(t *testing.T)
 
 	sentAt := time.Now().UTC().Truncate(time.Microsecond)
 	require.NoError(t, pr.MarkSent(sentAt))
-	require.NoError(t, repo.Update(ctx, pr))
+	require.NoError(t, repo.Update(ctx, pr, inbox.PendingReplyStatusApproved))
 
 	got2, err := repo.GetByID(ctx, userID, pr.ID)
 	require.NoError(t, err)

--- a/backend/internal/inbox/pending_reply_repository_test.go
+++ b/backend/internal/inbox/pending_reply_repository_test.go
@@ -166,6 +166,34 @@ func TestPendingReplyRepository_Update_CrossTenantReturnsNotFoundSentinel(t *tes
 	require.ErrorIs(t, err, inbox.ErrPendingReplyNotFound)
 }
 
+func TestPendingReplyRepository_Update_OptimisticLock_RejectsWhenStatusMoved(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	pr, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "race")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, pr))
+
+	// Simulate the race: operator A loaded the row at status=pending
+	// and is about to push status=approved. Meanwhile operator B
+	// already approved it — the persisted row is now status=approved.
+	bSnap := *pr
+	require.NoError(t, bSnap.Approve(time.Now().UTC()))
+	require.NoError(t, repo.Update(ctx, &bSnap, inbox.PendingReplyStatusPending))
+
+	// Operator A's stale snapshot, still expecting status=pending,
+	// must fail the optimistic check rather than overwriting B's
+	// decision.
+	aSnap := *pr
+	require.NoError(t, aSnap.Approve(time.Now().UTC()))
+	err = repo.Update(ctx, &aSnap, inbox.PendingReplyStatusPending)
+	require.ErrorIs(t, err, inbox.ErrPendingReplyNotFound,
+		"second Update with the same expected-status must fail — the row is no longer pending")
+}
+
 func TestPendingReplyRepository_Update_PersistsStatusAndTimestamps(t *testing.T) {
 	pool := testutil.TestDB(t)
 	userID := testutil.SeedUser(t, pool)

--- a/backend/internal/inbox/pending_reply_repository_test.go
+++ b/backend/internal/inbox/pending_reply_repository_test.go
@@ -1,0 +1,159 @@
+//go:build integration
+
+package inbox_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/daniil/floq/internal/inbox"
+	"github.com/daniil/floq/internal/testutil"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedLeadForUser inserts a minimal lead row tied to userID and returns
+// its id. Required because pending_replies.lead_id is a FK with
+// ON DELETE CASCADE — the test fixture has to satisfy it. Cleanup is
+// covered by the SeedUser CASCADE.
+func seedLeadForUser(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID) uuid.UUID {
+	t.Helper()
+	leadID := uuid.New()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO leads (id, user_id, channel, contact_name, first_message, status, created_at, updated_at)
+		 VALUES ($1, $2, 'telegram', 'Test Lead', 'hi', 'new', NOW(), NOW())`,
+		leadID, userID)
+	require.NoError(t, err, "seed test lead")
+	return leadID
+}
+
+func TestPendingReplyRepository_SaveAndGetByID(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	pr, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "hello")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, pr))
+
+	got, err := repo.GetByID(ctx, userID, pr.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, pr.ID, got.ID)
+	assert.Equal(t, userID, got.UserID)
+	assert.Equal(t, leadID, got.LeadID)
+	assert.Equal(t, inbox.ChannelTelegram, got.Channel)
+	assert.Equal(t, inbox.PendingReplyKindBookingLink, got.Kind)
+	assert.Equal(t, "hello", got.Body)
+	assert.Equal(t, inbox.PendingReplyStatusPending, got.Status)
+	assert.WithinDuration(t, pr.CreatedAt, got.CreatedAt, time.Second)
+	assert.Nil(t, got.DecidedAt)
+	assert.Nil(t, got.SentAt)
+}
+
+func TestPendingReplyRepository_GetByID_ScopedByUser(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userA := testutil.SeedUser(t, pool)
+	userB := testutil.SeedUser(t, pool)
+	leadA := seedLeadForUser(t, pool, userA)
+
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	pr, err := inbox.NewPendingReply(userA, leadA, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "owned by A")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, pr))
+
+	got, err := repo.GetByID(ctx, userB, pr.ID)
+	require.NoError(t, err, "cross-tenant lookup must not error")
+	assert.Nil(t, got, "cross-tenant lookup must return nil — never another user's row")
+}
+
+func TestPendingReplyRepository_GetByID_NotFound(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	got, err := repo.GetByID(ctx, userID, uuid.New())
+	require.NoError(t, err, "missing row is not an error")
+	assert.Nil(t, got)
+}
+
+func TestPendingReplyRepository_ListByLead_ScopedByUser(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userA := testutil.SeedUser(t, pool)
+	userB := testutil.SeedUser(t, pool)
+	leadA := seedLeadForUser(t, pool, userA)
+	leadB := seedLeadForUser(t, pool, userB)
+
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	prA1, err := inbox.NewPendingReply(userA, leadA, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "a1")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, prA1))
+
+	prA2, err := inbox.NewPendingReply(userA, leadA, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "a2")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, prA2))
+
+	prB, err := inbox.NewPendingReply(userB, leadB, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "b")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, prB))
+
+	got, err := repo.ListByLead(ctx, userA, leadA)
+	require.NoError(t, err)
+	assert.Len(t, got, 2)
+	for _, p := range got {
+		assert.Equal(t, userA, p.UserID, "ListByLead must never leak other-user rows")
+		assert.Equal(t, leadA, p.LeadID)
+	}
+
+	// Cross-tenant probe: userB asking for leadA returns nothing even if
+	// the lead exists (could happen via guessed UUIDs).
+	cross, err := repo.ListByLead(ctx, userB, leadA)
+	require.NoError(t, err)
+	assert.Empty(t, cross, "cross-tenant ListByLead must return empty")
+}
+
+func TestPendingReplyRepository_Update_PersistsStatusAndTimestamps(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	pr, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "body")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, pr))
+
+	decidedAt := time.Now().UTC().Truncate(time.Microsecond)
+	require.NoError(t, pr.Approve(decidedAt))
+	require.NoError(t, repo.Update(ctx, pr))
+
+	got, err := repo.GetByID(ctx, userID, pr.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, inbox.PendingReplyStatusApproved, got.Status)
+	require.NotNil(t, got.DecidedAt)
+	assert.WithinDuration(t, decidedAt, *got.DecidedAt, time.Second)
+	assert.Nil(t, got.SentAt)
+
+	sentAt := time.Now().UTC().Truncate(time.Microsecond)
+	require.NoError(t, pr.MarkSent(sentAt))
+	require.NoError(t, repo.Update(ctx, pr))
+
+	got2, err := repo.GetByID(ctx, userID, pr.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got2)
+	assert.Equal(t, inbox.PendingReplyStatusSent, got2.Status)
+	require.NotNil(t, got2.SentAt)
+	assert.WithinDuration(t, sentAt, *got2.SentAt, time.Second)
+}

--- a/backend/internal/inbox/pending_reply_test.go
+++ b/backend/internal/inbox/pending_reply_test.go
@@ -104,3 +104,130 @@ func TestNewPendingReply_TrimsBodyWhitespace(t *testing.T) {
 		t.Errorf("Body = %q, want %q", pr.Body, "hi")
 	}
 }
+
+func freshPendingReply(t *testing.T) *PendingReply {
+	t.Helper()
+	pr, err := NewPendingReply(uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "body")
+	if err != nil {
+		t.Fatalf("unexpected error building fixture: %v", err)
+	}
+	return pr
+}
+
+func TestPendingReply_Approve_FromPending(t *testing.T) {
+	pr := freshPendingReply(t)
+	at := time.Now().UTC()
+	if err := pr.Approve(at); err != nil {
+		t.Fatalf("Approve from pending should succeed, got %v", err)
+	}
+	if pr.Status != PendingReplyStatusApproved {
+		t.Errorf("Status = %v, want approved", pr.Status)
+	}
+	if pr.DecidedAt == nil || !pr.DecidedAt.Equal(at) {
+		t.Errorf("DecidedAt = %v, want %v", pr.DecidedAt, at)
+	}
+}
+
+func TestPendingReply_Reject_FromPending(t *testing.T) {
+	pr := freshPendingReply(t)
+	at := time.Now().UTC()
+	if err := pr.Reject(at); err != nil {
+		t.Fatalf("Reject from pending should succeed, got %v", err)
+	}
+	if pr.Status != PendingReplyStatusRejected {
+		t.Errorf("Status = %v, want rejected", pr.Status)
+	}
+	if pr.DecidedAt == nil || !pr.DecidedAt.Equal(at) {
+		t.Errorf("DecidedAt = %v, want %v", pr.DecidedAt, at)
+	}
+}
+
+func TestPendingReply_MarkSent_FromApproved(t *testing.T) {
+	pr := freshPendingReply(t)
+	if err := pr.Approve(time.Now().UTC()); err != nil {
+		t.Fatalf("Approve setup failed: %v", err)
+	}
+	sentAt := time.Now().UTC().Add(time.Second)
+	if err := pr.MarkSent(sentAt); err != nil {
+		t.Fatalf("MarkSent from approved should succeed, got %v", err)
+	}
+	if pr.Status != PendingReplyStatusSent {
+		t.Errorf("Status = %v, want sent", pr.Status)
+	}
+	if pr.SentAt == nil || !pr.SentAt.Equal(sentAt) {
+		t.Errorf("SentAt = %v, want %v", pr.SentAt, sentAt)
+	}
+}
+
+func TestPendingReply_IllegalTransitions(t *testing.T) {
+	cases := []struct {
+		name string
+		op   func(*PendingReply) error
+		seed func(t *testing.T) *PendingReply
+	}{
+		{
+			name: "MarkSent from pending is illegal",
+			op:   func(pr *PendingReply) error { return pr.MarkSent(time.Now().UTC()) },
+			seed: freshPendingReply,
+		},
+		{
+			name: "Approve from approved is illegal",
+			op:   func(pr *PendingReply) error { return pr.Approve(time.Now().UTC()) },
+			seed: func(t *testing.T) *PendingReply {
+				pr := freshPendingReply(t)
+				if err := pr.Approve(time.Now().UTC()); err != nil {
+					t.Fatalf("seed Approve failed: %v", err)
+				}
+				return pr
+			},
+		},
+		{
+			name: "Reject from approved is illegal",
+			op:   func(pr *PendingReply) error { return pr.Reject(time.Now().UTC()) },
+			seed: func(t *testing.T) *PendingReply {
+				pr := freshPendingReply(t)
+				if err := pr.Approve(time.Now().UTC()); err != nil {
+					t.Fatalf("seed Approve failed: %v", err)
+				}
+				return pr
+			},
+		},
+		{
+			name: "Approve from rejected is illegal",
+			op:   func(pr *PendingReply) error { return pr.Approve(time.Now().UTC()) },
+			seed: func(t *testing.T) *PendingReply {
+				pr := freshPendingReply(t)
+				if err := pr.Reject(time.Now().UTC()); err != nil {
+					t.Fatalf("seed Reject failed: %v", err)
+				}
+				return pr
+			},
+		},
+		{
+			name: "MarkSent from sent is illegal",
+			op:   func(pr *PendingReply) error { return pr.MarkSent(time.Now().UTC()) },
+			seed: func(t *testing.T) *PendingReply {
+				pr := freshPendingReply(t)
+				if err := pr.Approve(time.Now().UTC()); err != nil {
+					t.Fatalf("seed Approve failed: %v", err)
+				}
+				if err := pr.MarkSent(time.Now().UTC()); err != nil {
+					t.Fatalf("seed MarkSent failed: %v", err)
+				}
+				return pr
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := tc.seed(t)
+			before := pr.Status
+			if err := tc.op(pr); !errors.Is(err, ErrPendingReplyInvalidTransition) {
+				t.Fatalf("want ErrPendingReplyInvalidTransition, got %v", err)
+			}
+			if pr.Status != before {
+				t.Errorf("status mutated on rejected transition: %v -> %v", before, pr.Status)
+			}
+		})
+	}
+}

--- a/backend/internal/inbox/pending_reply_test.go
+++ b/backend/internal/inbox/pending_reply_test.go
@@ -1,0 +1,106 @@
+package inbox
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestNewPendingReply_RequiresUserID(t *testing.T) {
+	_, err := NewPendingReply(uuid.Nil, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "body")
+	if !errors.Is(err, ErrPendingReplyMissingUser) {
+		t.Fatalf("want ErrPendingReplyMissingUser, got %v", err)
+	}
+}
+
+func TestNewPendingReply_RequiresLeadID(t *testing.T) {
+	_, err := NewPendingReply(uuid.New(), uuid.Nil, ChannelTelegram, PendingReplyKindBookingLink, "body")
+	if !errors.Is(err, ErrPendingReplyMissingLead) {
+		t.Fatalf("want ErrPendingReplyMissingLead, got %v", err)
+	}
+}
+
+func TestNewPendingReply_RejectsUnknownChannel(t *testing.T) {
+	_, err := NewPendingReply(uuid.New(), uuid.New(), Channel("smoke-signal"), PendingReplyKindBookingLink, "body")
+	if !errors.Is(err, ErrPendingReplyInvalidChannel) {
+		t.Fatalf("want ErrPendingReplyInvalidChannel, got %v", err)
+	}
+}
+
+func TestNewPendingReply_RejectsUnknownKind(t *testing.T) {
+	_, err := NewPendingReply(uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKind("mystery"), "body")
+	if !errors.Is(err, ErrPendingReplyInvalidKind) {
+		t.Fatalf("want ErrPendingReplyInvalidKind, got %v", err)
+	}
+}
+
+func TestNewPendingReply_RejectsEmptyBody(t *testing.T) {
+	cases := []string{"", "   ", "\t\n"}
+	for _, body := range cases {
+		t.Run(body, func(t *testing.T) {
+			_, err := NewPendingReply(uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, body)
+			if !errors.Is(err, ErrPendingReplyEmptyBody) {
+				t.Fatalf("want ErrPendingReplyEmptyBody, got %v", err)
+			}
+		})
+	}
+}
+
+func TestNewPendingReply_StartsPendingWithGeneratedIDAndTimestamp(t *testing.T) {
+	userID := uuid.New()
+	leadID := uuid.New()
+	before := time.Now().UTC()
+
+	pr, err := NewPendingReply(userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	after := time.Now().UTC()
+
+	if pr.ID == uuid.Nil {
+		t.Fatal("expected generated ID, got Nil UUID")
+	}
+	if pr.UserID != userID {
+		t.Errorf("UserID = %v, want %v", pr.UserID, userID)
+	}
+	if pr.LeadID != leadID {
+		t.Errorf("LeadID = %v, want %v", pr.LeadID, leadID)
+	}
+	if pr.Channel != ChannelTelegram {
+		t.Errorf("Channel = %v, want telegram", pr.Channel)
+	}
+	if pr.Kind != PendingReplyKindBookingLink {
+		t.Errorf("Kind = %v, want booking_link", pr.Kind)
+	}
+	if pr.Body != "hello" {
+		t.Errorf("Body = %q, want hello", pr.Body)
+	}
+	if pr.Status != PendingReplyStatusPending {
+		t.Errorf("Status = %v, want pending", pr.Status)
+	}
+	if pr.CreatedAt.Before(before) || pr.CreatedAt.After(after) {
+		t.Errorf("CreatedAt = %v, expected within [%v, %v]", pr.CreatedAt, before, after)
+	}
+	if pr.DecidedAt != nil {
+		t.Errorf("DecidedAt = %v, want nil for pending reply", pr.DecidedAt)
+	}
+	if pr.SentAt != nil {
+		t.Errorf("SentAt = %v, want nil for pending reply", pr.SentAt)
+	}
+}
+
+func TestNewPendingReply_TrimsBodyWhitespace(t *testing.T) {
+	pr, err := NewPendingReply(uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "  hi  ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(pr.Body) != pr.Body {
+		t.Errorf("Body = %q, expected trimmed value", pr.Body)
+	}
+	if pr.Body != "hi" {
+		t.Errorf("Body = %q, want %q", pr.Body, "hi")
+	}
+}

--- a/backend/internal/inbox/pending_reply_usecase.go
+++ b/backend/internal/inbox/pending_reply_usecase.go
@@ -1,0 +1,143 @@
+package inbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ReplyDispatcher delivers an approved PendingReply to the customer
+// through the channel-native transport (Telegram Bot API, future
+// SMTP/IMAP, etc.). Implementations live in the composition root —
+// the usecase only knows the abstract port so the inbox package
+// stays free of transport-layer imports.
+//
+// Returning an error here keeps the entity in the Approved status so
+// the operator can retry; the usecase will NOT mark it sent on
+// failure.
+type ReplyDispatcher interface {
+	Dispatch(ctx context.Context, pr *PendingReply) error
+}
+
+// --- Sentinels ---
+
+var (
+	// ErrPendingReplyNotFound covers both "row does not exist" and
+	// "row exists but belongs to another tenant". The two are
+	// indistinguishable on purpose so the handler can answer a
+	// uniform 404 and not leak existence to attackers.
+	ErrPendingReplyNotFound = errors.New("pending reply: not found")
+
+	// ErrPendingReplyAlreadyDecided is returned when the operator
+	// tries to Approve or Reject a reply that is no longer in the
+	// Pending state. The state machine in the domain rejects the
+	// transition itself; this wrapper surfaces a stable sentinel for
+	// the handler layer.
+	ErrPendingReplyAlreadyDecided = errors.New("pending reply: already decided")
+)
+
+// PendingReplyUseCase orchestrates the HITL approval flow for inbox
+// auto-drafts. It is the only collaborator that mutates PendingReply
+// rows after Save — handlers parse input, call into the usecase, and
+// map the response/error to HTTP.
+type PendingReplyUseCase struct {
+	repo       PendingReplyRepository
+	dispatcher ReplyDispatcher
+}
+
+// NewPendingReplyUseCase wires the usecase with its persistence and
+// dispatch ports. Both are required — the usecase does not start
+// without a way to send approved replies.
+func NewPendingReplyUseCase(repo PendingReplyRepository, dispatcher ReplyDispatcher) *PendingReplyUseCase {
+	return &PendingReplyUseCase{repo: repo, dispatcher: dispatcher}
+}
+
+// Propose constructs a new PendingReply through the domain factory
+// (so invariants are enforced) and persists it. Dispatch is
+// deliberately skipped — that is the whole point of the HITL gate.
+func (uc *PendingReplyUseCase) Propose(ctx context.Context, userID, leadID uuid.UUID, channel Channel, kind PendingReplyKind, body string) (*PendingReply, error) {
+	pr, err := NewPendingReply(userID, leadID, channel, kind, body)
+	if err != nil {
+		return nil, err
+	}
+	if err := uc.repo.Save(ctx, pr); err != nil {
+		return nil, fmt.Errorf("propose pending reply: %w", err)
+	}
+	return pr, nil
+}
+
+// ListByLead returns every pending-or-decided reply tied to the given
+// lead for the given user. The repository scope guarantees no
+// cross-tenant leakage.
+func (uc *PendingReplyUseCase) ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error) {
+	return uc.repo.ListByLead(ctx, userID, leadID)
+}
+
+// Approve transitions the reply into Approved, persists the decision,
+// dispatches through the channel-native transport, and (on success)
+// marks the entity Sent. A dispatch failure leaves the entity in
+// Approved so the operator can retry; the error propagates so the
+// handler can surface it. Cross-tenant or missing IDs collapse to
+// ErrPendingReplyNotFound (uniform 404).
+func (uc *PendingReplyUseCase) Approve(ctx context.Context, userID, id uuid.UUID) error {
+	pr, err := uc.loadOwned(ctx, userID, id)
+	if err != nil {
+		return err
+	}
+	if err := pr.Approve(time.Now().UTC()); err != nil {
+		if errors.Is(err, ErrPendingReplyInvalidTransition) {
+			return ErrPendingReplyAlreadyDecided
+		}
+		return err
+	}
+	if err := uc.repo.Update(ctx, pr); err != nil {
+		return fmt.Errorf("persist approved pending reply: %w", err)
+	}
+	if err := uc.dispatcher.Dispatch(ctx, pr); err != nil {
+		return fmt.Errorf("dispatch approved pending reply: %w", err)
+	}
+	if err := pr.MarkSent(time.Now().UTC()); err != nil {
+		return fmt.Errorf("mark pending reply sent: %w", err)
+	}
+	if err := uc.repo.Update(ctx, pr); err != nil {
+		return fmt.Errorf("persist sent pending reply: %w", err)
+	}
+	return nil
+}
+
+// Reject transitions the reply into the terminal Rejected status and
+// persists the decision. No dispatch is performed. Cross-tenant or
+// missing IDs collapse to ErrPendingReplyNotFound.
+func (uc *PendingReplyUseCase) Reject(ctx context.Context, userID, id uuid.UUID) error {
+	pr, err := uc.loadOwned(ctx, userID, id)
+	if err != nil {
+		return err
+	}
+	if err := pr.Reject(time.Now().UTC()); err != nil {
+		if errors.Is(err, ErrPendingReplyInvalidTransition) {
+			return ErrPendingReplyAlreadyDecided
+		}
+		return err
+	}
+	if err := uc.repo.Update(ctx, pr); err != nil {
+		return fmt.Errorf("persist rejected pending reply: %w", err)
+	}
+	return nil
+}
+
+// loadOwned fetches a reply scoped by user_id and collapses
+// "not found" and "not owned" into ErrPendingReplyNotFound so callers
+// cannot leak existence cross-tenant by inspecting the error.
+func (uc *PendingReplyUseCase) loadOwned(ctx context.Context, userID, id uuid.UUID) (*PendingReply, error) {
+	pr, err := uc.repo.GetByID(ctx, userID, id)
+	if err != nil {
+		return nil, fmt.Errorf("load pending reply: %w", err)
+	}
+	if pr == nil {
+		return nil, ErrPendingReplyNotFound
+	}
+	return pr, nil
+}

--- a/backend/internal/inbox/pending_reply_usecase.go
+++ b/backend/internal/inbox/pending_reply_usecase.go
@@ -112,7 +112,13 @@ func (uc *PendingReplyUseCase) Approve(ctx context.Context, userID, id uuid.UUID
 		}
 		return err
 	}
-	if err := uc.repo.Update(ctx, pr); err != nil {
+	// Optimistic lock: we just loaded the row at status=pending; if
+	// the Update returns NotFound the row has been decided by
+	// somebody else in the meantime — surface as AlreadyDecided.
+	if err := uc.repo.Update(ctx, pr, PendingReplyStatusPending); err != nil {
+		if errors.Is(err, ErrPendingReplyNotFound) {
+			return ErrPendingReplyAlreadyDecided
+		}
 		return fmt.Errorf("persist approved pending reply: %w", err)
 	}
 	if uc.dispatcher == nil {
@@ -124,7 +130,10 @@ func (uc *PendingReplyUseCase) Approve(ctx context.Context, userID, id uuid.UUID
 	if err := pr.MarkSent(time.Now().UTC()); err != nil {
 		return fmt.Errorf("mark pending reply sent: %w", err)
 	}
-	if err := uc.repo.Update(ctx, pr); err != nil {
+	// The persisted row should still be at status=approved (we just
+	// set it). A NotFound here would be a serious anomaly — log it
+	// rather than convert to AlreadyDecided.
+	if err := uc.repo.Update(ctx, pr, PendingReplyStatusApproved); err != nil {
 		return fmt.Errorf("persist sent pending reply: %w", err)
 	}
 	return nil
@@ -144,7 +153,10 @@ func (uc *PendingReplyUseCase) Reject(ctx context.Context, userID, id uuid.UUID)
 		}
 		return err
 	}
-	if err := uc.repo.Update(ctx, pr); err != nil {
+	if err := uc.repo.Update(ctx, pr, PendingReplyStatusPending); err != nil {
+		if errors.Is(err, ErrPendingReplyNotFound) {
+			return ErrPendingReplyAlreadyDecided
+		}
 		return fmt.Errorf("persist rejected pending reply: %w", err)
 	}
 	return nil

--- a/backend/internal/inbox/pending_reply_usecase.go
+++ b/backend/internal/inbox/pending_reply_usecase.go
@@ -37,6 +37,15 @@ var (
 	// transition itself; this wrapper surfaces a stable sentinel for
 	// the handler layer.
 	ErrPendingReplyAlreadyDecided = errors.New("pending reply: already decided")
+
+	// ErrPendingReplyDispatcherNotConfigured surfaces a runtime
+	// misconfiguration: the usecase was constructed (or post-init
+	// SetDispatcher was never called) without a ReplyDispatcher. It
+	// is a deliberate sentinel rather than a bare error so the
+	// handler maps it to 500 explicitly and ops dashboards can
+	// alert on it. In production this should never fire — main.go
+	// wires SetDispatcher before SetPendingProposer.
+	ErrPendingReplyDispatcherNotConfigured = errors.New("pending reply: dispatcher not configured")
 )
 
 // PendingReplyUseCase orchestrates the HITL approval flow for inbox
@@ -107,7 +116,7 @@ func (uc *PendingReplyUseCase) Approve(ctx context.Context, userID, id uuid.UUID
 		return fmt.Errorf("persist approved pending reply: %w", err)
 	}
 	if uc.dispatcher == nil {
-		return errors.New("pending reply: dispatcher not configured")
+		return ErrPendingReplyDispatcherNotConfigured
 	}
 	if err := uc.dispatcher.Dispatch(ctx, pr); err != nil {
 		return fmt.Errorf("dispatch approved pending reply: %w", err)

--- a/backend/internal/inbox/pending_reply_usecase.go
+++ b/backend/internal/inbox/pending_reply_usecase.go
@@ -48,11 +48,21 @@ type PendingReplyUseCase struct {
 	dispatcher ReplyDispatcher
 }
 
-// NewPendingReplyUseCase wires the usecase with its persistence and
-// dispatch ports. Both are required — the usecase does not start
-// without a way to send approved replies.
+// NewPendingReplyUseCase wires the usecase with its persistence port.
+// The dispatcher may be nil at construction so the composition root
+// can register HTTP routes that reference the usecase before the
+// Telegram bot (and therefore the dispatcher built from its
+// *tgbotapi.BotAPI) is initialised. Call SetDispatcher once the bot
+// is up; Approve returns an explicit error if invoked before then.
 func NewPendingReplyUseCase(repo PendingReplyRepository, dispatcher ReplyDispatcher) *PendingReplyUseCase {
 	return &PendingReplyUseCase{repo: repo, dispatcher: dispatcher}
+}
+
+// SetDispatcher injects the ReplyDispatcher at runtime. Mirrors the
+// existing leadsUC.SetSender pattern; necessary to break the
+// bot -> usecase -> dispatcher -> bot cycle in the composition root.
+func (uc *PendingReplyUseCase) SetDispatcher(d ReplyDispatcher) {
+	uc.dispatcher = d
 }
 
 // Propose constructs a new PendingReply through the domain factory
@@ -95,6 +105,9 @@ func (uc *PendingReplyUseCase) Approve(ctx context.Context, userID, id uuid.UUID
 	}
 	if err := uc.repo.Update(ctx, pr); err != nil {
 		return fmt.Errorf("persist approved pending reply: %w", err)
+	}
+	if uc.dispatcher == nil {
+		return errors.New("pending reply: dispatcher not configured")
 	}
 	if err := uc.dispatcher.Dispatch(ctx, pr); err != nil {
 		return fmt.Errorf("dispatch approved pending reply: %w", err)

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -356,6 +356,47 @@ func TestPendingReplyUseCase_Reject_NotFoundReturnsSentinel(t *testing.T) {
 	}
 }
 
+func TestPendingReplyUseCase_Approve_WithoutDispatcherReturnsError(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, nil) // nil dispatcher allowed at construction time
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "ok")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = uc.Approve(ctx, userID, pr.ID)
+	if err == nil {
+		t.Fatal("Approve must error when no dispatcher is wired")
+	}
+	stored, _ := repo.GetByID(ctx, userID, pr.ID)
+	if stored.Status == PendingReplyStatusSent {
+		t.Error("entity must NOT reach sent state without a dispatcher")
+	}
+}
+
+func TestPendingReplyUseCase_SetDispatcher_InjectsAtRuntime(t *testing.T) {
+	repo := newFakeRepo()
+	disp := &spyDispatcher{}
+	uc := NewPendingReplyUseCase(repo, nil)
+	uc.SetDispatcher(disp)
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "ok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := uc.Approve(ctx, userID, pr.ID); err != nil {
+		t.Fatalf("Approve after SetDispatcher must succeed, got %v", err)
+	}
+	if len(disp.Calls()) != 1 {
+		t.Errorf("dispatcher injected via setter should receive the call, got %d calls", len(disp.Calls()))
+	}
+}
+
 func TestPendingReplyUseCase_Reject_AlreadyDecided(t *testing.T) {
 	repo := newFakeRepo()
 	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -89,7 +89,12 @@ type spyDispatcher struct {
 func (s *spyDispatcher) Dispatch(_ context.Context, pr *PendingReply) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.calls = append(s.calls, pr)
+	// Snapshot at dispatch time — the usecase mutates the entity to
+	// Sent immediately after a successful dispatch returns, so storing
+	// a pointer would lose the "what did the dispatcher actually see"
+	// signal that the test wants to assert.
+	snapshot := *pr
+	s.calls = append(s.calls, &snapshot)
 	return s.failErr
 }
 

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -368,8 +368,8 @@ func TestPendingReplyUseCase_Approve_WithoutDispatcherReturnsError(t *testing.T)
 	}
 
 	err = uc.Approve(ctx, userID, pr.ID)
-	if err == nil {
-		t.Fatal("Approve must error when no dispatcher is wired")
+	if !errors.Is(err, ErrPendingReplyDispatcherNotConfigured) {
+		t.Fatalf("want ErrPendingReplyDispatcherNotConfigured, got %v", err)
 	}
 	stored, _ := repo.GetByID(ctx, userID, pr.ID)
 	if stored.Status == PendingReplyStatusSent {

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -1,0 +1,372 @@
+package inbox
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// --- in-memory fakes ---
+
+type fakePendingReplyRepo struct {
+	mu      sync.Mutex
+	rows    map[uuid.UUID]*PendingReply
+	saveErr error
+	getErr  error
+	updErr  error
+	listErr error
+}
+
+func newFakeRepo() *fakePendingReplyRepo {
+	return &fakePendingReplyRepo{rows: map[uuid.UUID]*PendingReply{}}
+}
+
+func (f *fakePendingReplyRepo) Save(_ context.Context, pr *PendingReply) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	copy := *pr
+	f.rows[pr.ID] = &copy
+	return nil
+}
+
+func (f *fakePendingReplyRepo) GetByID(_ context.Context, userID, id uuid.UUID) (*PendingReply, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	row, ok := f.rows[id]
+	if !ok || row.UserID != userID {
+		return nil, nil
+	}
+	copy := *row
+	return &copy, nil
+}
+
+func (f *fakePendingReplyRepo) ListByLead(_ context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := []*PendingReply{}
+	for _, row := range f.rows {
+		if row.UserID == userID && row.LeadID == leadID {
+			copy := *row
+			out = append(out, &copy)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakePendingReplyRepo) Update(_ context.Context, pr *PendingReply) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.updErr != nil {
+		return f.updErr
+	}
+	if _, ok := f.rows[pr.ID]; !ok {
+		return errors.New("update: row not found")
+	}
+	copy := *pr
+	f.rows[pr.ID] = &copy
+	return nil
+}
+
+type spyDispatcher struct {
+	mu      sync.Mutex
+	calls   []*PendingReply
+	failErr error
+}
+
+func (s *spyDispatcher) Dispatch(_ context.Context, pr *PendingReply) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, pr)
+	return s.failErr
+}
+
+func (s *spyDispatcher) Calls() []*PendingReply {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*PendingReply{}, s.calls...)
+}
+
+// --- Propose ---
+
+func TestPendingReplyUseCase_Propose_PersistsAndReturnsEntity(t *testing.T) {
+	repo := newFakeRepo()
+	disp := &spyDispatcher{}
+	uc := NewPendingReplyUseCase(repo, disp)
+	ctx := context.Background()
+	userID := uuid.New()
+	leadID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "hello")
+	if err != nil {
+		t.Fatalf("Propose returned error: %v", err)
+	}
+	if pr == nil {
+		t.Fatal("Propose returned nil entity")
+	}
+	if pr.Status != PendingReplyStatusPending {
+		t.Errorf("returned status = %v, want pending", pr.Status)
+	}
+
+	stored, _ := repo.GetByID(ctx, userID, pr.ID)
+	if stored == nil {
+		t.Fatal("Propose did not persist the entity")
+	}
+	if stored.Body != "hello" {
+		t.Errorf("stored body = %q, want hello", stored.Body)
+	}
+	if len(disp.Calls()) != 0 {
+		t.Errorf("Propose must NOT dispatch — that's the whole point of the HITL gate")
+	}
+}
+
+func TestPendingReplyUseCase_Propose_RejectsInvalidInput(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+
+	_, err := uc.Propose(context.Background(), uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "  ")
+	if !errors.Is(err, ErrPendingReplyEmptyBody) {
+		t.Fatalf("want ErrPendingReplyEmptyBody, got %v", err)
+	}
+}
+
+func TestPendingReplyUseCase_Propose_PropagatesRepoError(t *testing.T) {
+	repo := newFakeRepo()
+	repo.saveErr = errors.New("db down")
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+
+	_, err := uc.Propose(context.Background(), uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "ok")
+	if err == nil || !errors.Is(err, repo.saveErr) {
+		t.Fatalf("want save error wrapped, got %v", err)
+	}
+}
+
+// --- ListByLead ---
+
+func TestPendingReplyUseCase_ListByLead_ScopedByUser(t *testing.T) {
+	repo := newFakeRepo()
+	disp := &spyDispatcher{}
+	uc := NewPendingReplyUseCase(repo, disp)
+	ctx := context.Background()
+	userA := uuid.New()
+	userB := uuid.New()
+	leadA := uuid.New()
+
+	_, err := uc.Propose(ctx, userA, leadA, ChannelTelegram, PendingReplyKindBookingLink, "first")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = uc.Propose(ctx, userA, leadA, ChannelTelegram, PendingReplyKindBookingLink, "second")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := uc.ListByLead(ctx, userA, leadA)
+	if err != nil {
+		t.Fatalf("ListByLead error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len = %d, want 2", len(got))
+	}
+
+	other, err := uc.ListByLead(ctx, userB, leadA)
+	if err != nil {
+		t.Fatalf("cross-tenant ListByLead error: %v", err)
+	}
+	if len(other) != 0 {
+		t.Errorf("cross-tenant ListByLead returned %d rows, want 0", len(other))
+	}
+}
+
+// --- Approve ---
+
+func TestPendingReplyUseCase_Approve_TransitionsThenDispatchesThenMarksSent(t *testing.T) {
+	repo := newFakeRepo()
+	disp := &spyDispatcher{}
+	uc := NewPendingReplyUseCase(repo, disp)
+	ctx := context.Background()
+	userID := uuid.New()
+	leadID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "ok")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := uc.Approve(ctx, userID, pr.ID); err != nil {
+		t.Fatalf("Approve error: %v", err)
+	}
+
+	calls := disp.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("dispatcher calls = %d, want 1", len(calls))
+	}
+	if calls[0].ID != pr.ID {
+		t.Errorf("dispatched ID = %v, want %v", calls[0].ID, pr.ID)
+	}
+	if calls[0].Status != PendingReplyStatusApproved {
+		t.Errorf("dispatcher saw status = %v, want approved (dispatcher acts on the approved snapshot)", calls[0].Status)
+	}
+
+	stored, _ := repo.GetByID(ctx, userID, pr.ID)
+	if stored.Status != PendingReplyStatusSent {
+		t.Errorf("stored status = %v, want sent after successful dispatch", stored.Status)
+	}
+	if stored.DecidedAt == nil {
+		t.Error("DecidedAt should be set after Approve")
+	}
+	if stored.SentAt == nil {
+		t.Error("SentAt should be set after successful dispatch")
+	}
+}
+
+func TestPendingReplyUseCase_Approve_NotFoundReturnsSentinel(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+
+	err := uc.Approve(context.Background(), uuid.New(), uuid.New())
+	if !errors.Is(err, ErrPendingReplyNotFound) {
+		t.Fatalf("want ErrPendingReplyNotFound, got %v", err)
+	}
+}
+
+func TestPendingReplyUseCase_Approve_CrossTenantReturnsNotFound(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+	userA := uuid.New()
+	userB := uuid.New()
+
+	pr, err := uc.Propose(ctx, userA, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "owned by A")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = uc.Approve(ctx, userB, pr.ID)
+	if !errors.Is(err, ErrPendingReplyNotFound) {
+		t.Fatalf("cross-tenant approve must surface ErrPendingReplyNotFound (uniform 404), got %v", err)
+	}
+}
+
+func TestPendingReplyUseCase_Approve_DispatcherFailureKeepsApprovedAndPropagates(t *testing.T) {
+	repo := newFakeRepo()
+	disp := &spyDispatcher{failErr: errors.New("telegram api 500")}
+	uc := NewPendingReplyUseCase(repo, disp)
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "ok")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = uc.Approve(ctx, userID, pr.ID)
+	if err == nil {
+		t.Fatal("Approve must propagate dispatcher failure")
+	}
+
+	stored, _ := repo.GetByID(ctx, userID, pr.ID)
+	if stored.Status != PendingReplyStatusApproved {
+		t.Errorf("after dispatch failure, status must remain approved (retry-friendly), got %v", stored.Status)
+	}
+	if stored.DecidedAt == nil {
+		t.Error("DecidedAt must be persisted even when dispatch fails — operator did decide")
+	}
+	if stored.SentAt != nil {
+		t.Error("SentAt must remain nil when dispatch failed")
+	}
+}
+
+func TestPendingReplyUseCase_Approve_RejectsAlreadyDecided(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "ok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := uc.Approve(ctx, userID, pr.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	err = uc.Approve(ctx, userID, pr.ID)
+	if !errors.Is(err, ErrPendingReplyAlreadyDecided) {
+		t.Fatalf("second Approve must return ErrPendingReplyAlreadyDecided, got %v", err)
+	}
+}
+
+// --- Reject ---
+
+func TestPendingReplyUseCase_Reject_HappyPath(t *testing.T) {
+	repo := newFakeRepo()
+	disp := &spyDispatcher{}
+	uc := NewPendingReplyUseCase(repo, disp)
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "ok")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before := time.Now().UTC()
+	if err := uc.Reject(ctx, userID, pr.ID); err != nil {
+		t.Fatalf("Reject error: %v", err)
+	}
+	after := time.Now().UTC()
+
+	stored, _ := repo.GetByID(ctx, userID, pr.ID)
+	if stored.Status != PendingReplyStatusRejected {
+		t.Errorf("status = %v, want rejected", stored.Status)
+	}
+	if stored.DecidedAt == nil || stored.DecidedAt.Before(before) || stored.DecidedAt.After(after) {
+		t.Errorf("DecidedAt = %v, want within [%v, %v]", stored.DecidedAt, before, after)
+	}
+	if len(disp.Calls()) != 0 {
+		t.Error("Reject must NOT dispatch")
+	}
+}
+
+func TestPendingReplyUseCase_Reject_NotFoundReturnsSentinel(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+
+	err := uc.Reject(context.Background(), uuid.New(), uuid.New())
+	if !errors.Is(err, ErrPendingReplyNotFound) {
+		t.Fatalf("want ErrPendingReplyNotFound, got %v", err)
+	}
+}
+
+func TestPendingReplyUseCase_Reject_AlreadyDecided(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "ok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := uc.Reject(ctx, userID, pr.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	err = uc.Reject(ctx, userID, pr.ID)
+	if !errors.Is(err, ErrPendingReplyAlreadyDecided) {
+		t.Fatalf("second Reject must return ErrPendingReplyAlreadyDecided, got %v", err)
+	}
+}

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -66,14 +66,18 @@ func (f *fakePendingReplyRepo) ListByLead(_ context.Context, userID, leadID uuid
 	return out, nil
 }
 
-func (f *fakePendingReplyRepo) Update(_ context.Context, pr *PendingReply) error {
+func (f *fakePendingReplyRepo) Update(_ context.Context, pr *PendingReply, expectedStatus PendingReplyStatus) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.updErr != nil {
 		return f.updErr
 	}
-	if _, ok := f.rows[pr.ID]; !ok {
-		return errors.New("update: row not found")
+	existing, ok := f.rows[pr.ID]
+	if !ok || existing.Status != expectedStatus {
+		// Either missing row or the optimistic lock failed — both
+		// surface as ErrPendingReplyNotFound to mirror the real
+		// repository's uniform-404 contract.
+		return ErrPendingReplyNotFound
 	}
 	copy := *pr
 	f.rows[pr.ID] = &copy
@@ -291,6 +295,36 @@ func TestPendingReplyUseCase_Approve_DispatcherFailureKeepsApprovedAndPropagates
 	}
 	if stored.SentAt != nil {
 		t.Error("SentAt must remain nil when dispatch failed")
+	}
+}
+
+func TestPendingReplyUseCase_Approve_LosesRaceToAnotherOperator_MapsToAlreadyDecided(t *testing.T) {
+	repo := newFakeRepo()
+	disp := &spyDispatcher{}
+	uc := NewPendingReplyUseCase(repo, disp)
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "racey")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-flip the persisted row to status=approved as if another
+	// operator beat us to it. fakeRepo.Update with expected=pending
+	// will then fail the optimistic check, and the usecase must
+	// translate that into ErrPendingReplyAlreadyDecided so the
+	// handler answers 409 instead of 500.
+	repo.mu.Lock()
+	repo.rows[pr.ID].Status = PendingReplyStatusApproved
+	repo.mu.Unlock()
+
+	err = uc.Approve(ctx, userID, pr.ID)
+	if !errors.Is(err, ErrPendingReplyAlreadyDecided) {
+		t.Fatalf("want ErrPendingReplyAlreadyDecided after lost race, got %v", err)
+	}
+	if len(disp.Calls()) != 0 {
+		t.Error("dispatcher MUST NOT fire when the optimistic lock was lost")
 	}
 }
 

--- a/backend/internal/inbox/ports.go
+++ b/backend/internal/inbox/ports.go
@@ -178,5 +178,13 @@ type PendingReplyRepository interface {
 	Save(ctx context.Context, pr *PendingReply) error
 	GetByID(ctx context.Context, userID, id uuid.UUID) (*PendingReply, error)
 	ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error)
-	Update(ctx context.Context, pr *PendingReply) error
+	// Update writes pr only when the persisted row still matches the
+	// expectedStatus the caller observed at load time — an optimistic
+	// lock that prevents two operators from concurrently approving
+	// the same pending reply (and therefore double-firing the
+	// dispatcher). On mismatch (or missing/cross-tenant row) the
+	// caller receives ErrPendingReplyNotFound; the usecase layer maps
+	// this to ErrPendingReplyAlreadyDecided when the row was loaded
+	// in the same operation.
+	Update(ctx context.Context, pr *PendingReply, expectedStatus PendingReplyStatus) error
 }

--- a/backend/internal/inbox/ports.go
+++ b/backend/internal/inbox/ports.go
@@ -154,3 +154,16 @@ type ConfigStore interface {
 type IdentityLinker interface {
 	LinkLeadToIdentity(ctx context.Context, userID, leadID uuid.UUID, email, phone, telegramUsername string) error
 }
+
+// PendingReplyRepository persists the HITL approval queue. Every read
+// method is scoped by userID — the repository never returns a row that
+// belongs to another tenant, so an attacker who guesses or enumerates
+// IDs still gets nil/empty. Callers SHOULD treat nil-without-error as
+// "not found OR not owned" and answer 404 to keep the two
+// indistinguishable on the wire.
+type PendingReplyRepository interface {
+	Save(ctx context.Context, pr *PendingReply) error
+	GetByID(ctx context.Context, userID, id uuid.UUID) (*PendingReply, error)
+	ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error)
+	Update(ctx context.Context, pr *PendingReply) error
+}

--- a/backend/internal/inbox/ports.go
+++ b/backend/internal/inbox/ports.go
@@ -155,6 +155,19 @@ type IdentityLinker interface {
 	LinkLeadToIdentity(ctx context.Context, userID, leadID uuid.UUID, email, phone, telegramUsername string) error
 }
 
+// PendingReplyProposer enqueues an auto-drafted reply for human
+// approval. It is the inversion-of-control seam between the inbox
+// pollers (Telegram bot, future email auto-replies) and the HITL
+// usecase: the poller knows only the abstract action "park this draft
+// for the operator", never how the queue is persisted.
+//
+// Implementations MUST be safe to call from background goroutines and
+// MUST NOT block on dispatch — actual delivery happens after operator
+// approval, not at Propose time.
+type PendingReplyProposer interface {
+	Propose(ctx context.Context, userID, leadID uuid.UUID, channel Channel, kind PendingReplyKind, body string) (*PendingReply, error)
+}
+
 // PendingReplyRepository persists the HITL approval queue. Every read
 // method is scoped by userID — the repository never returns a row that
 // belongs to another tenant, so an attacker who guesses or enumerates

--- a/backend/internal/inbox/telegram.go
+++ b/backend/internal/inbox/telegram.go
@@ -2,6 +2,7 @@ package inbox
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"log/slog"
 	"net/http"
@@ -12,6 +13,13 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/google/uuid"
 )
+
+// bookingLinkReplyTemplate is the user-facing body the HITL queue
+// enqueues when DetectCallAgreement triggers. Kept as a single
+// package-level constant so any future copy change is one edit,
+// not a hunt through handleMessage. The %s placeholder is the
+// configured booking URL — never interpolate untrusted input here.
+const bookingLinkReplyTemplate = "Отлично! Вот ссылка для выбора удобного времени для звонка: %s\n\nВыберите слот и я получу уведомление. До связи!"
 
 // TelegramBot listens for incoming Telegram messages and creates leads.
 type TelegramBot struct {
@@ -217,7 +225,7 @@ func (t *TelegramBot) handleMessage(ctx context.Context, msg *tgbotapi.Message) 
 			t.logger.WarnContext(ctx, "booking link suppressed: no pending reply proposer wired",
 				slog.Int64("chat_id", chatID), slog.String("lead_id", lead.ID.String()))
 		} else {
-			bookingMsg := "Отлично! Вот ссылка для выбора удобного времени для звонка: " + t.bookingLink + "\n\nВыберите слот и я получу уведомление. До связи!"
+			bookingMsg := fmt.Sprintf(bookingLinkReplyTemplate, t.bookingLink)
 			if _, err := t.pendingProposer.Propose(ctx, lead.UserID, lead.ID, ChannelTelegram, PendingReplyKindBookingLink, bookingMsg); err != nil {
 				t.logger.WarnContext(ctx, "failed to enqueue booking reply for approval",
 					slog.String("lead_id", lead.ID.String()), slog.Any("error", err))

--- a/backend/internal/inbox/telegram.go
+++ b/backend/internal/inbox/telegram.go
@@ -15,14 +15,15 @@ import (
 
 // TelegramBot listens for incoming Telegram messages and creates leads.
 type TelegramBot struct {
-	bot            *tgbotapi.BotAPI
-	repo           LeadRepository
-	prospectRepo   ProspectRepository
-	aiClient       AIQualifier
-	identityLinker IdentityLinker
-	logger         *slog.Logger
-	ownerID        uuid.UUID
-	bookingLink    string
+	bot             *tgbotapi.BotAPI
+	repo            LeadRepository
+	prospectRepo    ProspectRepository
+	aiClient        AIQualifier
+	identityLinker  IdentityLinker
+	pendingProposer PendingReplyProposer
+	logger          *slog.Logger
+	ownerID         uuid.UUID
+	bookingLink     string
 }
 
 // TelegramBotOption configures a *TelegramBot at construction. Used for
@@ -52,6 +53,20 @@ func WithTelegramLogger(l *slog.Logger) TelegramBotOption {
 			b.logger = l
 		}
 	}
+}
+
+// WithTelegramPendingReplyProposer wires the HITL queue used by the
+// booking-link branch in handleMessage. When set, DetectCallAgreement
+// enqueues a pending reply for operator approval instead of sending
+// the booking URL directly. When nil (or omitted), the booking-link
+// branch is suppressed entirely — a secure default that never falls
+// back to instant send.
+//
+// Named asymmetrically to its email-poller sibling for the same
+// reason as WithTelegramIdentityLinker — Go does not allow option-name
+// collisions across different option types in the same package.
+func WithTelegramPendingReplyProposer(p PendingReplyProposer) TelegramBotOption {
+	return func(b *TelegramBot) { b.pendingProposer = p }
 }
 
 // NewTelegramBot creates a new TelegramBot with the given token and dependencies.
@@ -181,17 +196,22 @@ func (t *TelegramBot) handleMessage(ctx context.Context, msg *tgbotapi.Message) 
 		return
 	}
 
-	// Auto-reply with booking link if lead agrees to a call
+	// HITL gate for booking link: when DetectCallAgreement triggers,
+	// the bot enqueues a pending reply for operator approval rather
+	// than sending the calendar URL directly. A misfired detector
+	// would otherwise leak a booking link to a lead who never asked,
+	// so the secure default when no proposer is wired is to suppress
+	// the branch entirely — we do NOT fall back to instant send.
 	if DetectCallAgreement(text) {
-		bookingMsg := "Отлично! Вот ссылка для выбора удобного времени для звонка: " + t.bookingLink + "\n\nВыберите слот и я получу уведомление. До связи!"
-		tgReply := tgbotapi.NewMessage(chatID, bookingMsg)
-		if _, err := t.bot.Send(tgReply); err != nil {
-			log.Printf("telegram inbox: error sending booking link: %v", err)
+		if t.pendingProposer == nil {
+			t.logger.WarnContext(ctx, "booking link suppressed: no pending reply proposer wired",
+				slog.Int64("chat_id", chatID), slog.String("lead_id", lead.ID.String()))
 		} else {
-			// Save as outbound message
-			outMsg := NewInboxMessage(lead.ID, DirectionOutbound, bookingMsg)
-			t.repo.CreateMessage(ctx, outMsg)
-			log.Printf("telegram inbox: sent booking link to chat %d", chatID)
+			bookingMsg := "Отлично! Вот ссылка для выбора удобного времени для звонка: " + t.bookingLink + "\n\nВыберите слот и я получу уведомление. До связи!"
+			if _, err := t.pendingProposer.Propose(ctx, lead.UserID, lead.ID, ChannelTelegram, PendingReplyKindBookingLink, bookingMsg); err != nil {
+				t.logger.WarnContext(ctx, "failed to enqueue booking reply for approval",
+					slog.String("lead_id", lead.ID.String()), slog.Any("error", err))
+			}
 		}
 	}
 

--- a/backend/internal/inbox/telegram.go
+++ b/backend/internal/inbox/telegram.go
@@ -90,6 +90,16 @@ func (t *TelegramBot) Bot() *tgbotapi.BotAPI {
 	return t.bot
 }
 
+// SetPendingProposer wires the HITL queue after construction. Used by
+// the composition root to break the
+// bot -> usecase -> dispatcher -> bot dependency cycle: the usecase
+// needs a dispatcher built from tgBot.Bot(), and the bot needs the
+// resulting usecase as proposer. Mirrors the existing leadsUC
+// .SetSender pattern in main.go.
+func (t *TelegramBot) SetPendingProposer(p PendingReplyProposer) {
+	t.pendingProposer = p
+}
+
 // Start begins listening for Telegram updates and processing them.
 // It blocks until ctx is cancelled.
 func (t *TelegramBot) Start(ctx context.Context) {

--- a/backend/internal/inbox/telegram_test.go
+++ b/backend/internal/inbox/telegram_test.go
@@ -303,16 +303,57 @@ func TestHandleMessage_ExistingLead(t *testing.T) {
 	assert.Equal(t, DirectionInbound, repo.messages[0].Direction)
 }
 
-func TestHandleMessage_CallAgreement(t *testing.T) {
+// spyPendingProposer captures Propose calls so tests can assert that
+// the booking-link branch in handleMessage routes through the HITL
+// approval queue instead of firing bot.Send directly.
+type spyPendingProposer struct {
+	mu    sync.Mutex
+	calls []proposeCall
+	err   error
+}
+
+type proposeCall struct {
+	UserID  uuid.UUID
+	LeadID  uuid.UUID
+	Channel Channel
+	Kind    PendingReplyKind
+	Body    string
+}
+
+func (s *spyPendingProposer) Propose(_ context.Context, userID, leadID uuid.UUID, channel Channel, kind PendingReplyKind, body string) (*PendingReply, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, proposeCall{userID, leadID, channel, kind, body})
+	if s.err != nil {
+		return nil, s.err
+	}
+	pr, err := NewPendingReply(userID, leadID, channel, kind, body)
+	if err != nil {
+		return nil, err
+	}
+	return pr, nil
+}
+
+func (s *spyPendingProposer) Calls() []proposeCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]proposeCall{}, s.calls...)
+}
+
+func TestHandleMessage_CallAgreement_EnqueuesForApproval(t *testing.T) {
 	repo := newMockLeadRepo()
 	aiClient := &mockAIQualifier{
 		result: &QualificationResult{Score: 9},
 	}
 	ownerID := uuid.New()
 	bookingLink := "https://cal.com/booking"
+	proposer := &spyPendingProposer{}
 	bot := newTestBot(repo, aiClient, ownerID, bookingLink)
+	bot.pendingProposer = proposer
 
-	// "давайте созвон" triggers call agreement detection.
+	// "давайте созвон" triggers call agreement detection — under HITL
+	// this must NOT send the booking link immediately; it must enqueue
+	// a pending reply for operator approval.
 	msg := makeTgMessage(77777, "Anna", "", "Звучит интересно, давайте созвон проведём!")
 	bot.handleMessage(context.Background(), msg)
 
@@ -327,7 +368,9 @@ func TestHandleMessage_CallAgreement(t *testing.T) {
 	lead := repo.leads[0]
 	assert.Equal(t, "Anna", lead.ContactName)
 
-	// We expect the inbound message + an outbound booking link message.
+	// Only the inbound message is recorded. The booking-link outbound
+	// is parked in the pending-replies queue, not in messages, until
+	// the operator approves it.
 	var inbound, outbound []*InboxMessage
 	for _, m := range repo.messages {
 		switch m.Direction {
@@ -339,10 +382,35 @@ func TestHandleMessage_CallAgreement(t *testing.T) {
 	}
 	require.Len(t, inbound, 1)
 	assert.Equal(t, lead.ID, inbound[0].LeadID)
+	assert.Empty(t, outbound, "booking link must NOT be sent immediately — HITL gate")
 
-	require.Len(t, outbound, 1)
-	assert.Equal(t, lead.ID, outbound[0].LeadID)
-	assert.Contains(t, outbound[0].Body, bookingLink)
+	// Proposer received exactly one enqueue call with the booking body.
+	calls := proposer.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, lead.UserID, calls[0].UserID)
+	assert.Equal(t, lead.ID, calls[0].LeadID)
+	assert.Equal(t, ChannelTelegram, calls[0].Channel)
+	assert.Equal(t, PendingReplyKindBookingLink, calls[0].Kind)
+	assert.Contains(t, calls[0].Body, bookingLink)
+}
+
+func TestHandleMessage_CallAgreement_NoProposerSuppressesBookingLink(t *testing.T) {
+	repo := newMockLeadRepo()
+	aiClient := &mockAIQualifier{result: &QualificationResult{Score: 9}}
+	ownerID := uuid.New()
+	bot := newTestBot(repo, aiClient, ownerID, "https://cal.com/booking")
+	// No proposer wired — secure-default: skip rather than fall back
+	// to instant send.
+
+	msg := makeTgMessage(88888, "Bob", "", "давайте созвон")
+	bot.handleMessage(context.Background(), msg)
+	waitQualifyDone(t, repo)
+
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	for _, m := range repo.messages {
+		assert.NotEqual(t, DirectionOutbound, m.Direction, "no proposer must NOT trigger instant send")
+	}
 }
 
 func TestHandleMessage_EmptyText(t *testing.T) {

--- a/backend/internal/inbox/telegram_test.go
+++ b/backend/internal/inbox/telegram_test.go
@@ -349,7 +349,10 @@ func TestHandleMessage_CallAgreement_EnqueuesForApproval(t *testing.T) {
 	bookingLink := "https://cal.com/booking"
 	proposer := &spyPendingProposer{}
 	bot := newTestBot(repo, aiClient, ownerID, bookingLink)
-	bot.pendingProposer = proposer
+	// Wire through the public setter that the composition root uses,
+	// not the private field — keeps the test honest about the
+	// production seam.
+	bot.SetPendingProposer(proposer)
 
 	// "давайте созвон" triggers call agreement detection — under HITL
 	// this must NOT send the booking link immediately; it must enqueue

--- a/backend/internal/inbox/telegram_test.go
+++ b/backend/internal/inbox/telegram_test.go
@@ -818,9 +818,15 @@ func newTestBotWithErrorHTTP(repo LeadRepository, aiClient AIQualifier, ownerID 
 		aiClient:    aiClient,
 		ownerID:     ownerID,
 		bookingLink: bookingLink,
+		logger:      slog.Default(),
 	}
 }
 
+// Pre-HITL this test exercised the bot.Send failure path. Under HITL
+// no proposer is wired here, so the booking branch is suppressed
+// entirely — the assertion that no outbound message lands in the repo
+// is the same invariant viewed from a different angle (secure default
+// holds even when the underlying bot transport is broken).
 func TestHandleMessage_CallAgreement_SendError(t *testing.T) {
 	repo := newMockLeadRepo()
 	aiClient := &mockAIQualifier{result: &QualificationResult{Score: 9}}

--- a/backend/internal/inbox/telegram_test.go
+++ b/backend/internal/inbox/telegram_test.go
@@ -825,12 +825,15 @@ func newTestBotWithErrorHTTP(repo LeadRepository, aiClient AIQualifier, ownerID 
 	}
 }
 
-// Pre-HITL this test exercised the bot.Send failure path. Under HITL
-// no proposer is wired here, so the booking branch is suppressed
-// entirely — the assertion that no outbound message lands in the repo
-// is the same invariant viewed from a different angle (secure default
-// holds even when the underlying bot transport is broken).
-func TestHandleMessage_CallAgreement_SendError(t *testing.T) {
+// TestHandleMessage_CallAgreement_BrokenBotTransport_DoesNotEscape pins
+// the secure-default invariant under a hostile bot transport: even
+// when bot.Send is doomed to fail (broken HTTP client), and no
+// PendingReplyProposer is wired, the booking-link branch must NOT
+// produce an outbound InboxMessage in the repository. Together with
+// TestHandleMessage_CallAgreement_NoProposerSuppressesBookingLink
+// this guards against any regression that re-introduces a direct
+// bot.Send fallback in the booking branch.
+func TestHandleMessage_CallAgreement_BrokenBotTransport_DoesNotEscape(t *testing.T) {
 	repo := newMockLeadRepo()
 	aiClient := &mockAIQualifier{result: &QualificationResult{Score: 9}}
 	ownerID := uuid.New()

--- a/backend/migrations/030_pending_replies.down.sql
+++ b/backend/migrations/030_pending_replies.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS pending_replies;

--- a/backend/migrations/030_pending_replies.up.sql
+++ b/backend/migrations/030_pending_replies.up.sql
@@ -1,0 +1,28 @@
+-- Human-in-the-loop approval queue for auto-drafted inbox replies.
+-- Each row is a customer-visible message that the inbox flow generated
+-- automatically (e.g. a booking link triggered by DetectCallAgreement
+-- in the Telegram bot) and parked here until an operator decides to
+-- approve and send it, or to reject it outright. Status transitions
+-- mirror the inbox.PendingReply aggregate state machine.
+CREATE TABLE pending_replies (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    lead_id    UUID NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+    channel    TEXT NOT NULL,
+    kind       TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    status     TEXT NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    decided_at TIMESTAMPTZ,
+    sent_at    TIMESTAMPTZ,
+    CONSTRAINT pending_replies_channel_check  CHECK (channel IN ('telegram', 'email')),
+    CONSTRAINT pending_replies_kind_check     CHECK (kind IN ('booking_link')),
+    CONSTRAINT pending_replies_status_check   CHECK (status IN ('pending', 'approved', 'sent', 'rejected')),
+    CONSTRAINT pending_replies_body_nonempty  CHECK (length(btrim(body)) > 0)
+);
+
+-- Operator inbox queue lookup: "everything pending for this user, newest first".
+CREATE INDEX idx_pending_replies_user_status ON pending_replies(user_id, status, created_at DESC);
+
+-- Per-lead drill-down: "show pending replies tied to this lead".
+CREATE INDEX idx_pending_replies_user_lead ON pending_replies(user_id, lead_id, created_at DESC);

--- a/docs/booking-hitl.md
+++ b/docs/booking-hitl.md
@@ -1,0 +1,109 @@
+# Booking-link HITL approval (P0-3)
+
+Status: shipped in v0.19.0 (Telegram booking-link path closed).
+
+## Why
+
+The inbox Telegram bot used to call `bot.Send` the moment `DetectCallAgreement` matched a phrase in an inbound message, attaching the user's calendar URL ("Отлично! Вот ссылка для выбора удобного времени для звонка: …"). The detector is a 30-marker substring match — false positives are easy ("ладно давайте попробуем что-то другое **вместо встречи**" matches "давайте встреч"). When it misfires, the bot has already leaked a booking URL to a lead who never asked for one, and the operator has no chance to intervene.
+
+This is a security and trust gate, not a UX feature: an unrequested booking link in a customer chat looks like spam and ends the conversation faster than no reply at all. Closing the gap was P0-3 in the post-v0.18.1 backlog.
+
+The fix is a human-in-the-loop approval queue. The bot no longer sends auto-drafted replies directly; it parks them in a `pending_replies` table and the operator approves or rejects through the lead detail UI. Only on approve does the dispatcher push the body to Telegram.
+
+## Domain model
+
+```
+pending_replies
+ ├─ id            UUID PRIMARY KEY
+ ├─ user_id       FK users(id)          -- tenant scope on every read
+ ├─ lead_id       FK leads(id)          -- which conversation it belongs to
+ ├─ channel       'telegram' | 'email'  -- check constraint
+ ├─ kind          'booking_link'        -- check constraint (extensible)
+ ├─ body          TEXT (CHECK length>0) -- the proposed message
+ ├─ status        'pending' | 'approved' | 'sent' | 'rejected'
+ ├─ created_at    TIMESTAMPTZ
+ ├─ decided_at    TIMESTAMPTZ?          -- set on Approve/Reject
+ └─ sent_at       TIMESTAMPTZ?          -- set after dispatcher succeeds
+```
+
+Aggregate root is `inbox.PendingReply` (`backend/internal/inbox/pending_reply.go`). The factory `NewPendingReply` enforces non-Nil user/lead ids, valid channel + kind, non-empty trimmed body. The status enum has a state machine encoded in `pendingReplyTransitions`:
+
+```
+pending  ──Approve──▶ approved ──MarkSent──▶ sent     (terminal)
+   │
+   └────Reject────▶ rejected                          (terminal)
+```
+
+`Approve(at)`, `Reject(at)` and `MarkSent(at)` are the only writes; each stamps the relevant timestamp atomically with the transition and returns `ErrPendingReplyInvalidTransition` if the move violates the state machine. There is no `TransitionTo` available to callers — domain methods own the timestamp, not the caller.
+
+## HTTP surface
+
+Three routes, all behind the same JWT middleware as the rest of `/api`:
+
+```
+GET  /api/leads/{id}/pending-replies     → operator queue for one lead
+POST /api/pending-replies/{id}/approve   → 204 on success
+POST /api/pending-replies/{id}/reject    → 204 on success
+```
+
+`GET` is lead-scoped: the handler gates on `leads.UseCase.OwnsLead` and answers a uniform 404 when the lead belongs to another tenant. `POST` approve / reject delegate to `inbox.PendingReplyUseCase`, which collapses missing-row and cross-tenant into the same `ErrPendingReplyNotFound` sentinel — the handler maps it to 404. Already-decided replies surface as 409.
+
+Response DTO (`PendingReplyResponse`) is intentionally separate from the domain entity so transport concerns (RFC3339 timestamps, JSON tags) stay out of the inbox package surface.
+
+## Wiring
+
+The composition root (`backend/cmd/server/main.go`) has a cycle: `TelegramBot` needs the usecase as `PendingReplyProposer`, the dispatcher needs `tgBot.Bot()`, the usecase needs the dispatcher. The cycle is broken with two runtime setters that mirror the existing `leadsUC.SetSender` pattern:
+
+```go
+pendingReplyUC := inbox.NewPendingReplyUseCase(pendingReplyRepo, nil)
+// ... register routes referencing pendingReplyUC ...
+
+if tgBot, err := inbox.NewTelegramBot(...); err == nil {
+    dispatcher := newTelegramReplyDispatcher(tgBot.Bot(), leadsRepo, inboxLeadAdapter)
+    pendingReplyUC.SetDispatcher(dispatcher)
+    tgBot.SetPendingProposer(pendingReplyUC)
+    go tgBot.Start(ctx)
+}
+```
+
+Ordering is intentional: `SetDispatcher` runs before `SetPendingProposer`, so any inbound message arriving in the gap finds at worst a logged "dispatcher not configured" error from `Approve`, never a nil-deref panic.
+
+`telegramReplyDispatcher` lives in `cmd/server/reply_dispatcher.go` because it is the cross-context bridge from inbox to Telegram. It exposes a single `Dispatch(ctx, pr) error` and is built from three narrow interfaces (`telegramBotSender`, `leadChatIDFetcher`, `inboxMessageWriter`) for testability. The dispatch order is **send-then-persist**: persist-first risks the UI showing a "sent" row for a message that never reached the customer, which is the worse failure mode.
+
+## Secure defaults
+
+The Telegram bot suppresses the booking-link branch entirely when no `PendingReplyProposer` is wired. There is no instant-send fallback — a misconfigured deploy is louder (booking links don't go out at all) than the alternative (booking links go out without operator review).
+
+Approve persists the entity as `approved` **before** calling the dispatcher. If dispatch fails (Telegram 5xx, network blip), the entity remains in `approved` so the operator can re-approve from the queue; the error propagates to the handler as 500. On dispatch success the usecase transitions to `sent` and persists again.
+
+`PendingReplyRepository` enforces tenant scope on every read method — `GetByID(ctx, userID, id)` returns nil if the row belongs to another user, `ListByLead(ctx, userID, leadID)` filters server-side. The handler relies on this; the usecase belt-and-braces it with its own `loadOwned` helper that collapses the two outcomes into `ErrPendingReplyNotFound`. An attacker who guesses pending-reply UUIDs cannot enumerate other tenants' drafts even if the handler is misrouted.
+
+## Frontend
+
+`frontend/src/components/leads/PendingReplySection.tsx` slots into the lead detail page between `ProspectSuggestionBanner` and `QualificationCard`. It fetches once on mount, renders only `pending` rows, exposes Approve / Reject buttons per row, and disables both buttons during an in-flight decision. Approve failures surface as a `role=alert` message and leave the row in place so the operator can retry.
+
+`onApproved` triggers a messages refetch on the page so the now-delivered body lands in the conversation thread without a manual reload, honouring the aggregated-view preference.
+
+## Future extensions
+
+Things deliberately not in this slice — feeds future issues:
+
+1. **Inbox-list badge** for leads with `pending` rows. Operator visibility today depends on the operator opening each lead detail page. Counts can be queried via `SELECT lead_id, COUNT(*) FROM pending_replies WHERE user_id = $1 AND status = 'pending' GROUP BY lead_id`.
+
+2. **Operator queue page** — a global "everything awaiting my approval" view, similar to the outbound queue. Useful when the operator triages many leads at once.
+
+3. **Email auto-replies**. The email poller currently only creates leads and saves inbound messages — it does not auto-draft. When AI-generated email auto-replies land, they should route through the same queue. The `channel` enum already includes `'email'`; only the dispatcher needs an email branch (Resend/SMTP).
+
+4. **Additional kinds**. `PendingReplyKind` is an open enum (extensible by adding constants + CHECK constraint values). Candidates: `qualification_followup`, `meeting_proposal`, `pricing_response`.
+
+5. **Bulk approve / reject** for power operators. Not strictly necessary at current volume but easy to add over the existing endpoints.
+
+6. **Edit before approve**. Today the operator can only approve the body as-drafted or reject it. Inline editing would require a `PATCH /api/pending-replies/{id}` endpoint that re-validates through the domain factory.
+
+7. **Operator attribution** (`decided_by` column). The audit-log feature already captures per-request `CallMeta`; adding `decided_by uuid REFERENCES users(id)` would surface "who approved this" in the UI. Low effort, deferred to keep the slice focused on the security gate.
+
+## Migration
+
+`backend/migrations/030_pending_replies.up.sql` creates the table and two indexes (`user_id, status, created_at DESC` for the operator queue; `user_id, lead_id, created_at DESC` for the per-lead drill-down). The down migration drops the table.
+
+Verified up → down → up cycle locally before merge.

--- a/frontend/src/app/(dashboard)/inbox/[leadId]/page.tsx
+++ b/frontend/src/app/(dashboard)/inbox/[leadId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, Clock, Archive, ArrowRightLeft, Send } from "lucide-react";
 import { ProspectSuggestionBanner } from "@/components/leads/ProspectSuggestionBanner";
+import { PendingReplySection } from "@/components/leads/PendingReplySection";
 import { IdentityBadge } from "@/components/leads/IdentityBadge";
 import { api, Lead, Message, Qualification, Draft } from "@/lib/api";
 import { getTimeAgo, getInitials } from "@/components/inbox/helpers";
@@ -113,6 +114,12 @@ export default function LeadDetailPage() {
         </section>
 
         <ProspectSuggestionBanner leadId={leadId} onChanged={() => { api.getLead(leadId).then(setLead).catch(() => {}); }} />
+        <PendingReplySection
+          leadId={leadId}
+          onApproved={() => {
+            api.getMessages(leadId, { aggregated: aggregated ?? true }).then(setMessages).catch(() => {});
+          }}
+        />
         <QualificationCard qualification={qualification} loading={qualLoading} />
 
         <section className="max-w-4xl">

--- a/frontend/src/components/leads/PendingReplySection.test.tsx
+++ b/frontend/src/components/leads/PendingReplySection.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PendingReplySection } from "./PendingReplySection";
+import { api, type PendingReply } from "@/lib/api";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      getPendingReplies: vi.fn(),
+      approvePendingReply: vi.fn(),
+      rejectPendingReply: vi.fn(),
+    },
+  };
+});
+
+const reply = (over: Partial<PendingReply> = {}): PendingReply => ({
+  id: "pr-1",
+  lead_id: "lead-1",
+  channel: "telegram",
+  kind: "booking_link",
+  body: "Отлично! Вот ссылка: https://cal.com/x",
+  status: "pending",
+  created_at: "2026-05-17T18:00:00Z",
+  ...over,
+});
+
+describe("PendingReplySection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing while the fetch is in-flight", () => {
+    vi.mocked(api.getPendingReplies).mockReturnValue(new Promise(() => {}));
+    const { container } = render(<PendingReplySection leadId="lead-1" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when there are no pending rows", async () => {
+    vi.mocked(api.getPendingReplies).mockResolvedValue([]);
+    const { container } = render(<PendingReplySection leadId="lead-1" />);
+    await waitFor(() => expect(api.getPendingReplies).toHaveBeenCalledWith("lead-1"));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when every reply is already decided (sent/rejected/approved)", async () => {
+    vi.mocked(api.getPendingReplies).mockResolvedValue([
+      reply({ id: "a", status: "sent" }),
+      reply({ id: "b", status: "rejected" }),
+      reply({ id: "c", status: "approved" }),
+    ]);
+    const { container } = render(<PendingReplySection leadId="lead-1" />);
+    await waitFor(() => expect(api.getPendingReplies).toHaveBeenCalled());
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders pending body with kind + channel labels", async () => {
+    vi.mocked(api.getPendingReplies).mockResolvedValue([reply()]);
+    render(<PendingReplySection leadId="lead-1" />);
+
+    expect(await screen.findByText(/Отлично! Вот ссылка/)).toBeInTheDocument();
+    expect(screen.getByText(/Ссылка на встречу/i)).toBeInTheDocument();
+    expect(screen.getByText(/Telegram/i)).toBeInTheDocument();
+  });
+
+  it("approves on click, removes the row, and calls onApproved", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.getPendingReplies).mockResolvedValue([reply()]);
+    vi.mocked(api.approvePendingReply).mockResolvedValue(undefined);
+    const onApproved = vi.fn();
+    render(<PendingReplySection leadId="lead-1" onApproved={onApproved} />);
+
+    const btn = await screen.findByRole("button", { name: /Одобрить и отправить/i });
+    await user.click(btn);
+
+    await waitFor(() => expect(api.approvePendingReply).toHaveBeenCalledWith("pr-1"));
+    await waitFor(() => expect(screen.queryByText(/Отлично! Вот ссылка/)).not.toBeInTheDocument());
+    expect(onApproved).toHaveBeenCalledOnce();
+  });
+
+  it("rejects on click and removes the row without calling onApproved", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.getPendingReplies).mockResolvedValue([reply()]);
+    vi.mocked(api.rejectPendingReply).mockResolvedValue(undefined);
+    const onApproved = vi.fn();
+    render(<PendingReplySection leadId="lead-1" onApproved={onApproved} />);
+
+    const btn = await screen.findByRole("button", { name: /Отклонить/i });
+    await user.click(btn);
+
+    await waitFor(() => expect(api.rejectPendingReply).toHaveBeenCalledWith("pr-1"));
+    await waitFor(() => expect(screen.queryByText(/Отлично! Вот ссылка/)).not.toBeInTheDocument());
+    expect(onApproved).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error message when approve fails and keeps the row", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.getPendingReplies).mockResolvedValue([reply()]);
+    vi.mocked(api.approvePendingReply).mockRejectedValue(new Error("boom"));
+    render(<PendingReplySection leadId="lead-1" />);
+
+    const btn = await screen.findByRole("button", { name: /Одобрить и отправить/i });
+    await user.click(btn);
+
+    await waitFor(() => expect(api.approvePendingReply).toHaveBeenCalled());
+    expect(await screen.findByRole("alert")).toHaveTextContent(/не удалось одобрить/i);
+    // Row still present after failure so the operator can retry.
+    expect(screen.getByText(/Отлично! Вот ссылка/)).toBeInTheDocument();
+  });
+
+  it("disables both buttons while a decision is in flight", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.getPendingReplies).mockResolvedValue([reply()]);
+    let resolve: (v: void) => void = () => {};
+    vi.mocked(api.approvePendingReply).mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    render(<PendingReplySection leadId="lead-1" />);
+
+    const approveBtn = await screen.findByRole("button", { name: /Одобрить и отправить/i });
+    const rejectBtn = screen.getByRole("button", { name: /Отклонить/i });
+
+    await user.click(approveBtn);
+    expect(approveBtn).toBeDisabled();
+    expect(rejectBtn).toBeDisabled();
+
+    resolve();
+  });
+
+  it("renders nothing when the fetch fails", async () => {
+    vi.mocked(api.getPendingReplies).mockRejectedValue(new Error("boom"));
+    const { container } = render(<PendingReplySection leadId="lead-1" />);
+    await waitFor(() => expect(api.getPendingReplies).toHaveBeenCalled());
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/components/leads/PendingReplySection.tsx
+++ b/frontend/src/components/leads/PendingReplySection.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ShieldCheck, X, AlertCircle } from "lucide-react";
+import { api, PendingReply } from "@/lib/api";
+
+interface Props {
+  leadId: string;
+  /** Called after Approve so the parent can refresh messages (the
+   *  approved body lands in the conversation thread). */
+  onApproved?: () => void;
+}
+
+/**
+ * PendingReplySection surfaces auto-drafted replies parked by the
+ * inbox HITL gate. Today the only source is the Telegram bot's
+ * booking-link branch, which used to fire bot.Send the moment
+ * DetectCallAgreement matched a phrase; now it enqueues a draft here
+ * for the operator to approve before it reaches the customer.
+ *
+ * Only pending rows render — approved/sent/rejected drafts are
+ * already either visible in the conversation thread (sent) or
+ * terminated (rejected), so re-displaying them adds noise without
+ * value.
+ */
+export function PendingReplySection({ leadId, onApproved }: Props) {
+  const [replies, setReplies] = useState<PendingReply[] | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getPendingReplies(leadId)
+      .then((items) => {
+        if (!cancelled) setReplies(items);
+      })
+      .catch(() => {
+        if (!cancelled) setReplies([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [leadId]);
+
+  if (!replies) return null;
+  const pending = replies.filter((r) => r.status === "pending");
+  if (pending.length === 0) return null;
+
+  async function handleApprove(id: string) {
+    setBusyId(id);
+    setError(null);
+    try {
+      await api.approvePendingReply(id);
+      setReplies((prev) => prev?.filter((r) => r.id !== id) ?? []);
+      onApproved?.();
+    } catch {
+      setError("Не удалось одобрить — попробуйте ещё раз");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleReject(id: string) {
+    setBusyId(id);
+    setError(null);
+    try {
+      await api.rejectPendingReply(id);
+      setReplies((prev) => prev?.filter((r) => r.id !== id) ?? []);
+    } catch {
+      setError("Не удалось отклонить — попробуйте ещё раз");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <section
+      className="mb-8 rounded-xl border border-[#f5b73c]/40 bg-[#fff8e1] p-5 shadow-sm"
+      aria-label="Сообщения, ожидающие подтверждения"
+    >
+      <header className="mb-4 flex items-center gap-2">
+        <ShieldCheck className="size-4 text-[#a06b00]" />
+        <h3 className="text-sm font-bold text-[#0d1c2e]">
+          Ожидают подтверждения
+        </h3>
+        <span className="ml-auto rounded-full bg-white px-2 py-0.5 text-[0.65rem] font-semibold text-[#434655]">
+          {pending.length}
+        </span>
+      </header>
+
+      {error && (
+        <div
+          role="alert"
+          className="mb-3 flex items-center gap-2 rounded-lg bg-[#fde2e4] px-3 py-2 text-xs text-[#a00025]"
+        >
+          <AlertCircle className="size-3.5" />
+          {error}
+        </div>
+      )}
+
+      <ul className="space-y-3">
+        {pending.map((r) => {
+          const isBusy = busyId === r.id;
+          return (
+            <li
+              key={r.id}
+              className="rounded-lg border border-[#f5b73c]/30 bg-white p-4"
+            >
+              <p className="mb-3 whitespace-pre-wrap text-sm text-[#0d1c2e]">
+                {r.body}
+              </p>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-[0.65rem] font-medium uppercase tracking-wide text-[#737686]">
+                  {kindLabel(r.kind)} · {channelLabel(r.channel)}
+                </span>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleReject(r.id)}
+                    disabled={isBusy}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-[#c3c6d7]/50 bg-white px-3 py-1.5 text-xs font-semibold text-[#434655] transition-colors hover:bg-[#f7f9fd] disabled:opacity-50"
+                  >
+                    <X className="size-3.5" />
+                    Отклонить
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleApprove(r.id)}
+                    disabled={isBusy}
+                    className="inline-flex items-center gap-1.5 rounded-lg bg-[#0d7a2c] px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[#0a6324] disabled:opacity-50"
+                  >
+                    <ShieldCheck className="size-3.5" />
+                    Одобрить и отправить
+                  </button>
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+function kindLabel(kind: PendingReply["kind"]): string {
+  switch (kind) {
+    case "booking_link":
+      return "Ссылка на встречу";
+    default:
+      return kind;
+  }
+}
+
+function channelLabel(channel: PendingReply["channel"]): string {
+  switch (channel) {
+    case "telegram":
+      return "Telegram";
+    case "email":
+      return "Email";
+    default:
+      return channel;
+  }
+}

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -98,6 +98,28 @@ describe("api module", () => {
 
       await expect(api.getLeads()).rejects.toThrow("API error: 500 Internal Server Error");
     });
+
+    it("returns undefined on 204 No Content without calling json()", async () => {
+      // A real fetch Response with empty body throws SyntaxError when
+      // .json() is called. The mock pins the same shape by rejecting
+      // json() with the same error the browser would surface — any
+      // implementation that unconditionally invokes res.json() on a
+      // 204 fails this test, matching the real-world bug operators
+      // would hit on approve/reject (HTTP 204) in production.
+      const jsonMock = vi.fn().mockRejectedValue(new SyntaxError("Unexpected end of JSON input"));
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        statusText: "No Content",
+        headers: new Headers(),
+        json: jsonMock,
+      } as unknown as Response);
+
+      const result = await api.approvePendingReply("pr-1");
+
+      expect(result).toBeUndefined();
+      expect(jsonMock).not.toHaveBeenCalled();
+    });
   });
 
   // ── 401 refresh token flow ───────────────────────────────────────

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -333,5 +333,25 @@ describe("api module", () => {
       expect(url).toBe("http://localhost:8080/api/leads/lead-2/qualify");
       expect(opts.method).toBe("POST");
     });
+
+    it("getPendingReplies → GET /api/leads/:id/pending-replies", async () => {
+      await api.getPendingReplies("lead-7");
+      expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:8080/api/leads/lead-7/pending-replies");
+      expect(fetchMock.mock.calls[0][1].method).toBeUndefined();
+    });
+
+    it("approvePendingReply → POST /api/pending-replies/:id/approve", async () => {
+      await api.approvePendingReply("pr-1");
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("http://localhost:8080/api/pending-replies/pr-1/approve");
+      expect(opts.method).toBe("POST");
+    });
+
+    it("rejectPendingReply → POST /api/pending-replies/:id/reject", async () => {
+      await api.rejectPendingReply("pr-2");
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("http://localhost:8080/api/pending-replies/pr-2/reject");
+      expect(opts.method).toBe("POST");
+    });
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -169,6 +169,21 @@ export const api = {
   regenerateDraft: (leadId: string) =>
     apiFetch<Draft>(`/api/leads/${leadId}/draft/regen`, { method: "POST" }),
 
+  // Pending replies (HITL approval queue)
+  //
+  // The inbox flow parks auto-drafted replies that would otherwise
+  // reach the customer (currently the booking-link branch in the
+  // Telegram bot) until an operator approves them. List per lead,
+  // approve to dispatch and mark sent, reject to terminate the
+  // draft. Approve / reject return 204; status flips are visible by
+  // re-listing.
+  getPendingReplies: (leadId: string) =>
+    apiFetch<PendingReply[]>(`/api/leads/${leadId}/pending-replies`),
+  approvePendingReply: (id: string) =>
+    apiFetch<void>(`/api/pending-replies/${id}/approve`, { method: "POST" }),
+  rejectPendingReply: (id: string) =>
+    apiFetch<void>(`/api/pending-replies/${id}/reject`, { method: "POST" }),
+
   // Reminders
   getReminders: () => apiFetch<Reminder[]>("/api/reminders"),
   snoozeReminder: (id: string) =>
@@ -411,6 +426,21 @@ export interface Draft {
   lead_id: string;
   body: string;
   created_at: string;
+}
+
+export type PendingReplyStatus = "pending" | "approved" | "sent" | "rejected";
+export type PendingReplyKind = "booking_link";
+
+export interface PendingReply {
+  id: string;
+  lead_id: string;
+  channel: "telegram" | "email";
+  kind: PendingReplyKind;
+  body: string;
+  status: PendingReplyStatus;
+  created_at: string;
+  decided_at?: string;
+  sent_at?: string;
 }
 
 export interface Reminder {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -36,7 +36,10 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
               ...options?.headers,
             },
           });
-          if (retryRes.ok) return retryRes.json();
+          if (retryRes.ok) {
+            if (retryRes.status === 204) return undefined as T;
+            return retryRes.json();
+          }
         }
       } catch {
         // refresh failed
@@ -51,6 +54,11 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
     throw new Error(`API error: ${res.status} ${res.statusText}`);
   }
 
+  // 204 No Content has an empty body — calling .json() throws
+  // SyntaxError. The HITL approve/reject endpoints answer 204 on
+  // success; callers expect undefined (the generic T is typically
+  // void at the call site).
+  if (res.status === 204) return undefined as T;
   return res.json();
 }
 


### PR DESCRIPTION
## Summary

Closes the P0-3 security gap: the Telegram inbox bot used to call `bot.Send` the moment `DetectCallAgreement` matched a phrase in an inbound message, leaking a calendar URL to leads who never asked. The detector is a 30-marker substring match — false positives are easy ("**вместо встречи**" matches "давайте встреч"). Misfires reached the customer with zero operator review.

This PR routes the booking-link branch through a human-in-the-loop approval queue. The bot now parks drafts in `pending_replies`; operator approves or rejects from the lead detail page, and only on approve does the dispatcher push the body to Telegram.

**Scope**: Telegram booking-link path (the only current gap). Email auto-replies do not exist yet but the `channel` enum already allows `email` for the future extension. Inbox-list badge for pending counts is left as a follow-up — it's a UX nice-to-have, not part of the security gate.

## What landed

**Backend**
- `inbox.PendingReply` aggregate with factory, status enum, state machine (`pending → approved → sent` or `pending → rejected`), 9 domain sentinels.
- `PendingReplyRepository` (pgx) with **optimistic-lock Update** (`WHERE ... AND status = $expected`) to defend against dual-approve races; every read scoped by `user_id`.
- `PendingReplyUseCase` orchestrating Propose / Approve / Reject / ListByLead with `loadOwned` collapsing missing-row and cross-tenant into uniform `ErrPendingReplyNotFound`.
- HTTP surface: `GET /api/leads/{id}/pending-replies`, `POST /api/pending-replies/{id}/approve|reject`. 404 / 409 / 500 mapped from sentinels.
- `telegramReplyDispatcher` adapter in `cmd/server/` with send-then-persist ordering. Compile-time port check.
- Telegram bot: instant `bot.Send` in the booking branch replaced with `PendingReplyProposer.Propose`. Secure default — when no proposer is wired the branch is suppressed entirely, never falls back to instant send. Startup warn logs the misconfig case.
- Migration 030 (`pending_replies` table with CHECK constraints + two indexes).

**Frontend**
- `PendingReplySection` component in lead detail (Approve / Reject buttons, disabled during in-flight decision, error surfaces via `role=alert`).
- `apiFetch` short-circuits on HTTP 204 to avoid `SyntaxError` from `res.json()` on empty body.
- 3 new API contract tests + 9 component vitest cases.

**Docs**
- `docs/booking-hitl.md` — design rationale, state machine, secure defaults, future-extensions list.

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go test ./...` — all pass
- [x] `cd backend && go test -tags=integration ./internal/inbox/... ./internal/audit/... ./internal/leads/...` — all pass (requires local Postgres)
- [x] `cd frontend && npm test -- --run` — 32 files / 356 tests pass
- [x] Migration up → down → up cycle verified locally
- [x] Two-round code review via `superpowers:code-reviewer`: round 1 caught 2 build/runtime blockers (now fixed); round 2 scored **TDD 9 / DDD 10 / CA 9 / Enterprise 9** — all ≥9 gate satisfied
- [ ] Manual smoke against running stack: send "давайте созвон" to bot → verify no booking link sent → verify row appears in `GET /api/leads/{id}/pending-replies` → approve via UI → verify booking message delivered to chat

## Notable design decisions

- **`PendingReplyResponse` (not `DTO` suffix)** — matches existing Floq convention (`LeadResponse`, `LeadsToResponse`).
- **Send-then-persist** in dispatcher — accepts history loss as smaller failure mode than UI showing "sent" for messages that never reached the customer.
- **`SetDispatcher` runtime setter** on usecase — breaks the bot → usecase → dispatcher → bot wiring cycle following the existing `leadsUC.SetSender` pattern.
- **Optimistic lock via `expectedStatus` parameter** — chosen over `SELECT FOR UPDATE` to keep the dispatcher's external Telegram call outside any DB transaction.

## Out of scope (follow-ups)

- Inbox-list badge for leads with pending replies
- Operator-queue page (everything-awaiting-approval view)
- Email auto-reply dispatch branch
- Idempotency on `Propose` (dedup if `DetectCallAgreement` fires twice on bot reconnect)
- `decided_by` column for operator attribution