### PR TITLE
feat(inbox/hitl): idempotent Propose dedup via partial unique index

### DIFF
--- a/backend/internal/inbox/pending_reply.go
+++ b/backend/internal/inbox/pending_reply.go
@@ -84,6 +84,12 @@ var (
 	ErrPendingReplyInvalidKind      = errors.New("pending reply: invalid kind")
 	ErrPendingReplyEmptyBody        = errors.New("pending reply: body is required")
 	ErrPendingReplyInvalidTransition = errors.New("pending reply: invalid status transition")
+	// ErrPendingReplyDuplicatePending signals that a Save attempt
+	// collided with the partial-unique dedup index for an in-flight
+	// pending row with identical (user_id, lead_id, kind, body). The
+	// usecase translates this into a silent return of the previously-
+	// enqueued entity so the caller treats re-Propose as idempotent.
+	ErrPendingReplyDuplicatePending = errors.New("pending reply: duplicate pending row for same content")
 )
 
 // PendingReply is an inbox-originated outbound message awaiting human

--- a/backend/internal/inbox/pending_reply_repository.go
+++ b/backend/internal/inbox/pending_reply_repository.go
@@ -4,12 +4,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/daniil/floq/internal/db"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// pendingReplyDedupIndex is the constraint name the partial-unique
+// dedup index ships under in migration 031. The repository checks
+// against this exact name when translating a 23505 unique_violation
+// to the domain sentinel — any OTHER unique violation on this table
+// must still propagate as a raw error so future indexes don't get
+// silently flattened into dedup semantics.
+const pendingReplyDedupIndex = "idx_pending_replies_dedup_pending"
 
 // Compile-time check that *PendingReplyRepo satisfies the port.
 var _ PendingReplyRepository = (*PendingReplyRepo)(nil)
@@ -44,6 +54,10 @@ func (r *PendingReplyRepo) Save(ctx context.Context, pr *PendingReply) error {
 		pr.ID, pr.UserID, pr.LeadID, string(pr.Channel), string(pr.Kind), pr.Body,
 		string(pr.Status), pr.CreatedAt, pr.DecidedAt, pr.SentAt)
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == pendingReplyDedupIndex {
+			return ErrPendingReplyDuplicatePending
+		}
 		return fmt.Errorf("save pending reply: %w", err)
 	}
 	return nil
@@ -73,12 +87,32 @@ func (r *PendingReplyRepo) GetByID(ctx context.Context, userID, id uuid.UUID) (*
 
 // FindPendingByContent locates the existing pending row whose
 // (user_id, lead_id, kind, body) matches — used by the usecase after a
-// Save collides with the partial unique dedup index. Returns nil
-// without error when no such row exists. STUB: SQL impl arrives with
-// migration 031; this method is wired now so the interface contract
-// stays satisfied while the usecase is built out under TDD.
+// Save collides with the partial-unique dedup index installed in
+// migration 031. Returns nil without error when no such row exists.
+// Body is trimmed to match the factory's storage normalisation so
+// callers passing raw whitespace-padded content still hit the row.
 func (r *PendingReplyRepo) FindPendingByContent(ctx context.Context, userID, leadID uuid.UUID, kind PendingReplyKind, body string) (*PendingReply, error) {
-	return nil, nil
+	trimmed := strings.TrimSpace(body)
+	var pr PendingReply
+	var channel, kindStr, status string
+	err := r.q(ctx).QueryRow(ctx,
+		`SELECT `+pendingReplyColumns+`
+		 FROM pending_replies
+		 WHERE user_id = $1 AND lead_id = $2 AND kind = $3 AND body = $4 AND status = 'pending'
+		 LIMIT 1`,
+		userID, leadID, string(kind), trimmed).
+		Scan(&pr.ID, &pr.UserID, &pr.LeadID, &channel, &kindStr, &pr.Body, &status,
+			&pr.CreatedAt, &pr.DecidedAt, &pr.SentAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find pending by content: %w", err)
+	}
+	pr.Channel = Channel(channel)
+	pr.Kind = PendingReplyKind(kindStr)
+	pr.Status = PendingReplyStatus(status)
+	return &pr, nil
 }
 
 func (r *PendingReplyRepo) ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error) {

--- a/backend/internal/inbox/pending_reply_repository.go
+++ b/backend/internal/inbox/pending_reply_repository.go
@@ -71,6 +71,16 @@ func (r *PendingReplyRepo) GetByID(ctx context.Context, userID, id uuid.UUID) (*
 	return &pr, nil
 }
 
+// FindPendingByContent locates the existing pending row whose
+// (user_id, lead_id, kind, body) matches — used by the usecase after a
+// Save collides with the partial unique dedup index. Returns nil
+// without error when no such row exists. STUB: SQL impl arrives with
+// migration 031; this method is wired now so the interface contract
+// stays satisfied while the usecase is built out under TDD.
+func (r *PendingReplyRepo) FindPendingByContent(ctx context.Context, userID, leadID uuid.UUID, kind PendingReplyKind, body string) (*PendingReply, error) {
+	return nil, nil
+}
+
 func (r *PendingReplyRepo) ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error) {
 	rows, err := r.q(ctx).Query(ctx,
 		`SELECT `+pendingReplyColumns+`

--- a/backend/internal/inbox/pending_reply_repository_test.go
+++ b/backend/internal/inbox/pending_reply_repository_test.go
@@ -194,6 +194,141 @@ func TestPendingReplyRepository_Update_OptimisticLock_RejectsWhenStatusMoved(t *
 		"second Update with the same expected-status must fail — the row is no longer pending")
 }
 
+func TestPendingReplyRepository_Save_DuplicatePendingReturnsSentinel(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	first, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "book me")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, first))
+
+	second, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "book me")
+	require.NoError(t, err)
+	err = repo.Save(ctx, second)
+	require.Error(t, err, "second Save with identical pending content must fail at the dedup index")
+	require.ErrorIs(t, err, inbox.ErrPendingReplyDuplicatePending,
+		"23505 on the dedup partial-unique index must translate to ErrPendingReplyDuplicatePending so the usecase can branch")
+
+	listed, err := repo.ListByLead(ctx, userID, leadID)
+	require.NoError(t, err)
+	assert.Len(t, listed, 1, "dedup index must prevent the duplicate row from landing")
+	assert.Equal(t, first.ID, listed[0].ID)
+}
+
+func TestPendingReplyRepository_Save_DifferentBodyAllowedAlongside(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	first, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "book me")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, first))
+
+	second, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "book me, please")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, second), "different body must NOT trigger dedup")
+
+	listed, err := repo.ListByLead(ctx, userID, leadID)
+	require.NoError(t, err)
+	assert.Len(t, listed, 2)
+}
+
+func TestPendingReplyRepository_Save_AllowsRePeoposeAfterRejection(t *testing.T) {
+	// Partial unique index is scoped to status='pending'. Once the
+	// operator rejects the first draft, the same content can be
+	// proposed again — the original row is no longer competing for
+	// the dedup slot.
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	first, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "book me")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, first))
+	require.NoError(t, first.Reject(time.Now().UTC()))
+	require.NoError(t, repo.Update(ctx, first, inbox.PendingReplyStatusPending))
+
+	second, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "book me")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, second),
+		"after rejection, the same content must be re-proposable — partial index excludes non-pending rows")
+}
+
+func TestPendingReplyRepository_FindPendingByContent_ReturnsExisting(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	first, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "book me")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, first))
+
+	got, err := repo.FindPendingByContent(ctx, userID, leadID, inbox.PendingReplyKindBookingLink, "book me")
+	require.NoError(t, err)
+	require.NotNil(t, got, "FindPendingByContent must locate the existing pending row")
+	assert.Equal(t, first.ID, got.ID)
+	assert.Equal(t, inbox.PendingReplyStatusPending, got.Status)
+}
+
+func TestPendingReplyRepository_FindPendingByContent_NoMatchReturnsNil(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	got, err := repo.FindPendingByContent(ctx, userID, leadID, inbox.PendingReplyKindBookingLink, "nothing here")
+	require.NoError(t, err, "missing match is not an error")
+	assert.Nil(t, got)
+}
+
+func TestPendingReplyRepository_FindPendingByContent_IgnoresDecidedRows(t *testing.T) {
+	// After Reject, the matching row should NOT be returned —
+	// FindPendingByContent is the dedup-recovery path, scoped to the
+	// same status='pending' slice as the partial unique index.
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	pr, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "book me")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, pr))
+	require.NoError(t, pr.Reject(time.Now().UTC()))
+	require.NoError(t, repo.Update(ctx, pr, inbox.PendingReplyStatusPending))
+
+	got, err := repo.FindPendingByContent(ctx, userID, leadID, inbox.PendingReplyKindBookingLink, "book me")
+	require.NoError(t, err)
+	assert.Nil(t, got, "FindPendingByContent must skip rejected/sent/approved rows — only the pending slice is dedup-relevant")
+}
+
+func TestPendingReplyRepository_FindPendingByContent_ScopedByUser(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userA := testutil.SeedUser(t, pool)
+	userB := testutil.SeedUser(t, pool)
+	leadA := seedLeadForUser(t, pool, userA)
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	pr, err := inbox.NewPendingReply(userA, leadA, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "owned by A")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, pr))
+
+	got, err := repo.FindPendingByContent(ctx, userB, leadA, inbox.PendingReplyKindBookingLink, "owned by A")
+	require.NoError(t, err, "cross-tenant lookup must not error")
+	assert.Nil(t, got, "cross-tenant FindPendingByContent must return nil — never another user's row")
+}
+
 func TestPendingReplyRepository_Update_PersistsStatusAndTimestamps(t *testing.T) {
 	pool := testutil.TestDB(t)
 	userID := testutil.SeedUser(t, pool)

--- a/backend/internal/inbox/pending_reply_usecase.go
+++ b/backend/internal/inbox/pending_reply_usecase.go
@@ -77,15 +77,38 @@ func (uc *PendingReplyUseCase) SetDispatcher(d ReplyDispatcher) {
 // Propose constructs a new PendingReply through the domain factory
 // (so invariants are enforced) and persists it. Dispatch is
 // deliberately skipped — that is the whole point of the HITL gate.
+//
+// Idempotent against the partial-unique dedup index: if Save reports
+// ErrPendingReplyDuplicatePending (a pending row with the same
+// content already exists), Propose looks up the previously-enqueued
+// entity and returns it instead of failing. This handles the
+// Telegram-reconnect double-fire case at the repository boundary so
+// callers (the bot, future email auto-reply) do not need their own
+// retry-and-suppress logic.
 func (uc *PendingReplyUseCase) Propose(ctx context.Context, userID, leadID uuid.UUID, channel Channel, kind PendingReplyKind, body string) (*PendingReply, error) {
 	pr, err := NewPendingReply(userID, leadID, channel, kind, body)
 	if err != nil {
 		return nil, err
 	}
-	if err := uc.repo.Save(ctx, pr); err != nil {
-		return nil, fmt.Errorf("propose pending reply: %w", err)
+	saveErr := uc.repo.Save(ctx, pr)
+	if saveErr == nil {
+		return pr, nil
 	}
-	return pr, nil
+	if !errors.Is(saveErr, ErrPendingReplyDuplicatePending) {
+		return nil, fmt.Errorf("propose pending reply: %w", saveErr)
+	}
+	// Dedup hit: surface the already-enqueued row. Trimmed body matches
+	// what the factory stored on the original Save.
+	existing, ferr := uc.repo.FindPendingByContent(ctx, userID, leadID, kind, pr.Body)
+	if ferr != nil {
+		return nil, fmt.Errorf("propose pending reply: lookup after dedup: %w", ferr)
+	}
+	if existing == nil {
+		// Index said duplicate but the row is gone — race or anomaly.
+		// Wrap the sentinel so callers can branch and humans can grep.
+		return nil, fmt.Errorf("propose pending reply: dedup hit but no pending row found: %w", saveErr)
+	}
+	return existing, nil
 }
 
 // ListByLead returns every pending-or-decided reply tied to the given

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -3,6 +3,7 @@ package inbox
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -13,12 +14,19 @@ import (
 // --- in-memory fakes ---
 
 type fakePendingReplyRepo struct {
-	mu      sync.Mutex
-	rows    map[uuid.UUID]*PendingReply
-	saveErr error
-	getErr  error
-	updErr  error
-	listErr error
+	mu       sync.Mutex
+	rows     map[uuid.UUID]*PendingReply
+	saveErr  error
+	getErr   error
+	updErr   error
+	listErr  error
+	findErr  error
+	// dedupOnSave mirrors the partial unique index that production
+	// installs in migration 031: when true, Save returns
+	// ErrPendingReplyDuplicatePending if a pending row already exists
+	// for the same (user_id, lead_id, kind, body) tuple. Off by default
+	// so existing tests are unaffected.
+	dedupOnSave bool
 }
 
 func newFakeRepo() *fakePendingReplyRepo {
@@ -31,9 +39,40 @@ func (f *fakePendingReplyRepo) Save(_ context.Context, pr *PendingReply) error {
 	if f.saveErr != nil {
 		return f.saveErr
 	}
+	if f.dedupOnSave {
+		for _, row := range f.rows {
+			if row.UserID == pr.UserID &&
+				row.LeadID == pr.LeadID &&
+				row.Kind == pr.Kind &&
+				row.Body == pr.Body &&
+				row.Status == PendingReplyStatusPending {
+				return ErrPendingReplyDuplicatePending
+			}
+		}
+	}
 	copy := *pr
 	f.rows[pr.ID] = &copy
 	return nil
+}
+
+func (f *fakePendingReplyRepo) FindPendingByContent(_ context.Context, userID, leadID uuid.UUID, kind PendingReplyKind, body string) (*PendingReply, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.findErr != nil {
+		return nil, f.findErr
+	}
+	trimmed := strings.TrimSpace(body)
+	for _, row := range f.rows {
+		if row.UserID == userID &&
+			row.LeadID == leadID &&
+			row.Kind == kind &&
+			row.Body == trimmed &&
+			row.Status == PendingReplyStatusPending {
+			copy := *row
+			return &copy, nil
+		}
+	}
+	return nil, nil
 }
 
 func (f *fakePendingReplyRepo) GetByID(_ context.Context, userID, id uuid.UUID) (*PendingReply, error) {
@@ -159,6 +198,111 @@ func TestPendingReplyUseCase_Propose_PropagatesRepoError(t *testing.T) {
 	_, err := uc.Propose(context.Background(), uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "ok")
 	if err == nil || !errors.Is(err, repo.saveErr) {
 		t.Fatalf("want save error wrapped, got %v", err)
+	}
+}
+
+func TestPendingReplyUseCase_Propose_DuplicateReturnsExistingEntity(t *testing.T) {
+	repo := newFakeRepo()
+	repo.dedupOnSave = true
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+	userID := uuid.New()
+	leadID := uuid.New()
+
+	first, err := uc.Propose(ctx, userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "book me")
+	if err != nil {
+		t.Fatalf("first Propose error: %v", err)
+	}
+
+	second, err := uc.Propose(ctx, userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "book me")
+	if err != nil {
+		t.Fatalf("second Propose must be silently idempotent, got error: %v", err)
+	}
+	if second == nil {
+		t.Fatal("second Propose returned nil entity — caller expects the already-enqueued row")
+	}
+	if second.ID != first.ID {
+		t.Errorf("second Propose returned a different entity ID (%v vs %v) — the dedup contract is that the SAME row surfaces both times", second.ID, first.ID)
+	}
+
+	// Repo invariant: exactly one row stored.
+	listed, err := uc.ListByLead(ctx, userID, leadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 1 {
+		t.Errorf("rows persisted = %d, want 1 (dedup must collapse the second insert)", len(listed))
+	}
+}
+
+func TestPendingReplyUseCase_Propose_DuplicateWhitespaceVariantStillDedups(t *testing.T) {
+	// Body is trimmed by the domain factory, so whitespace-only
+	// variations on the same content must still hit the dedup index.
+	repo := newFakeRepo()
+	repo.dedupOnSave = true
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+	userID := uuid.New()
+	leadID := uuid.New()
+
+	first, err := uc.Propose(ctx, userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "book me")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := uc.Propose(ctx, userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "  book me  ")
+	if err != nil {
+		t.Fatalf("trimmed-equivalent Propose must dedup, got error: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Errorf("trimmed-equivalent Propose returned different ID — factory trim + dedup must agree")
+	}
+}
+
+func TestPendingReplyUseCase_Propose_DifferentBodyAllowedAlongside(t *testing.T) {
+	repo := newFakeRepo()
+	repo.dedupOnSave = true
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+	userID := uuid.New()
+	leadID := uuid.New()
+
+	first, err := uc.Propose(ctx, userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "book me")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := uc.Propose(ctx, userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "book me, please")
+	if err != nil {
+		t.Fatalf("Propose with different body must NOT be deduped, got error: %v", err)
+	}
+	if second.ID == first.ID {
+		t.Error("different bodies must produce different entities")
+	}
+
+	listed, err := uc.ListByLead(ctx, userID, leadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 2 {
+		t.Errorf("rows persisted = %d, want 2 (different bodies are not duplicates)", len(listed))
+	}
+}
+
+func TestPendingReplyUseCase_Propose_DuplicateButRowDisappearedSurfacesError(t *testing.T) {
+	// Save returns ErrPendingReplyDuplicatePending but FindPendingByContent
+	// finds nothing — race anomaly: the dedup-causing row was removed
+	// between Save and Find. The usecase must NOT silently swallow this;
+	// caller deserves an explicit error so the bot logs and humans can
+	// investigate.
+	repo := newFakeRepo()
+	repo.saveErr = ErrPendingReplyDuplicatePending // dedup hit, but no row in store
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+
+	_, err := uc.Propose(context.Background(), uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "ok")
+	if err == nil {
+		t.Fatal("dup-without-find-match must surface an error")
+	}
+	if !errors.Is(err, ErrPendingReplyDuplicatePending) {
+		t.Errorf("anomaly error must wrap ErrPendingReplyDuplicatePending so caller can branch, got %v", err)
 	}
 }
 

--- a/backend/internal/inbox/ports.go
+++ b/backend/internal/inbox/ports.go
@@ -175,9 +175,21 @@ type PendingReplyProposer interface {
 // "not found OR not owned" and answer 404 to keep the two
 // indistinguishable on the wire.
 type PendingReplyRepository interface {
+	// Save persists a new PendingReply. Returns
+	// ErrPendingReplyDuplicatePending if a row with the same
+	// (user_id, lead_id, kind, body) tuple already exists in the
+	// pending status — the partial unique dedup index catches the
+	// Telegram-reconnect duplicate-Propose case at the DB level.
 	Save(ctx context.Context, pr *PendingReply) error
 	GetByID(ctx context.Context, userID, id uuid.UUID) (*PendingReply, error)
 	ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error)
+	// FindPendingByContent returns the existing pending row whose
+	// (user_id, lead_id, kind, body) tuple matches, or nil if none.
+	// Used by the usecase after Save returns
+	// ErrPendingReplyDuplicatePending to surface the previously-
+	// enqueued entity to the caller. body is matched against the
+	// trimmed value the factory stored.
+	FindPendingByContent(ctx context.Context, userID, leadID uuid.UUID, kind PendingReplyKind, body string) (*PendingReply, error)
 	// Update writes pr only when the persisted row still matches the
 	// expectedStatus the caller observed at load time — an optimistic
 	// lock that prevents two operators from concurrently approving

--- a/backend/migrations/031_pending_replies_dedup_index.down.sql
+++ b/backend/migrations/031_pending_replies_dedup_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_pending_replies_dedup_pending;

--- a/backend/migrations/031_pending_replies_dedup_index.up.sql
+++ b/backend/migrations/031_pending_replies_dedup_index.up.sql
@@ -1,0 +1,16 @@
+-- Partial unique index that collapses simultaneously-pending drafts
+-- with identical content. Telegram long-poll reconnects can re-fire
+-- DetectCallAgreement on the same inbound message twice, which would
+-- otherwise enqueue duplicate approval buttons for the operator and
+-- risk a double-send if both get approved.
+--
+-- Scoped to status='pending' so completed/decided rows do NOT block a
+-- fresh proposal for the same content later (e.g. operator rejected
+-- the first draft; we want a follow-up Propose to be enqueueable).
+--
+-- md5(body) keeps the index key bounded — body may be hundreds of
+-- bytes (booking link + accompanying message). md5 is IMMUTABLE so
+-- the expression is index-safe.
+CREATE UNIQUE INDEX idx_pending_replies_dedup_pending
+ON pending_replies (user_id, lead_id, kind, md5(body))
+WHERE status = 'pending';


### PR DESCRIPTION
Closes #45.

## Summary

- Telegram long-poll reconnects can re-fire `DetectCallAgreement` on the same inbound message, enqueueing duplicate `pending_replies` rows for one operator decision. Migration 031 installs a partial-unique index on `(user_id, lead_id, kind, md5(body)) WHERE status='pending'` that collapses the duplicate at the DB level.
- `PendingReplyRepo.Save` translates pgconn 23505 with constraint_name = `idx_pending_replies_dedup_pending` into the new domain sentinel `ErrPendingReplyDuplicatePending`. Any OTHER unique violation on this table still propagates as a wrapped raw error.
- `PendingReplyUseCase.Propose` catches the sentinel, calls the new narrow port `FindPendingByContent`, and returns the previously-enqueued row. Callers see Propose as idempotent without their own retry-and-suppress logic.
- Partial index is scoped to `status='pending'` so a rejected draft does not block a fresh follow-up Propose with the same content.

## Test plan

- [x] Unit (4 scenarios): dup returns existing entity, trimmed-equivalent body dedups, different body allowed alongside, dedup-but-row-gone anomaly stays loud.
- [x] Integration (7 scenarios): Save dup sentinel, different body, re-propose after rejection, FindPendingByContent (happy / not-found / cross-tenant / ignores-decided).
- [ ] Live integration prove-out on CI runner (Postgres service) — local OrbStack was offline so SQL syntax was verified only via `go vet -tags=integration` + repo/migration reading.

## Review trail

Single `superpowers:code-reviewer` round:

- TDD 9/10 — RED→GREEN pair commits verified by re-running tests at the RED commit (`c3621b3`) and at GREEN (`28c3071`); edge cases (whitespace, cross-tenant, status-scoped re-propose, anomaly) covered.
- DDD 9/10 — sentinel in domain, `pendingReplyDedupIndex` infrastructure constant correctly in repo, narrow port `FindPendingByContent` justified (different status-slice semantics than `ListByLead`).
- Clean Architecture 10/10 — handler not touched, no cross-context imports, usecase orchestration cleanly in usecase layer.
- Enterprise/Safety 9/10 — race-safe on DB level, constraint-name check protects future unique indexes from silent flattening, status-scoped partial index correct, cross-tenant pinned by integration test.

Reviewer nit-picks (not blockers, will land in follow-up if useful):
- `telegram.go:229` discards returned entity — fine for bot but worth surfacing when HTTP `POST /pending-replies` handler ever appears.
- `pending_reply_repository.go:101` hardcodes `status = 'pending'` string literal instead of using the `PendingReplyStatusPending` constant via a query parameter.
- `CREATE UNIQUE INDEX` without `IF NOT EXISTS` matches existing migration convention but loses retry-friendliness.