### PR TITLE
ci(backend): widen Go build gate to all packages + vet integration tag (closes #44)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,20 @@ jobs:
       - name: Vet
         run: go vet ./...
 
-      - name: Build
-        run: go build -o /dev/null ./cmd/server
+      # Build every package, not just cmd/server. Catches downstream
+      # build breaks when a signature change to a port leaves consumer
+      # packages compiling individually but the binary unbuildable.
+      # See issue #44 for the P0-3 incident that motivated widening
+      # the scope.
+      - name: Build (all packages)
+        run: go build ./...
+
+      # Vet integration-tagged files too. `go vet ./...` skips files
+      # behind build tags by default, so an outdated integration test
+      # signature can slip through until somebody runs the tagged
+      # suite locally. This catches it at the same gate as the rest.
+      - name: Vet (integration tag)
+        run: go vet -tags=integration ./...
 
       - name: Test
         run: go test -race -count=1 ./...


### PR DESCRIPTION
## Summary

Closes #44.

- `go build -o /dev/null ./cmd/server` → `go build ./...` so every package links, not just the main binary.
- New step: `go vet -tags=integration ./...` — default vet skips files behind build tags, so an outdated integration-test signature otherwise slips through until somebody runs the tagged suite locally.

## Test plan

- [x] `cd backend && go build ./...` — clean locally
- [x] `cd backend && go vet -tags=integration ./...` — clean locally
- [ ] CI green after push