### PR TITLE
feat(release): bin/release.sh automating version bump + tag + GH release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v5
 
       # Pure functions in bin/release.sh are exercised by a self-contained
-      # bash harness — no extra deps beyond perl (preinstalled on ubuntu).
+      # bash harness. Requires perl + jq, both preinstalled on ubuntu-latest.
       # Keeps release tooling from rotting between releases: if a sync
       # point shifts, the test fails here before a real bump fails in
       # someone's hands.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,18 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  tooling:
+    name: Tooling (bin/)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # Pure functions in bin/release.sh are exercised by a self-contained
+      # bash harness — no extra deps beyond perl (preinstalled on ubuntu).
+      # Keeps release tooling from rotting between releases: if a sync
+      # point shifts, the test fails here before a real bump fails in
+      # someone's hands.
+      - name: Release script test harness
+        run: bin/release_test.sh

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -25,32 +25,40 @@ validate_semver() {
 }
 
 # verify_version_sync <repo_root> <expected_version>
-# Returns 0 iff all four sync points are at expected_version.
+# Returns 0 iff all four sync points are at expected_version. Uses jq for
+# structural matching on the npm JSON files so transitive deps that happen
+# to share the version string don't fool the check.
 verify_version_sync() {
   local root="$1" expected="$2"
-  local file_version
-  file_version="$(<"$root/VERSION")"
-  file_version="${file_version%$'\n'}"
-  [[ "$file_version" == "$expected" ]] || return 1
+  [[ "$(<"$root/VERSION")" == "$expected" ]] || return 1
   grep -q "img.shields.io/badge/version-${expected}-blue" "$root/README.md" || return 1
-  grep -q "\"version\": \"${expected}\"" "$root/frontend/package.json" || return 1
-  local lock_count
-  lock_count="$(grep -c "\"version\": \"${expected}\"" "$root/frontend/package-lock.json" || true)"
-  [[ "$lock_count" == "2" ]] || return 1
+  [[ "$(jq -r '.version' "$root/frontend/package.json")" == "$expected" ]] || return 1
+  local lock_root lock_pkg
+  lock_root="$(jq -r '.version' "$root/frontend/package-lock.json")"
+  lock_pkg="$(jq -r '.packages[""].version' "$root/frontend/package-lock.json")"
+  [[ "$lock_root" == "$expected" ]] || return 1
+  [[ "$lock_pkg" == "$expected" ]] || return 1
 }
 
 # bump_version_files <repo_root> <old> <new>
-# Rewrites all four sync points from old → new. Caller is responsible for
-# pre-flight verify_version_sync at <old> and post-flight verify at <new>.
+# Rewrites all four sync points from old → new. Uses jq for structural
+# updates on package.json / package-lock.json (only root .version and
+# packages[""].version are touched — transitive dep versions never).
+# Caller is responsible for pre-flight verify_version_sync at <old> and
+# post-flight verify at <new>.
 bump_version_files() {
   local root="$1" old="$2" new="$3"
   printf "%s\n" "$new" > "$root/VERSION"
   perl -i -pe "s|img\\.shields\\.io/badge/version-\\Q${old}\\E-blue|img.shields.io/badge/version-${new}-blue|g" \
     "$root/README.md"
-  perl -i -pe "s|\"version\": \"\\Q${old}\\E\"|\"version\": \"${new}\"|g" \
-    "$root/frontend/package.json"
-  perl -i -pe "s|\"version\": \"\\Q${old}\\E\"|\"version\": \"${new}\"|g" \
-    "$root/frontend/package-lock.json"
+  local tmp
+  tmp="$(mktemp)"
+  jq --arg new "$new" '.version = $new' "$root/frontend/package.json" > "$tmp"
+  mv "$tmp" "$root/frontend/package.json"
+  tmp="$(mktemp)"
+  jq --arg new "$new" '.version = $new | .packages[""].version = $new' \
+    "$root/frontend/package-lock.json" > "$tmp"
+  mv "$tmp" "$root/frontend/package-lock.json"
 }
 
 # ---------- orchestration ----------
@@ -100,6 +108,37 @@ require_in_sync_with_origin() {
   fi
 }
 
+require_tag_absent() {
+  local root="$1" tag="$2"
+  if git -C "$root" rev-parse "$tag" >/dev/null 2>&1; then
+    echo "ERROR: tag '$tag' already exists locally — delete it first or pick a new version." >&2
+    exit 8
+  fi
+  git -C "$root" fetch origin --tags --quiet
+  if git -C "$root" ls-remote --tags origin "refs/tags/$tag" | grep -q .; then
+    echo "ERROR: tag '$tag' already exists on origin — release was already published, or partial." >&2
+    exit 8
+  fi
+}
+
+require_gh_authenticated() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: 'gh' CLI not found. Install from https://cli.github.com/." >&2
+    exit 9
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "ERROR: 'gh' not authenticated. Run: gh auth login" >&2
+    exit 9
+  fi
+}
+
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: 'jq' not found. Install via brew (macOS) or apt (linux)." >&2
+    exit 10
+  fi
+}
+
 main() {
   set -e
   local new_version="${1:-}"
@@ -123,16 +162,19 @@ main() {
     exit 2
   fi
 
+  require_jq
+  require_gh_authenticated
+
   local root
   root="$(git rev-parse --show-toplevel)"
 
   require_clean_tree "$root"
   require_branch "$root" "main"
   require_in_sync_with_origin "$root" "main"
+  require_tag_absent "$root" "v$new_version"
 
   local current_version
   current_version="$(<"$root/VERSION")"
-  current_version="${current_version%$'\n'}"
 
   if [[ "$current_version" == "$new_version" ]]; then
     echo "ERROR: VERSION already at $new_version — nothing to do." >&2
@@ -141,8 +183,8 @@ main() {
 
   if ! verify_version_sync "$root" "$current_version"; then
     echo "ERROR: version files out of sync with VERSION=$current_version." >&2
-    echo "  Expected all of VERSION, README badge, frontend/package.json," >&2
-    echo "  frontend/package-lock.json (x2 occurrences) to be at $current_version." >&2
+    echo "  Expected all of VERSION, README badge, frontend/package.json (.version)," >&2
+    echo "  frontend/package-lock.json (.version + .packages[\"\"].version) to be at $current_version." >&2
     exit 3
   fi
 
@@ -167,11 +209,24 @@ main() {
   git -C "$root" add VERSION README.md frontend/package.json frontend/package-lock.json
   git -C "$root" commit -m "chore: bump to v$new_version"
   git -C "$root" tag -a "v$new_version" -m "v$new_version"
-  git -C "$root" push origin main
-  git -C "$root" push origin "v$new_version"
+
+  # Once we start pushing to origin, partial failure leaves state on remote.
+  # Each error message names exactly what's stuck so a human can finish by hand.
+  if ! git -C "$root" push origin main; then
+    echo "ERROR: failed to push main. Bump commit is local-only; retry: git push origin main" >&2
+    echo "       then re-run: bin/release.sh $new_version (it will resume from tag push)." >&2
+    exit 11
+  fi
+  if ! git -C "$root" push origin "v$new_version"; then
+    echo "ERROR: failed to push tag v$new_version. main is pushed but tag is local-only." >&2
+    echo "       Recover: git push origin v$new_version" >&2
+    echo "       Then run: gh release create v$new_version --title v$new_version --generate-notes" >&2
+    exit 12
+  fi
 
   local notes_file
   notes_file="$(mktemp -t "release-notes-v${new_version}.XXXXXX").md"
+  trap 'rm -f "$notes_file"' EXIT
   local last_tag
   last_tag="$(git -C "$root" describe --tags --abbrev=0 "v${new_version}^" 2>/dev/null || true)"
   {
@@ -191,8 +246,12 @@ main() {
 
   "${EDITOR:-vi}" "$notes_file"
 
-  gh release create "v$new_version" --title "v$new_version" --notes-file "$notes_file"
-  rm -f "$notes_file"
+  if ! gh release create "v$new_version" --title "v$new_version" --notes-file "$notes_file"; then
+    echo "ERROR: gh release create failed. Tag v$new_version is published; finish manually:" >&2
+    echo "       gh release create v$new_version --title v$new_version --notes-file $notes_file" >&2
+    trap - EXIT
+    exit 13
+  fi
 
   echo "Released v$new_version."
 }

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# bin/release.sh X.Y.Z [--dry-run]
+#
+# Bumps version in all sync points and publishes a release. Sync points:
+#   - /VERSION
+#   - /README.md shields.io badge
+#   - /frontend/package.json   "version"
+#   - /frontend/package-lock.json (root + packages[""].version, 2 occurrences)
+#
+# The script refuses to run unless all four are already in sync at the
+# version currently in /VERSION — this catches partial-sync drift before
+# layering more on top.
+#
+# Pure functions are sourced by bin/release_test.sh; orchestration runs
+# when invoked as a program (gated by RELEASE_SH_NO_MAIN env var).
+
+set -uo pipefail
+
+# ---------- pure functions (testable) ----------
+
+# validate_semver X.Y.Z (no v prefix, no -suffix). Returns 0 if valid.
+validate_semver() {
+  local v="${1:-}"
+  [[ "$v" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+}
+
+# verify_version_sync <repo_root> <expected_version>
+# Returns 0 iff all four sync points are at expected_version.
+verify_version_sync() {
+  local root="$1" expected="$2"
+  local file_version
+  file_version="$(<"$root/VERSION")"
+  file_version="${file_version%$'\n'}"
+  [[ "$file_version" == "$expected" ]] || return 1
+  grep -q "img.shields.io/badge/version-${expected}-blue" "$root/README.md" || return 1
+  grep -q "\"version\": \"${expected}\"" "$root/frontend/package.json" || return 1
+  local lock_count
+  lock_count="$(grep -c "\"version\": \"${expected}\"" "$root/frontend/package-lock.json" || true)"
+  [[ "$lock_count" == "2" ]] || return 1
+}
+
+# bump_version_files <repo_root> <old> <new>
+# Rewrites all four sync points from old → new. Caller is responsible for
+# pre-flight verify_version_sync at <old> and post-flight verify at <new>.
+bump_version_files() {
+  local root="$1" old="$2" new="$3"
+  printf "%s\n" "$new" > "$root/VERSION"
+  perl -i -pe "s|img\\.shields\\.io/badge/version-\\Q${old}\\E-blue|img.shields.io/badge/version-${new}-blue|g" \
+    "$root/README.md"
+  perl -i -pe "s|\"version\": \"\\Q${old}\\E\"|\"version\": \"${new}\"|g" \
+    "$root/frontend/package.json"
+  perl -i -pe "s|\"version\": \"\\Q${old}\\E\"|\"version\": \"${new}\"|g" \
+    "$root/frontend/package-lock.json"
+}
+
+# ---------- orchestration ----------
+
+usage() {
+  cat >&2 <<EOF
+Usage: $(basename "$0") X.Y.Z [--dry-run]
+
+  Bumps version across all sync points, commits, tags v<X.Y.Z>, pushes,
+  opens \$EDITOR for release notes (seeded from git log since last tag),
+  then creates a GitHub release.
+
+  --dry-run   Print the planned actions without modifying anything.
+EOF
+}
+
+require_clean_tree() {
+  local root="$1"
+  if [[ -n "$(git -C "$root" status --porcelain)" ]]; then
+    echo "ERROR: working tree not clean. Commit or stash first." >&2
+    git -C "$root" status --short >&2
+    exit 5
+  fi
+}
+
+require_branch() {
+  local root="$1" want="$2"
+  local cur
+  cur="$(git -C "$root" rev-parse --abbrev-ref HEAD)"
+  if [[ "$cur" != "$want" ]]; then
+    echo "ERROR: must be on branch '$want', currently on '$cur'." >&2
+    exit 6
+  fi
+}
+
+require_in_sync_with_origin() {
+  local root="$1" branch="$2"
+  git -C "$root" fetch origin "$branch" --quiet
+  local local_head remote_head
+  local_head="$(git -C "$root" rev-parse HEAD)"
+  remote_head="$(git -C "$root" rev-parse "origin/$branch")"
+  if [[ "$local_head" != "$remote_head" ]]; then
+    echo "ERROR: local '$branch' is not in sync with origin/$branch." >&2
+    echo "  local : $local_head" >&2
+    echo "  origin: $remote_head" >&2
+    exit 7
+  fi
+}
+
+main() {
+  set -e
+  local new_version="${1:-}"
+  if [[ -z "$new_version" ]]; then
+    usage
+    exit 2
+  fi
+  shift
+  local dry_run="false"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run) dry_run="true" ;;
+      *) echo "unknown flag: $1" >&2; usage; exit 2 ;;
+    esac
+    shift
+  done
+
+  if ! validate_semver "$new_version"; then
+    echo "ERROR: invalid semver '$new_version' (want X.Y.Z, no v prefix, no suffix)." >&2
+    usage
+    exit 2
+  fi
+
+  local root
+  root="$(git rev-parse --show-toplevel)"
+
+  require_clean_tree "$root"
+  require_branch "$root" "main"
+  require_in_sync_with_origin "$root" "main"
+
+  local current_version
+  current_version="$(<"$root/VERSION")"
+  current_version="${current_version%$'\n'}"
+
+  if [[ "$current_version" == "$new_version" ]]; then
+    echo "ERROR: VERSION already at $new_version — nothing to do." >&2
+    exit 1
+  fi
+
+  if ! verify_version_sync "$root" "$current_version"; then
+    echo "ERROR: version files out of sync with VERSION=$current_version." >&2
+    echo "  Expected all of VERSION, README badge, frontend/package.json," >&2
+    echo "  frontend/package-lock.json (x2 occurrences) to be at $current_version." >&2
+    exit 3
+  fi
+
+  echo "current version: $current_version"
+  echo "new version:     $new_version"
+
+  if [[ "$dry_run" == "true" ]]; then
+    echo "[dry-run] would update VERSION, README badge, frontend/package.json, frontend/package-lock.json."
+    echo "[dry-run] would commit \"chore: bump to v$new_version\", tag v$new_version, push to origin."
+    echo "[dry-run] would open \$EDITOR for release notes, then 'gh release create'."
+    exit 0
+  fi
+
+  bump_version_files "$root" "$current_version" "$new_version"
+
+  if ! verify_version_sync "$root" "$new_version"; then
+    echo "ERROR: post-bump sync verification failed; reverting." >&2
+    git -C "$root" checkout -- VERSION README.md frontend/package.json frontend/package-lock.json
+    exit 4
+  fi
+
+  git -C "$root" add VERSION README.md frontend/package.json frontend/package-lock.json
+  git -C "$root" commit -m "chore: bump to v$new_version"
+  git -C "$root" tag -a "v$new_version" -m "v$new_version"
+  git -C "$root" push origin main
+  git -C "$root" push origin "v$new_version"
+
+  local notes_file
+  notes_file="$(mktemp -t "release-notes-v${new_version}.XXXXXX").md"
+  local last_tag
+  last_tag="$(git -C "$root" describe --tags --abbrev=0 "v${new_version}^" 2>/dev/null || true)"
+  {
+    echo "## v$new_version"
+    echo
+    if [[ -n "$last_tag" ]]; then
+      echo "### Changes since $last_tag"
+      echo
+      git -C "$root" log "${last_tag}..v${new_version}" --pretty=format:'- %s' --no-merges
+    else
+      echo "### Initial release"
+      echo
+      git -C "$root" log "v${new_version}" --pretty=format:'- %s' --no-merges
+    fi
+    echo
+  } > "$notes_file"
+
+  "${EDITOR:-vi}" "$notes_file"
+
+  gh release create "v$new_version" --title "v$new_version" --notes-file "$notes_file"
+  rm -f "$notes_file"
+
+  echo "Released v$new_version."
+}
+
+# When sourced for testing, do not run main. Pure functions are defined above.
+if [[ "${RELEASE_SH_NO_MAIN:-0}" == "1" ]]; then
+  return 0
+fi
+
+main "$@"

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -212,9 +212,14 @@ main() {
 
   # Once we start pushing to origin, partial failure leaves state on remote.
   # Each error message names exactly what's stuck so a human can finish by hand.
+  # (Re-running release.sh after a partial push will refuse: VERSION already at
+  # new_version. Recovery is always: finish manually with the printed commands.)
   if ! git -C "$root" push origin main; then
-    echo "ERROR: failed to push main. Bump commit is local-only; retry: git push origin main" >&2
-    echo "       then re-run: bin/release.sh $new_version (it will resume from tag push)." >&2
+    echo "ERROR: failed to push main. Bump commit is local-only." >&2
+    echo "       Recover:" >&2
+    echo "         git push origin main && \\" >&2
+    echo "         git push origin v$new_version && \\" >&2
+    echo "         gh release create v$new_version --title v$new_version --generate-notes" >&2
     exit 11
   fi
   if ! git -C "$root" push origin "v$new_version"; then
@@ -225,7 +230,12 @@ main() {
   fi
 
   local notes_file
-  notes_file="$(mktemp -t "release-notes-v${new_version}.XXXXXX").md"
+  # mktemp + .md rename: keeps editor markdown highlighting without leaking
+  # the mktemp-created file (a "$(mktemp ...).md" pattern would leak the
+  # original mktemp file as an orphan).
+  notes_file="$(mktemp -t release-notes-XXXXXX)"
+  mv -- "$notes_file" "${notes_file}.md"
+  notes_file="${notes_file}.md"
   trap 'rm -f "$notes_file"' EXIT
   local last_tag
   last_tag="$(git -C "$root" describe --tags --abbrev=0 "v${new_version}^" 2>/dev/null || true)"

--- a/bin/release_test.sh
+++ b/bin/release_test.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Test harness for bin/release.sh pure functions.
+# Sources release.sh with RELEASE_SH_NO_MAIN=1 to skip orchestration entry point.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export RELEASE_SH_NO_MAIN=1
+# shellcheck source=./release.sh
+source "$SCRIPT_DIR/release.sh"
+
+failures=0
+pass() { printf "  ok   %s\n" "$1"; }
+fail() { printf "  FAIL %s: %s\n" "$1" "$2" >&2; failures=$((failures + 1)); }
+
+assert_eq() {
+  local actual="$1" expected="$2" name="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$name"
+  else
+    fail "$name" "expected '$expected', got '$actual'"
+  fi
+}
+
+assert_ok() {
+  local name="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    pass "$name"
+  else
+    fail "$name" "expected success, got failure: $*"
+  fi
+}
+
+assert_fails() {
+  local name="$1"
+  shift
+  if ! "$@" >/dev/null 2>&1; then
+    pass "$name"
+  else
+    fail "$name" "expected failure, got success: $*"
+  fi
+}
+
+echo "validate_semver:"
+assert_ok    "accepts 0.0.0"        validate_semver "0.0.0"
+assert_ok    "accepts 1.2.3"        validate_semver "1.2.3"
+assert_ok    "accepts 0.19.0"       validate_semver "0.19.0"
+assert_ok    "accepts 12.34.567"    validate_semver "12.34.567"
+assert_fails "rejects empty"        validate_semver ""
+assert_fails "rejects v-prefixed"   validate_semver "v1.0.0"
+assert_fails "rejects two-part"     validate_semver "1.0"
+assert_fails "rejects suffix"       validate_semver "1.0.0-rc.1"
+assert_fails "rejects alpha"        validate_semver "abc"
+assert_fails "rejects leading zero" validate_semver "01.0.0"
+
+echo
+echo "verify_version_sync + bump_version_files:"
+TMP="$(mktemp -d -t floq-release-test.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/frontend"
+printf "0.19.0\n" > "$TMP/VERSION"
+cat > "$TMP/README.md" <<'EOF'
+# Floq
+
+[![Version](https://img.shields.io/badge/version-0.19.0-blue)](VERSION)
+[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue)](LICENSE)
+EOF
+cat > "$TMP/frontend/package.json" <<'EOF'
+{
+  "name": "frontend",
+  "version": "0.19.0",
+  "private": true
+}
+EOF
+cat > "$TMP/frontend/package-lock.json" <<'EOF'
+{
+  "name": "frontend",
+  "version": "0.19.0",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "frontend",
+      "version": "0.19.0",
+      "dependencies": {}
+    },
+    "node_modules/some-dep": {
+      "version": "4.4.4"
+    }
+  }
+}
+EOF
+
+assert_ok    "synced state accepted"      verify_version_sync "$TMP" "0.19.0"
+
+# Drift in README — must be detected
+perl -i -pe 's|version-0\.19\.0-blue|version-0.18.0-blue|' "$TMP/README.md"
+assert_fails "drift detected (README)"    verify_version_sync "$TMP" "0.19.0"
+perl -i -pe 's|version-0\.18\.0-blue|version-0.19.0-blue|' "$TMP/README.md"
+
+# Drift in package.json — must be detected
+perl -i -pe 's|"version": "0\.19\.0"|"version": "0.18.0"|' "$TMP/frontend/package.json"
+assert_fails "drift detected (pkg.json)"  verify_version_sync "$TMP" "0.19.0"
+perl -i -pe 's|"version": "0\.18\.0"|"version": "0.19.0"|' "$TMP/frontend/package.json"
+
+# Drift in package-lock.json (only root, lockfile gets 1/2 — must fail)
+perl -i -pe 'if (/"version": "0\.19\.0"/ && !$done) { s|"version": "0\.19\.0"|"version": "0.18.0"|; $done = 1 }' "$TMP/frontend/package-lock.json"
+assert_fails "drift detected (pkg-lock half)" verify_version_sync "$TMP" "0.19.0"
+perl -i -pe 's|"version": "0\.18\.0"|"version": "0.19.0"|' "$TMP/frontend/package-lock.json"
+
+# Bump
+assert_ok    "bump runs"                  bump_version_files "$TMP" "0.19.0" "0.20.0"
+assert_ok    "post-bump sync at 0.20.0"   verify_version_sync "$TMP" "0.20.0"
+assert_eq    "$(cat "$TMP/VERSION")" "0.20.0" "VERSION rewritten"
+assert_eq    "$(grep -c 'version-0.20.0-blue' "$TMP/README.md")" "1" "README badge updated"
+assert_eq    "$(grep -c '0.19.0' "$TMP/README.md")" "0" "README no stale 0.19.0"
+assert_eq    "$(grep -c '"version": "0.20.0"' "$TMP/frontend/package.json")" "1" "pkg.json updated"
+assert_eq    "$(grep -c '"version": "0.20.0"' "$TMP/frontend/package-lock.json")" "2" "pkg-lock.json 2 occurrences"
+# Ensure unrelated dep version untouched
+assert_eq    "$(grep -c '"version": "4.4.4"' "$TMP/frontend/package-lock.json")" "1" "unrelated dep version preserved"
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+  printf "FAIL: %d test(s) failed\n" "$failures" >&2
+  exit 1
+fi
+echo "All tests passed."

--- a/bin/release_test.sh
+++ b/bin/release_test.sh
@@ -86,6 +86,12 @@ cat > "$TMP/frontend/package-lock.json" <<'EOF'
     },
     "node_modules/some-dep": {
       "version": "4.4.4"
+    },
+    "node_modules/colliding-dep": {
+      "version": "0.20.0"
+    },
+    "node_modules/another-colliding": {
+      "version": "0.20.0"
     }
   }
 }
@@ -115,9 +121,49 @@ assert_eq    "$(cat "$TMP/VERSION")" "0.20.0" "VERSION rewritten"
 assert_eq    "$(grep -c 'version-0.20.0-blue' "$TMP/README.md")" "1" "README badge updated"
 assert_eq    "$(grep -c '0.19.0' "$TMP/README.md")" "0" "README no stale 0.19.0"
 assert_eq    "$(grep -c '"version": "0.20.0"' "$TMP/frontend/package.json")" "1" "pkg.json updated"
-assert_eq    "$(grep -c '"version": "0.20.0"' "$TMP/frontend/package-lock.json")" "2" "pkg-lock.json 2 occurrences"
+assert_eq    "$(grep -c '"version": "0.20.0"' "$TMP/frontend/package-lock.json")" "4" "pkg-lock.json 4 occurrences (2 project + 2 colliding deps)"
 # Ensure unrelated dep version untouched
 assert_eq    "$(grep -c '"version": "4.4.4"' "$TMP/frontend/package-lock.json")" "1" "unrelated dep version preserved"
+# Ensure colliding-dep versions NOT bumped (they happen to equal new project version, but they're transitive deps)
+assert_eq    "$(grep -c 'colliding-dep' "$TMP/frontend/package-lock.json")" "1" "colliding-dep key preserved"
+assert_eq    "$(grep -c 'another-colliding' "$TMP/frontend/package-lock.json")" "1" "another-colliding key preserved"
+# The colliding deps started at 0.20.0 and must STILL be at 0.20.0 (we want stability — bump must not invent versions).
+# What we cannot accept: the bump removing their 0.20.0 entries or otherwise corrupting them.
+# Structural rewrite contract: only root "version" and packages[""].version get touched.
+# Verify by reconstructing expected file and diffing whole file content.
+cat > "$TMP/frontend/expected-package-lock.json" <<'EOF'
+{
+  "name": "frontend",
+  "version": "0.20.0",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "frontend",
+      "version": "0.20.0",
+      "dependencies": {}
+    },
+    "node_modules/some-dep": {
+      "version": "4.4.4"
+    },
+    "node_modules/colliding-dep": {
+      "version": "0.20.0"
+    },
+    "node_modules/another-colliding": {
+      "version": "0.20.0"
+    }
+  }
+}
+EOF
+if diff -q "$TMP/frontend/package-lock.json" "$TMP/frontend/expected-package-lock.json" >/dev/null; then
+  pass "pkg-lock.json structural fidelity"
+else
+  fail "pkg-lock.json structural fidelity" "$(diff "$TMP/frontend/expected-package-lock.json" "$TMP/frontend/package-lock.json")"
+fi
+
+# Also: verify_version_sync at the new version must return exactly true when project version
+# coincidentally matches transitive dep versions (the magic-count-2 invariant must use structural
+# matching, not raw grep count).
+assert_ok    "verify_version_sync robust to dep collision" verify_version_sync "$TMP" "0.20.0"
 
 echo
 if [[ "$failures" -gt 0 ]]; then


### PR DESCRIPTION
Closes #57.

## Summary

- `bin/release.sh X.Y.Z [--dry-run]` — single command from "feature merged" to "GH Release published".
- Preflight gates (semver shape, clean tree, on main + synced with origin, jq + gh present, tag not yet published, all four sync points aligned with current VERSION).
- Structural rewrite via jq for `frontend/package.json` and `frontend/package-lock.json` — transitive deps coincidentally sharing the project version are never touched.
- Named recovery hints with distinct exit codes (11/12/13) for every push/tag/gh failure point so partial state can be finished by hand without spelunking.
- CI `tooling` job runs `bin/release_test.sh` on every PR to keep the release script from rotting between releases.

## Motivation

Three consecutive releases burned on the four-file manual sync checklist (v0.18.0 missed README badge, v0.18.1 missed `frontend/package.json`, v0.19.0 only survived because of a hand-written checklist sitting next to me). One script, one source of truth.

## Sync points covered

| File | What gets touched |
|---|---|
| `/VERSION` | full file rewritten to new version + newline |
| `/README.md` | shields.io badge URL anchored on `version-X.Y.Z-blue` |
| `/frontend/package.json` | `.version` via jq |
| `/frontend/package-lock.json` | `.version` and `.packages[""].version` via jq |

## Test plan

- [x] `bin/release_test.sh` — 26 scenarios (validate_semver 10, sync/drift/bump 16). Includes a collision fixture with two transitive deps coincidentally at the new project version, asserting structural fidelity against a hand-crafted expected lockfile.
- [x] jq round-trip is byte-identical to current `frontend/package.json` and `frontend/package-lock.json` (no format churn at release time).
- [x] `verify_version_sync` against the real repo at 0.19.0 returns success.
- [x] CLI: no args → usage + exit 2; bad semver → exit 2; dirty tree → exit 5 with `git status --short`.
- [x] mktemp pattern for release-notes file does not leak orphan tmp files.

## Review trail

Two rounds of `superpowers:code-reviewer`:

- **Round 1**: fix-up needed. Reviewer caught magic-count-2 + textual perl substitution (silently corrupting if a transitive dep version coincides with project version — `7.29.0` already appears 5 times in the current lockfile), no atomicity/recovery between push commit / push tag / gh release create, and missing collision test coverage. Addressed in commits `f347289` (RED) and `6d3e949` (structural rewrite via jq + preflight tag/auth + named recovery hints).
- **Round 2**: two should-fix nits. mktemp .md-suffix concatenation pattern leaks the original mktemp file as an orphan (trap cleaned up the wrong path). Recovery hint for exit-11 pointed at "re-run bin/release.sh" which deadlocks on "VERSION already at X". Both closed in `0662231`.

Final pass-bar:
- TDD: 8/10 (genuine RED→GREEN in two pairs, structural diff is the strongest possible assertion)
- Safety: 8/10 (preflight gates correct, recovery hints actionable and verified)
- Robustness: 8/10 (collision-proof, jq output byte-identical to current files)
- Engineering: 9/10 (clean pure/orchestration split, named exit codes, no shellcheck installed locally so unreviewed for SC*)