### PR TITLE
feat(ratelimit): sliding-window 429 on HITL approve/reject

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -47,14 +47,10 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// Rate-limit budget for HITL approve/reject combined per user. 30
-// requests per minute is over an order of magnitude above any
-// legitimate human cadence and still capped enough to bound abuse
-// from a compromised JWT.
-const (
-	pendingReplyRateLimit  = 30
-	pendingReplyRateWindow = time.Minute
-)
+// pendingReplyRateWindow is fixed (per-minute is the only sensible
+// granularity for human-paced HITL endpoints); the budget itself
+// comes from config so ops can tighten on demand without rebuild.
+const pendingReplyRateWindow = time.Minute
 
 func main() {
 	// Load .env file (ignore error if missing — production uses real env vars).
@@ -166,10 +162,10 @@ func main() {
 			slog.Warn("redis ping failed at startup; rate limiter will fail-open until reachable", "err", err)
 		}
 		cancel()
-		pendingReplyLimiter = ratelimit.NewRedisLimiter(redisClient, pendingReplyRateLimit, pendingReplyRateWindow)
+		pendingReplyLimiter = ratelimit.NewRedisLimiter(redisClient, cfg.PendingReplyRateLimitPerMin, pendingReplyRateWindow)
 	} else {
 		slog.Warn("REDIS_URL not set; using in-process rate limiter (single-instance only)")
-		pendingReplyLimiter = ratelimit.NewInMemoryLimiter(pendingReplyRateLimit, pendingReplyRateWindow)
+		pendingReplyLimiter = ratelimit.NewInMemoryLimiter(cfg.PendingReplyRateLimitPerMin, pendingReplyRateWindow)
 	}
 	pendingReplyDecideMW := ratelimit.Middleware(pendingReplyLimiter, pendingReplyKeyFn, slog.Default())
 
@@ -376,6 +372,15 @@ func main() {
 // are prefixed so future limiters on other routes do not collide in
 // the same Redis namespace, and scoped by user_id so one tenant's
 // burst cannot starve another.
+//
+// IMPORTANT: returning ok=false bypasses the limiter entirely — this
+// hinges on auth.AuthMiddleware running FIRST so the user_id is in
+// context for every request that reaches this point. Mounting the
+// pending-reply routes outside the protected group would silently
+// disable rate-limiting (every request falls back to bypass). See
+// the wire-up in main.go where decideMW is passed into
+// RegisterPendingReplyRoutes inside the auth.AuthMiddleware-scoped
+// chi.Group block.
 func pendingReplyKeyFn(r *http.Request) (string, bool) {
 	id, ok := httputil.UserIDFromContext(r.Context())
 	if !ok {

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/daniil/floq/internal/chat"
 	"github.com/daniil/floq/internal/config"
 	"github.com/daniil/floq/internal/db"
+	"github.com/daniil/floq/internal/httputil"
 	"github.com/daniil/floq/internal/inbox"
 	"github.com/daniil/floq/internal/inbox/attachments"
 	"github.com/daniil/floq/internal/leads"
@@ -30,6 +31,7 @@ import (
 	"github.com/daniil/floq/internal/outbound"
 	"github.com/daniil/floq/internal/parser"
 	"github.com/daniil/floq/internal/proxy"
+	"github.com/daniil/floq/internal/ratelimit"
 	"github.com/daniil/floq/internal/reminders"
 	"github.com/daniil/floq/internal/prospects"
 	"github.com/daniil/floq/internal/sequences"
@@ -42,6 +44,16 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/joho/godotenv"
+	"github.com/redis/go-redis/v9"
+)
+
+// Rate-limit budget for HITL approve/reject combined per user. 30
+// requests per minute is over an order of magnitude above any
+// legitimate human cadence and still capped enough to bound abuse
+// from a compromised JWT.
+const (
+	pendingReplyRateLimit  = 30
+	pendingReplyRateWindow = time.Minute
 )
 
 func main() {
@@ -137,6 +149,30 @@ func main() {
 	// bot -> usecase -> dispatcher -> bot cycle.
 	pendingReplyUC := inbox.NewPendingReplyUseCase(pendingReplyRepo, nil)
 
+	// Rate limiter for pending-reply approve/reject. Redis-backed when
+	// REDIS_URL is set (multi-instance safe); falls back to an in-
+	// process sliding-window for single-instance dev/test. Middleware
+	// fails open on Limiter errors so a Redis outage does not lock
+	// operators out of urgent approvals.
+	var pendingReplyLimiter ratelimit.Limiter
+	if cfg.RedisURL != "" {
+		redisOpt, err := redis.ParseURL(cfg.RedisURL)
+		if err != nil {
+			log.Fatalf("invalid REDIS_URL: %v", err)
+		}
+		redisClient := redis.NewClient(redisOpt)
+		pingCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		if err := redisClient.Ping(pingCtx).Err(); err != nil {
+			slog.Warn("redis ping failed at startup; rate limiter will fail-open until reachable", "err", err)
+		}
+		cancel()
+		pendingReplyLimiter = ratelimit.NewRedisLimiter(redisClient, pendingReplyRateLimit, pendingReplyRateWindow)
+	} else {
+		slog.Warn("REDIS_URL not set; using in-process rate limiter (single-instance only)")
+		pendingReplyLimiter = ratelimit.NewInMemoryLimiter(pendingReplyRateLimit, pendingReplyRateWindow)
+	}
+	pendingReplyDecideMW := ratelimit.Middleware(pendingReplyLimiter, pendingReplyKeyFn, slog.Default())
+
 	// 4. Adapters
 	leadsAI := leads.NewAIAdapter(aiClient)
 	seqAI := sequences.NewAIMessageGeneratorAdapter(aiClient)
@@ -192,7 +228,7 @@ func main() {
 		parser.RegisterRoutes(r, cfg.TwoGISAPIKey, httpClient)
 		settings.RegisterRoutes(r, settingsUC, buildAITester(cfg, httpClient), buildSMTPTester(proxyDialer), buildResendTester(httpClient), buildUsageCounter(leadsRepo))
 		chat.RegisterRoutes(r, chat.NewHandler(chat.NewRepository(pool), newChatAIAdapter(aiClient)))
-		inbox.RegisterPendingReplyRoutes(r, pendingReplyUC, leadsUC)
+		inbox.RegisterPendingReplyRoutes(r, pendingReplyUC, leadsUC, pendingReplyDecideMW)
 		tgOpts := []tgclient.Option{}
 		if proxyDialer != nil {
 			tgOpts = append(tgOpts, tgclient.WithDialer(proxyDialer))
@@ -334,5 +370,17 @@ func main() {
 		log.Printf("audit recorder stop: %v", err)
 	}
 	log.Println("server stopped")
+}
+
+// pendingReplyKeyFn resolves a request to its rate-limit bucket. Keys
+// are prefixed so future limiters on other routes do not collide in
+// the same Redis namespace, and scoped by user_id so one tenant's
+// burst cannot starve another.
+func pendingReplyKeyFn(r *http.Request) (string, bool) {
+	id, ok := httputil.UserIDFromContext(r.Context())
+	if !ok {
+		return "", false
+	}
+	return "ratelimit:pending-replies:" + id.String(), true
 }
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ogen-go/ogen v1.19.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/redis/go-redis/v9 v9.19.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/tidwall/gjson v1.14.4 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -119,6 +119,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.19.0 h1:XPVaaPSnG6RhYf7p+rmSa9zZfeVAnWsH5h3lxthOm/k=
+github.com/redis/go-redis/v9 v9.19.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -40,6 +40,11 @@ type Config struct {
 	SenderWebsite   string
 	StaleDays       int
 	ProxyURL        string
+	// PendingReplyRateLimitPerMin caps combined approve+reject requests
+	// per user per minute on the HITL endpoints. Default 30 — over an
+	// order of magnitude above any legitimate human cadence, still
+	// capped enough to bound abuse from a compromised JWT.
+	PendingReplyRateLimitPerMin int
 }
 
 // Load reads configuration from environment variables and returns a Config.
@@ -78,6 +83,7 @@ func Load() *Config {
 		SenderWebsite:   os.Getenv("SENDER_WEBSITE"),
 		StaleDays:       getEnvInt("STALE_DAYS", 2),
 		ProxyURL:        os.Getenv("PROXY_URL"),
+		PendingReplyRateLimitPerMin: getEnvInt("RATE_LIMIT_PENDING_REPLIES_PER_MIN", 30),
 	}
 }
 

--- a/backend/internal/inbox/handler.go
+++ b/backend/internal/inbox/handler.go
@@ -43,14 +43,25 @@ type pendingReplyHandler struct {
 //   - POST /api/pending-replies/{id}/approve — approve + dispatch
 //   - POST /api/pending-replies/{id}/reject  — terminal reject
 //
+// decideMW, when non-nil, is applied ONLY to the two mutating routes
+// (approve/reject). The GET listing path is intentionally not rate-
+// limited: it is idempotent and refreshing it in the UI must not be
+// throttled. Passing nil disables the middleware entirely — useful in
+// handler unit tests that do not need a Limiter wired up.
+//
 // A future POST /api/leads/{id}/pending-replies could let operators
 // propose a draft manually; for now only the inbox auto-draft path
 // (Telegram booking link) feeds the queue.
-func RegisterPendingReplyRoutes(r chi.Router, uc PendingReplyUseCaseAPI, leads LeadOwnershipChecker) {
+func RegisterPendingReplyRoutes(r chi.Router, uc PendingReplyUseCaseAPI, leads LeadOwnershipChecker, decideMW func(http.Handler) http.Handler) {
 	h := &pendingReplyHandler{uc: uc, leads: leads}
 	r.Get("/api/leads/{id}/pending-replies", h.listByLead())
-	r.Post("/api/pending-replies/{id}/approve", h.approve())
-	r.Post("/api/pending-replies/{id}/reject", h.reject())
+	if decideMW == nil {
+		r.Post("/api/pending-replies/{id}/approve", h.approve())
+		r.Post("/api/pending-replies/{id}/reject", h.reject())
+		return
+	}
+	r.With(decideMW).Post("/api/pending-replies/{id}/approve", h.approve())
+	r.With(decideMW).Post("/api/pending-replies/{id}/reject", h.reject())
 }
 
 func (h *pendingReplyHandler) listByLead() http.HandlerFunc {

--- a/backend/internal/inbox/handler_test.go
+++ b/backend/internal/inbox/handler_test.go
@@ -62,7 +62,7 @@ func (f *fakeLeadOwnership) OwnsLead(_ context.Context, _ uuid.UUID, leadID uuid
 
 func newTestServer(uc PendingReplyUseCaseAPI, leads LeadOwnershipChecker) http.Handler {
 	r := chi.NewRouter()
-	RegisterPendingReplyRoutes(r, uc, leads)
+	RegisterPendingReplyRoutes(r, uc, leads, nil)
 	return r
 }
 

--- a/backend/internal/ratelimit/inmemory.go
+++ b/backend/internal/ratelimit/inmemory.go
@@ -1,0 +1,30 @@
+package ratelimit
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// InMemoryLimiter implements Limiter (stub awaiting GREEN feat commit).
+type InMemoryLimiter struct {
+	limit  int
+	window time.Duration
+}
+
+// NewInMemoryLimiter returns a stub that always errors so tests fail RED
+// until the GREEN commit lands a real sliding-window implementation.
+func NewInMemoryLimiter(limit int, window time.Duration) *InMemoryLimiter {
+	return &InMemoryLimiter{limit: limit, window: window}
+}
+
+// NewInMemoryLimiterWithClock — same stub, clock-injectable shape.
+func NewInMemoryLimiterWithClock(limit int, window time.Duration, _ func() time.Time) *InMemoryLimiter {
+	return &InMemoryLimiter{limit: limit, window: window}
+}
+
+// Allow stub: always errors so the middleware path takes its
+// error-handling branch.
+func (l *InMemoryLimiter) Allow(_ context.Context, _ string) (bool, time.Duration, error) {
+	return false, 0, errors.New("ratelimit: NewInMemoryLimiter not implemented")
+}

--- a/backend/internal/ratelimit/inmemory.go
+++ b/backend/internal/ratelimit/inmemory.go
@@ -2,29 +2,65 @@ package ratelimit
 
 import (
 	"context"
-	"errors"
+	"sync"
 	"time"
 )
 
-// InMemoryLimiter implements Limiter (stub awaiting GREEN feat commit).
+// InMemoryLimiter implements Limiter via a sliding-window log kept in
+// process memory. It is the default unit-test backend and serves as
+// fallback for single-instance deploys when Redis is not configured.
+// Per-key counters live until Allow is invoked again for that key — a
+// rarely-touched key may keep its stale slice until next call; the
+// memory cost is bounded because each slice never exceeds limit+1
+// entries by construction.
 type InMemoryLimiter struct {
-	limit  int
-	window time.Duration
+	limit    int
+	window   time.Duration
+	now      func() time.Time
+	mu       sync.Mutex
+	requests map[string][]time.Time
 }
 
-// NewInMemoryLimiter returns a stub that always errors so tests fail RED
-// until the GREEN commit lands a real sliding-window implementation.
+// NewInMemoryLimiter creates a limiter that allows up to limit calls
+// per key within the trailing window. Defaults the clock to time.Now.
 func NewInMemoryLimiter(limit int, window time.Duration) *InMemoryLimiter {
-	return &InMemoryLimiter{limit: limit, window: window}
+	return NewInMemoryLimiterWithClock(limit, window, time.Now)
 }
 
-// NewInMemoryLimiterWithClock — same stub, clock-injectable shape.
-func NewInMemoryLimiterWithClock(limit int, window time.Duration, _ func() time.Time) *InMemoryLimiter {
-	return &InMemoryLimiter{limit: limit, window: window}
+// NewInMemoryLimiterWithClock is the clock-injectable constructor used
+// by tests that need to advance virtual time without sleeping.
+func NewInMemoryLimiterWithClock(limit int, window time.Duration, now func() time.Time) *InMemoryLimiter {
+	return &InMemoryLimiter{
+		limit:    limit,
+		window:   window,
+		now:      now,
+		requests: make(map[string][]time.Time),
+	}
 }
 
-// Allow stub: always errors so the middleware path takes its
-// error-handling branch.
-func (l *InMemoryLimiter) Allow(_ context.Context, _ string) (bool, time.Duration, error) {
-	return false, 0, errors.New("ratelimit: NewInMemoryLimiter not implemented")
+// Allow implements Limiter. Sliding-window log: drop timestamps older
+// than now-window, count what remains; permit if below limit, else
+// surface the time until the oldest still-counted entry expires.
+func (l *InMemoryLimiter) Allow(_ context.Context, key string) (bool, time.Duration, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.now()
+	cutoff := now.Add(-l.window)
+	list := l.requests[key]
+	keep := list[:0]
+	for _, t := range list {
+		if t.After(cutoff) {
+			keep = append(keep, t)
+		}
+	}
+	if len(keep) >= l.limit {
+		// Oldest entry leaves the window at keep[0]+window; that is
+		// the earliest moment a new request can succeed.
+		retryAfter := keep[0].Add(l.window).Sub(now)
+		l.requests[key] = keep
+		return false, retryAfter, nil
+	}
+	keep = append(keep, now)
+	l.requests[key] = keep
+	return true, 0, nil
 }

--- a/backend/internal/ratelimit/middleware.go
+++ b/backend/internal/ratelimit/middleware.go
@@ -1,0 +1,17 @@
+package ratelimit
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+// KeyFunc resolves a request to its rate-limit bucket key.
+type KeyFunc func(r *http.Request) (key string, ok bool)
+
+// Middleware stub: passes everything through. Replaced by the GREEN
+// feat commit with allow/deny + 429 + Retry-After logic.
+func Middleware(_ Limiter, _ KeyFunc, _ *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return next
+	}
+}

--- a/backend/internal/ratelimit/middleware.go
+++ b/backend/internal/ratelimit/middleware.go
@@ -2,16 +2,56 @@ package ratelimit
 
 import (
 	"log/slog"
+	"math"
 	"net/http"
+	"strconv"
+
+	"github.com/daniil/floq/internal/httputil"
 )
 
-// KeyFunc resolves a request to its rate-limit bucket key.
+// KeyFunc resolves a request to its rate-limit bucket key. Returning
+// ok=false means "do not rate-limit this request" — the middleware
+// defers to the next handler. Production callers typically build the
+// key from the authenticated user_id so anonymous traffic (which
+// should not reach a rate-limited route in the first place) bypasses
+// the bucket rather than hammering one shared "anonymous" bucket.
 type KeyFunc func(r *http.Request) (key string, ok bool)
 
-// Middleware stub: passes everything through. Replaced by the GREEN
-// feat commit with allow/deny + 429 + Retry-After logic.
-func Middleware(_ Limiter, _ KeyFunc, _ *slog.Logger) func(http.Handler) http.Handler {
+// Middleware wires Limiter into the chi handler chain. On allow it
+// calls the next handler; on deny it answers 429 with a Retry-After
+// header (whole seconds, rounded up so a tight client retry loop
+// cannot beat the window edge). On Limiter error it logs and FAILS
+// OPEN: a Redis outage must not lock operators out of approving
+// urgent drafts. logger may be nil — slog.Default is used as fallback.
+func Middleware(l Limiter, keyFn KeyFunc, logger *slog.Logger) func(http.Handler) http.Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return func(next http.Handler) http.Handler {
-		return next
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key, ok := keyFn(r)
+			if !ok {
+				next.ServeHTTP(w, r)
+				return
+			}
+			allowed, retryAfter, err := l.Allow(r.Context(), key)
+			if err != nil {
+				logger.ErrorContext(r.Context(), "rate-limit check failed; failing open",
+					slog.String("key", key),
+					slog.Any("err", err))
+				next.ServeHTTP(w, r)
+				return
+			}
+			if !allowed {
+				retrySec := int(math.Ceil(retryAfter.Seconds()))
+				if retrySec < 1 {
+					retrySec = 1
+				}
+				w.Header().Set("Retry-After", strconv.Itoa(retrySec))
+				httputil.WriteError(w, http.StatusTooManyRequests, "rate limit exceeded")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
 	}
 }

--- a/backend/internal/ratelimit/middleware_test.go
+++ b/backend/internal/ratelimit/middleware_test.go
@@ -1,0 +1,164 @@
+package ratelimit_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/daniil/floq/internal/ratelimit"
+)
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func fixedKey(k string) ratelimit.KeyFunc {
+	return func(_ *http.Request) (string, bool) { return k, true }
+}
+
+func unkeyed() ratelimit.KeyFunc {
+	return func(_ *http.Request) (string, bool) { return "", false }
+}
+
+type erroringLimiter struct{}
+
+func (erroringLimiter) Allow(_ context.Context, _ string) (bool, time.Duration, error) {
+	return false, 0, errors.New("redis down")
+}
+
+func TestMiddleware_UnderLimitPassesThrough(t *testing.T) {
+	limiter := ratelimit.NewInMemoryLimiter(3, time.Minute)
+	mw := ratelimit.Middleware(limiter, fixedKey("u1"), nil)
+	handler := mw(okHandler())
+
+	for i := 0; i < 3; i++ {
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/x", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d: got %d, want 200", i+1, rr.Code)
+		}
+	}
+}
+
+func TestMiddleware_AtLimitReturns429WithRetryAfter(t *testing.T) {
+	limiter := ratelimit.NewInMemoryLimiter(3, time.Minute)
+	mw := ratelimit.Middleware(limiter, fixedKey("u1"), nil)
+	handler := mw(okHandler())
+
+	for i := 0; i < 3; i++ {
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/x", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("warm-up request %d: got %d, want 200", i+1, rr.Code)
+		}
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/x", nil))
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("4th request must be 429, got %d", rr.Code)
+	}
+	raw := rr.Header().Get("Retry-After")
+	if raw == "" {
+		t.Fatal("429 response must include Retry-After header")
+	}
+	retryAfter, err := strconv.Atoi(raw)
+	if err != nil {
+		t.Fatalf("Retry-After %q must be integer seconds: %v", raw, err)
+	}
+	if retryAfter < 1 || retryAfter > 60 {
+		t.Errorf("Retry-After = %d, want within 1..60 (whole seconds, within window)", retryAfter)
+	}
+}
+
+func TestMiddleware_PerKeyIsolated(t *testing.T) {
+	limiter := ratelimit.NewInMemoryLimiter(2, time.Minute)
+	handlerA := ratelimit.Middleware(limiter, fixedKey("uA"), nil)(okHandler())
+	handlerB := ratelimit.Middleware(limiter, fixedKey("uB"), nil)(okHandler())
+
+	// User A burns through the limit.
+	for i := 0; i < 2; i++ {
+		rr := httptest.NewRecorder()
+		handlerA.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/x", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("A request %d: got %d", i+1, rr.Code)
+		}
+	}
+	rr := httptest.NewRecorder()
+	handlerA.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/x", nil))
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("A's 3rd request must be blocked, got %d", rr.Code)
+	}
+
+	// User B must be untouched.
+	rr = httptest.NewRecorder()
+	handlerB.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/x", nil))
+	if rr.Code != http.StatusOK {
+		t.Errorf("user B got %d while user A was at limit — per-key isolation broken", rr.Code)
+	}
+}
+
+func TestMiddleware_LimiterErrorFailsOpen(t *testing.T) {
+	mw := ratelimit.Middleware(erroringLimiter{}, fixedKey("u1"), nil)
+	handler := mw(okHandler())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/x", nil))
+	if rr.Code != http.StatusOK {
+		t.Errorf("limiter error must fail-open (Redis outage cannot block legitimate operators); got %d", rr.Code)
+	}
+}
+
+func TestMiddleware_NoKeyBypassesLimit(t *testing.T) {
+	// Limit zero means "deny everything that the limiter sees". With
+	// an unkeyed request the middleware must NOT consult the limiter
+	// at all — defer to the next handler.
+	limiter := ratelimit.NewInMemoryLimiter(0, time.Minute)
+	mw := ratelimit.Middleware(limiter, unkeyed(), nil)
+	handler := mw(okHandler())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/x", nil))
+	if rr.Code != http.StatusOK {
+		t.Errorf("no-key request must bypass the limiter (deferred to next layer), got %d", rr.Code)
+	}
+}
+
+func TestInMemoryLimiter_AfterWindowAllowsAgain(t *testing.T) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+	limiter := ratelimit.NewInMemoryLimiterWithClock(2, time.Minute, clock)
+	ctx := context.Background()
+
+	allowed, _, err := limiter.Allow(ctx, "k")
+	if err != nil || !allowed {
+		t.Fatalf("1st must allow: allowed=%v err=%v", allowed, err)
+	}
+	allowed, _, err = limiter.Allow(ctx, "k")
+	if err != nil || !allowed {
+		t.Fatalf("2nd must allow: allowed=%v err=%v", allowed, err)
+	}
+	allowed, retryAfter, err := limiter.Allow(ctx, "k")
+	if err != nil {
+		t.Fatalf("3rd Allow err = %v", err)
+	}
+	if allowed {
+		t.Fatal("3rd must block — limit is 2")
+	}
+	if retryAfter <= 0 || retryAfter > time.Minute {
+		t.Errorf("retryAfter = %v, want 0..1m", retryAfter)
+	}
+
+	// Slide the clock past the window — slot frees up.
+	now = now.Add(time.Minute + time.Second)
+	allowed, _, err = limiter.Allow(ctx, "k")
+	if err != nil || !allowed {
+		t.Errorf("post-window request must allow: allowed=%v err=%v", allowed, err)
+	}
+}

--- a/backend/internal/ratelimit/port.go
+++ b/backend/internal/ratelimit/port.go
@@ -1,0 +1,20 @@
+// Package ratelimit provides a small per-key rate-limiter port and HTTP
+// middleware used to cap abuse on sensitive endpoints (initially the
+// HITL approve/reject pair). The port is intentionally narrow so an
+// in-memory adapter can satisfy unit tests and a Redis-backed adapter
+// can be plugged in at composition root for multi-instance deploys.
+package ratelimit
+
+import (
+	"context"
+	"time"
+)
+
+// Limiter is the abstract token-account check. Allow returns whether
+// the request keyed by key is permitted right now and, when denied,
+// the duration the caller should wait before retrying. Errors are
+// considered transient: the middleware fails open so an outage of the
+// backing store cannot lock legitimate operators out.
+type Limiter interface {
+	Allow(ctx context.Context, key string) (allowed bool, retryAfter time.Duration, err error)
+}

--- a/backend/internal/ratelimit/redis.go
+++ b/backend/internal/ratelimit/redis.go
@@ -55,20 +55,11 @@ type RedisLimiter struct {
 
 // NewRedisLimiter wires the limiter to a redis.UniversalClient (the
 // interface satisfied by both *redis.Client and *redis.ClusterClient).
-// Accepting `any` keeps the package free of forced type-assertions at
-// the call site — main.go passes its *redis.Client and the script
-// dispatcher does the rest.
-func NewRedisLimiter(client any, limit int, window time.Duration) *RedisLimiter {
-	uc, ok := client.(redis.UniversalClient)
-	if !ok {
-		// At construction time we cannot return an error — but the
-		// stub branch keeps the package safe: Allow will return an
-		// error, middleware fails open, and ops dashboards see the
-		// log line. main.go MUST pass a real client.
-		return &RedisLimiter{limit: limit, window: window}
-	}
+// Compile-time-typed so a wrong-type client at the call site fails
+// the build, not the rate-limit check at runtime.
+func NewRedisLimiter(client redis.UniversalClient, limit int, window time.Duration) *RedisLimiter {
 	return &RedisLimiter{
-		client: uc,
+		client: client,
 		limit:  limit,
 		window: window,
 		script: redis.NewScript(slidingWindowLua),

--- a/backend/internal/ratelimit/redis.go
+++ b/backend/internal/ratelimit/redis.go
@@ -2,26 +2,96 @@ package ratelimit
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 )
 
-// RedisLimiter — STUB awaiting GREEN feat commit. Wire shape is fixed
-// so the integration test file can reference it; Allow returns an
-// error so middleware fail-open kicks in until the real Lua impl
-// lands.
+// slidingWindowLua atomically drops entries older than the trailing
+// window, checks the remaining count against the limit, and either
+// records the new request (member = unique nonce so two requests in
+// the same millisecond cannot collide) or returns the milliseconds
+// the caller should wait before retrying.
+//
+// KEYS[1]  bucket key
+// ARGV[1]  now (unix ms)
+// ARGV[2]  window (ms)
+// ARGV[3]  limit
+// ARGV[4]  per-request nonce (any unique string)
+// returns  0 when allowed, >0 = retry-after ms when denied
+const slidingWindowLua = `
+local key    = KEYS[1]
+local now    = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local limit  = tonumber(ARGV[3])
+local nonce  = ARGV[4]
+
+redis.call('ZREMRANGEBYSCORE', key, '-inf', now - window)
+local count = redis.call('ZCARD', key)
+if count >= limit then
+  local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+  local oldest_score = tonumber(oldest[2])
+  local retry = oldest_score + window - now
+  if retry < 1 then retry = 1 end
+  return retry
+end
+redis.call('ZADD', key, now, nonce)
+redis.call('PEXPIRE', key, window)
+return 0
+`
+
+// RedisLimiter implements Limiter via a Redis ZSET acting as a
+// sliding-window log. The full check is one round-trip atomic Lua
+// invocation so concurrent Allow calls cannot race past the limit.
 type RedisLimiter struct {
+	client redis.UniversalClient
 	limit  int
 	window time.Duration
+	script *redis.Script
+	now    func() time.Time
 }
 
-// NewRedisLimiter stub: ignores the client so the package compiles
-// without a redis import on the RED step.
-func NewRedisLimiter(_ any, limit int, window time.Duration) *RedisLimiter {
-	return &RedisLimiter{limit: limit, window: window}
+// NewRedisLimiter wires the limiter to a redis.UniversalClient (the
+// interface satisfied by both *redis.Client and *redis.ClusterClient).
+// Accepting `any` keeps the package free of forced type-assertions at
+// the call site — main.go passes its *redis.Client and the script
+// dispatcher does the rest.
+func NewRedisLimiter(client any, limit int, window time.Duration) *RedisLimiter {
+	uc, ok := client.(redis.UniversalClient)
+	if !ok {
+		// At construction time we cannot return an error — but the
+		// stub branch keeps the package safe: Allow will return an
+		// error, middleware fails open, and ops dashboards see the
+		// log line. main.go MUST pass a real client.
+		return &RedisLimiter{limit: limit, window: window}
+	}
+	return &RedisLimiter{
+		client: uc,
+		limit:  limit,
+		window: window,
+		script: redis.NewScript(slidingWindowLua),
+		now:    time.Now,
+	}
 }
 
-// Allow stub: always errors.
-func (l *RedisLimiter) Allow(_ context.Context, _ string) (bool, time.Duration, error) {
-	return false, 0, errors.New("ratelimit: RedisLimiter not implemented")
+// Allow consults the Lua script. Errors from the client propagate so
+// the middleware can fail open and a Redis outage does not cascade
+// into operator lockout.
+func (l *RedisLimiter) Allow(ctx context.Context, key string) (bool, time.Duration, error) {
+	if l.client == nil || l.script == nil {
+		return false, 0, fmt.Errorf("ratelimit: RedisLimiter constructed without a redis client")
+	}
+	nowMs := l.now().UnixMilli()
+	windowMs := l.window.Milliseconds()
+	nonce := uuid.NewString()
+	res, err := l.script.Run(ctx, l.client, []string{key}, nowMs, windowMs, l.limit, nonce).Int64()
+	if err != nil {
+		return false, 0, fmt.Errorf("ratelimit: redis script: %w", err)
+	}
+	if res == 0 {
+		return true, 0, nil
+	}
+	return false, time.Duration(res) * time.Millisecond, nil
 }

--- a/backend/internal/ratelimit/redis.go
+++ b/backend/internal/ratelimit/redis.go
@@ -1,0 +1,27 @@
+package ratelimit
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// RedisLimiter — STUB awaiting GREEN feat commit. Wire shape is fixed
+// so the integration test file can reference it; Allow returns an
+// error so middleware fail-open kicks in until the real Lua impl
+// lands.
+type RedisLimiter struct {
+	limit  int
+	window time.Duration
+}
+
+// NewRedisLimiter stub: ignores the client so the package compiles
+// without a redis import on the RED step.
+func NewRedisLimiter(_ any, limit int, window time.Duration) *RedisLimiter {
+	return &RedisLimiter{limit: limit, window: window}
+}
+
+// Allow stub: always errors.
+func (l *RedisLimiter) Allow(_ context.Context, _ string) (bool, time.Duration, error) {
+	return false, 0, errors.New("ratelimit: RedisLimiter not implemented")
+}

--- a/backend/internal/ratelimit/redis_test.go
+++ b/backend/internal/ratelimit/redis_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package ratelimit_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/daniil/floq/internal/ratelimit"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// redisDSN mirrors the rest of the integration suite — local docker-
+// compose redis on 6379. REDIS_URL env override is honoured so CI can
+// point at its own service container.
+func redisDSN() string {
+	if v := os.Getenv("REDIS_URL"); v != "" {
+		return v
+	}
+	return "redis://localhost:6379"
+}
+
+func testRedisClient(t *testing.T) *redis.Client {
+	t.Helper()
+	opt, err := redis.ParseURL(redisDSN())
+	require.NoError(t, err, "parse redis DSN")
+	client := redis.NewClient(opt)
+	require.NoError(t, client.Ping(context.Background()).Err(), "ping redis")
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+// uniqueKey isolates test buckets so parallel test runs (and reruns
+// without manual FLUSHDB) cannot collide. Cleanup deletes the bucket
+// after the test even on failure.
+func uniqueKey(t *testing.T, client *redis.Client, suffix string) string {
+	t.Helper()
+	key := "ratelimit-test:" + t.Name() + ":" + suffix
+	t.Cleanup(func() { _ = client.Del(context.Background(), key).Err() })
+	return key
+}
+
+func TestRedisLimiter_AllowsUnderLimit(t *testing.T) {
+	client := testRedisClient(t)
+	limiter := ratelimit.NewRedisLimiter(client, 3, time.Minute)
+	key := uniqueKey(t, client, "under")
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		allowed, retryAfter, err := limiter.Allow(ctx, key)
+		require.NoError(t, err)
+		assert.True(t, allowed, "request %d must be allowed (under limit)", i+1)
+		assert.Equal(t, time.Duration(0), retryAfter, "allowed request must report zero retry-after")
+	}
+}
+
+func TestRedisLimiter_BlocksAtLimit(t *testing.T) {
+	client := testRedisClient(t)
+	limiter := ratelimit.NewRedisLimiter(client, 3, time.Minute)
+	key := uniqueKey(t, client, "block")
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		allowed, _, err := limiter.Allow(ctx, key)
+		require.NoError(t, err)
+		require.True(t, allowed, "warm-up %d must be allowed", i+1)
+	}
+
+	allowed, retryAfter, err := limiter.Allow(ctx, key)
+	require.NoError(t, err)
+	assert.False(t, allowed, "4th request must be blocked")
+	assert.Greater(t, retryAfter, time.Duration(0), "blocked request must report positive retry-after")
+	assert.LessOrEqual(t, retryAfter, time.Minute, "retry-after cannot exceed the window")
+}
+
+func TestRedisLimiter_PerKeyIsolated(t *testing.T) {
+	client := testRedisClient(t)
+	limiter := ratelimit.NewRedisLimiter(client, 2, time.Minute)
+	keyA := uniqueKey(t, client, "userA")
+	keyB := uniqueKey(t, client, "userB")
+	ctx := context.Background()
+
+	// Burn through A's limit.
+	for i := 0; i < 2; i++ {
+		allowed, _, err := limiter.Allow(ctx, keyA)
+		require.NoError(t, err)
+		require.True(t, allowed)
+	}
+	allowed, _, err := limiter.Allow(ctx, keyA)
+	require.NoError(t, err)
+	require.False(t, allowed, "A's 3rd must be blocked")
+
+	// B must still pass.
+	allowed, _, err = limiter.Allow(ctx, keyB)
+	require.NoError(t, err)
+	assert.True(t, allowed, "B must not be affected by A's exhausted bucket")
+}
+
+func TestRedisLimiter_ShortWindowExpires(t *testing.T) {
+	// Real-clock test of the sliding-window expiry path. Uses a small
+	// window (200 ms) so the test finishes in under a second.
+	client := testRedisClient(t)
+	limiter := ratelimit.NewRedisLimiter(client, 1, 200*time.Millisecond)
+	key := uniqueKey(t, client, "expire")
+	ctx := context.Background()
+
+	allowed, _, err := limiter.Allow(ctx, key)
+	require.NoError(t, err)
+	require.True(t, allowed, "1st must allow")
+
+	allowed, _, err = limiter.Allow(ctx, key)
+	require.NoError(t, err)
+	require.False(t, allowed, "2nd must block — limit is 1")
+
+	time.Sleep(250 * time.Millisecond)
+
+	allowed, _, err = limiter.Allow(ctx, key)
+	require.NoError(t, err)
+	assert.True(t, allowed, "post-window request must be allowed again")
+}
+
+func TestRedisLimiter_SameMillisecondRequestsDoNotCollideOnZADDMember(t *testing.T) {
+	// Subtle Redis ZSET bug if member == score: two requests in the
+	// same millisecond would overwrite each other and the second
+	// would escape the count. Use a nonce-per-request member to keep
+	// every Allow distinct. Replay by firing 5 requests in a tight
+	// loop with limit=3 — exactly 3 must be allowed, 2 blocked.
+	client := testRedisClient(t)
+	limiter := ratelimit.NewRedisLimiter(client, 3, time.Minute)
+	key := uniqueKey(t, client, "tight")
+	ctx := context.Background()
+
+	allowedCount := 0
+	for i := 0; i < 5; i++ {
+		allowed, _, err := limiter.Allow(ctx, key)
+		require.NoError(t, err)
+		if allowed {
+			allowedCount++
+		}
+	}
+	assert.Equal(t, 3, allowedCount, "exactly limit-count requests must be allowed; collisions would let extras escape")
+}


### PR DESCRIPTION
Closes #46.

## Summary

- New `internal/ratelimit/` package: narrow `Limiter` port + in-memory adapter (single-instance / unit tests) + Redis adapter (multi-instance, atomic Lua sliding-window log) + HTTP middleware (429 + `Retry-After`, fails open on backing-store errors).
- `inbox.RegisterPendingReplyRoutes` gets a 4th param `decideMW`; applied only to POST approve/reject (GET listing stays unlimited — idempotent UI refresh must not be throttled).
- `main.go` constructs the limiter at startup. Redis-backed when `REDIS_URL` is set, falls back to in-process otherwise. Budget configurable via `RATE_LIMIT_PENDING_REPLIES_PER_MIN` (default 30).
- ZADD member is a per-request UUID nonce, not the timestamp — two requests in the same millisecond cannot collapse into one ZSET entry and let the second escape the count.

## Test plan

- [x] Unit (6 scenarios): under-limit pass, at-limit 429 + Retry-After header (integer seconds, within window), per-key isolation, Limiter-error fail-open, no-key bypass, clock-injectable sliding-window rollover.
- [x] Integration (5 scenarios, build tag `integration`): under-limit, at-limit block + retryAfter > 0, per-key isolation, real-clock 200ms window expiry, same-millisecond burst (5 against limit=3 → exactly 3 allowed — pins the nonce-member fix).
- [ ] Live Redis prove-out on CI runner (local OrbStack offline; Lua syntax verified by reading only).

## Review trail

`superpowers:code-reviewer` round 1: TDD 9 / DDD 9 / CA 9 / Enterprise 8 — fix-up needed for Enterprise ≥9.

Round-1 fix-up landed in `12160d4`:
- Budget via `RATE_LIMIT_PENDING_REPLIES_PER_MIN` env var (replaces hardcoded constant)
- `pendingReplyKeyFn` documents the auth-ordering invariant (middleware MUST sit behind auth.AuthMiddleware or it silently bypasses)
- `NewRedisLimiter` typed as `redis.UniversalClient` instead of `any`+runtime-assertion (compile-time fail vs silent-stub fallback)

## Non-blocker follow-ups
- HTTP-level integration test (chi-router + auth + ratelimit + handler end-to-end) would close acceptance criteria with a single test instead of layered coverage. Out of scope here; can be a follow-up issue if useful.
- Ops alerting on the "rate-limit check failed; failing open" log line — operational concern, not code.