### PR TITLE
feat(outbound): Idempotency-Key + retry on Resend POST

### DIFF
--- a/backend/internal/outbound/errors_test.go
+++ b/backend/internal/outbound/errors_test.go
@@ -20,7 +20,7 @@ func TestSendViaResend_NoAPIKey_ReturnsErrNoResendAPIKey(t *testing.T) {
 		"", "", "", "",
 		nil, nil, nil, nil, nil, nil)
 
-	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body")
+	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body", "")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrNoResendAPIKey),
 		"expected errors.Is to match ErrNoResendAPIKey, got: %v", err)
@@ -42,7 +42,7 @@ func TestSendViaResend_HTTP400_WrapsErrResendAPI(t *testing.T) {
 		"", "", "", "",
 		nil, nil, nil, nil, nil, nil)
 
-	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body")
+	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body", "")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrResendAPI),
 		"expected errors.Is to match ErrResendAPI, got: %v", err)
@@ -63,7 +63,7 @@ func TestSendViaResend_HTTP500_WrapsErrResendAPI(t *testing.T) {
 		"", "", "", "",
 		nil, nil, nil, nil, nil, nil)
 
-	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body")
+	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body", "")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrResendAPI),
 		"expected errors.Is to match ErrResendAPI on 500, got: %v", err)
@@ -85,7 +85,7 @@ func TestSendViaResend_HTTP200_NoError(t *testing.T) {
 		"", "", "", "",
 		nil, nil, nil, nil, nil, nil)
 
-	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body")
+	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body", "")
 	assert.NoError(t, err)
 }
 
@@ -104,7 +104,7 @@ func TestResendAPIError_CarriesStatusCode(t *testing.T) {
 		"", "", "", "",
 		nil, nil, nil, nil, nil, nil)
 
-	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body")
+	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body", "")
 	require.Error(t, err)
 
 	var apiErr *ResendAPIError
@@ -130,7 +130,7 @@ func TestSendViaResend_NetworkError_NotResendAPIError(t *testing.T) {
 		"", "", "", "",
 		nil, nil, nil, nil, nil, nil)
 
-	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body")
+	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body", "")
 	require.Error(t, err)
 	assert.False(t, errors.Is(err, ErrResendAPI),
 		"network error must not be classified as a Resend API protocol error")

--- a/backend/internal/outbound/idempotency_test.go
+++ b/backend/internal/outbound/idempotency_test.go
@@ -140,6 +140,33 @@ func TestSendViaResend_StopsAfterMaxAttemptsOn5xx(t *testing.T) {
 	}
 }
 
+func TestSendViaResend_RetriesOn429RateLimit(t *testing.T) {
+	// 429 is transient (rate-limit), not a client mistake. Same
+	// Idempotency-Key is safe to retry — Resend dedups if the
+	// original eventually landed. Pin: 429 → 200 collapses into
+	// success after 2 attempts.
+	attempt := 0
+	c, cleanup := stubResend(t, func(w http.ResponseWriter, _ *http.Request) {
+		attempt++
+		if attempt == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"msg_x"}`)
+	})
+	defer cleanup()
+
+	cfgStore := &mockConfigStore{cfg: &settingsdomain.UserConfig{}}
+	s := NewSender(cfgStore, uuid.New(), "test-key", "from@test.com", "",
+		"", "", "", "",
+		nil, nil, nil, nil, nil, nil)
+
+	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body", "outbound:rate-1")
+	require.NoError(t, err, "429 must be retried as transient; second attempt succeeds")
+	assert.Equal(t, 2, c.calls(), "expected exactly 2 attempts on 429 → 200")
+}
+
 func TestSendViaResend_DoesNotRetryOn4xx(t *testing.T) {
 	// 4xx is a client error (bad payload, bad auth, etc.) — retrying
 	// with the same Idempotency-Key and the same body cannot fix

--- a/backend/internal/outbound/idempotency_test.go
+++ b/backend/internal/outbound/idempotency_test.go
@@ -87,6 +87,78 @@ func TestSendViaResend_SendsIdempotencyKeyHeader(t *testing.T) {
 		"every Resend POST must carry the supplied Idempotency-Key verbatim — Resend dedups retries by this header")
 }
 
+func TestSendViaResend_RetriesOn5xxAndSucceeds(t *testing.T) {
+	// First attempt: 503 (transient). Second: 200. With a stable
+	// Idempotency-Key on both attempts, Resend dedups server-side —
+	// our retry is safe. Test pins: success returned, exactly 2 calls,
+	// same key on both.
+	attempt := 0
+	c, cleanup := stubResend(t, func(w http.ResponseWriter, _ *http.Request) {
+		attempt++
+		if attempt == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"msg_x"}`)
+	})
+	defer cleanup()
+
+	cfgStore := &mockConfigStore{cfg: &settingsdomain.UserConfig{}}
+	s := NewSender(cfgStore, uuid.New(), "test-key", "from@test.com", "",
+		"", "", "", "",
+		nil, nil, nil, nil, nil, nil)
+
+	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body", "outbound:retry-1")
+	require.NoError(t, err, "second attempt must succeed; retry loop must absorb the transient 503")
+	assert.Equal(t, 2, c.calls(), "expected exactly 2 attempts (1 fail + 1 success)")
+
+	keys := c.idempotencyKeys()
+	require.Len(t, keys, 2)
+	assert.Equal(t, keys[0], keys[1],
+		"Idempotency-Key MUST be stable across retry attempts — otherwise Resend cannot dedup and we lose the safety we just added")
+	assert.Equal(t, "outbound:retry-1", keys[0])
+}
+
+func TestSendViaResend_StopsAfterMaxAttemptsOn5xx(t *testing.T) {
+	c, cleanup := stubResend(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer cleanup()
+
+	cfgStore := &mockConfigStore{cfg: &settingsdomain.UserConfig{}}
+	s := NewSender(cfgStore, uuid.New(), "test-key", "from@test.com", "",
+		"", "", "", "",
+		nil, nil, nil, nil, nil, nil)
+
+	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body", "outbound:stuck")
+	require.Error(t, err, "consecutive 5xx must surface after max attempts; retry cannot loop forever")
+
+	got := c.calls()
+	if got != 3 {
+		t.Errorf("expected 3 attempts before giving up, got %d", got)
+	}
+}
+
+func TestSendViaResend_DoesNotRetryOn4xx(t *testing.T) {
+	// 4xx is a client error (bad payload, bad auth, etc.) — retrying
+	// with the same Idempotency-Key and the same body cannot fix
+	// the client mistake and just burns rate-limit budget on Resend.
+	c, cleanup := stubResend(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	})
+	defer cleanup()
+
+	cfgStore := &mockConfigStore{cfg: &settingsdomain.UserConfig{}}
+	s := NewSender(cfgStore, uuid.New(), "test-key", "from@test.com", "",
+		"", "", "", "",
+		nil, nil, nil, nil, nil, nil)
+
+	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body", "outbound:bad")
+	require.Error(t, err)
+	assert.Equal(t, 1, c.calls(), "4xx must NOT retry — same body + same key cannot succeed on attempt 2")
+}
+
 func TestSendPending_UsesMessageIDAsIdempotencyKey(t *testing.T) {
 	// SendPending end-to-end: drains one approved outbound row, calls
 	// sendViaResend with an Idempotency-Key derived from the row ID.

--- a/backend/internal/outbound/idempotency_test.go
+++ b/backend/internal/outbound/idempotency_test.go
@@ -1,0 +1,131 @@
+package outbound
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	prospectsdomain "github.com/daniil/floq/internal/prospects/domain"
+	seqdomain "github.com/daniil/floq/internal/sequences/domain"
+	settingsdomain "github.com/daniil/floq/internal/settings/domain"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captured collects header + body of every request hitting the Resend
+// stub so tests can pin both presence and stability of the
+// Idempotency-Key across attempts.
+type captured struct {
+	mu      sync.Mutex
+	headers []http.Header
+}
+
+func (c *captured) record(h http.Header) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	clone := h.Clone()
+	c.headers = append(c.headers, clone)
+}
+
+func (c *captured) calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.headers)
+}
+
+func (c *captured) idempotencyKeys() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	keys := make([]string, 0, len(c.headers))
+	for _, h := range c.headers {
+		keys = append(keys, h.Get("Idempotency-Key"))
+	}
+	return keys
+}
+
+// stubResend swaps the package-level resendAPIURL for a httptest server
+// driven by handler. Returns the captured tape and a cleanup func.
+func stubResend(t *testing.T, handler http.HandlerFunc) (*captured, func()) {
+	t.Helper()
+	c := &captured{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.record(r.Header)
+		handler(w, r)
+	}))
+	old := resendAPIURL
+	resendAPIURL = server.URL
+	cleanup := func() {
+		resendAPIURL = old
+		server.Close()
+	}
+	return c, cleanup
+}
+
+func TestSendViaResend_SendsIdempotencyKeyHeader(t *testing.T) {
+	c, cleanup := stubResend(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"msg_x"}`)
+	})
+	defer cleanup()
+
+	cfgStore := &mockConfigStore{cfg: &settingsdomain.UserConfig{}}
+	s := NewSender(cfgStore, uuid.New(), "test-key", "from@test.com", "",
+		"", "", "", "",
+		nil, nil, nil, nil, nil, nil)
+
+	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body", "outbound:abc-123")
+	require.NoError(t, err)
+
+	keys := c.idempotencyKeys()
+	require.Len(t, keys, 1, "exactly one Resend POST expected")
+	assert.Equal(t, "outbound:abc-123", keys[0],
+		"every Resend POST must carry the supplied Idempotency-Key verbatim — Resend dedups retries by this header")
+}
+
+func TestSendPending_UsesMessageIDAsIdempotencyKey(t *testing.T) {
+	// SendPending end-to-end: drains one approved outbound row, calls
+	// sendViaResend with an Idempotency-Key derived from the row ID.
+	// Pins the wire contract: an attacker who guesses the next msg.ID
+	// cannot replay; a retry of the same msg.ID hits Resend's dedup.
+	c, cleanup := stubResend(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"msg_x"}`)
+	})
+	defer cleanup()
+
+	prospectID := uuid.New()
+	msgID := uuid.New()
+
+	seqRepo := &mockOutboundRepository{
+		pending: []seqdomain.OutboundMessage{{
+			ID:         msgID,
+			ProspectID: prospectID,
+			Channel:    seqdomain.StepChannelEmail,
+			Status:     seqdomain.OutboundStatusApproved,
+			Body:       "<p>hi</p>",
+		}},
+	}
+	prospectRepo := &mockProspectLookup{
+		prospects: map[uuid.UUID]*prospectsdomain.Prospect{
+			prospectID: {ID: prospectID, Name: "Alice", Company: "Acme", Email: "alice@acme.com"},
+		},
+	}
+	cfgStore := &mockConfigStore{cfg: &settingsdomain.UserConfig{ResendAPIKey: "test-key"}}
+
+	s := NewSender(cfgStore, uuid.New(), "fallback-key", "from@test.com", "",
+		"", "", "", "", // no SMTP — falls through to Resend
+		seqRepo, prospectRepo, nil, nil, nil, nil)
+
+	require.NoError(t, s.SendPending(context.Background()))
+	require.Equal(t, 1, c.calls(), "expected exactly one Resend call for one pending row")
+
+	keys := c.idempotencyKeys()
+	require.Len(t, keys, 1)
+	assert.True(t, strings.Contains(keys[0], msgID.String()),
+		"Idempotency-Key %q must contain the message UUID so retries of the same row collapse server-side", keys[0])
+}

--- a/backend/internal/outbound/sender.go
+++ b/backend/internal/outbound/sender.go
@@ -6,7 +6,9 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/smtp"
@@ -127,7 +129,7 @@ func (s *Sender) SendPending(ctx context.Context) error {
 		if smtpHost != "" && smtpUser != "" && smtpPassword != "" {
 			sendErr = s.sendViaSMTPWith(ctx, smtpHost, smtpPort, smtpUser, smtpPassword, fromAddr, prospect.Email, subject, htmlBody)
 		} else {
-			sendErr = s.sendViaResend(ctx, prospect.Email, subject, htmlBody, "outbound:"+msg.ID.String())
+			sendErr = s.sendViaResend(ctx, prospect.Email, subject, htmlBody, idempotencyKeyPrefix+msg.ID.String())
 		}
 
 		if sendErr != nil {
@@ -168,6 +170,15 @@ func (s *Sender) SendPending(ctx context.Context) error {
 }
 
 // sendViaSMTPWith sends email through an SMTP server (mail.ru, Yandex, Gmail, etc.)
+//
+// UNLIKE sendViaResend, the SMTP path has no retry and no idempotency
+// guarantee. SMTP-level dedup would require a stable Message-ID header
+// plus cooperation from every receiving MTA's duplicate-detection (or
+// our own server-side tracking of which Message-IDs have already been
+// SMTP-handed-off). Neither is implemented. A timeout between SMTP
+// handoff and ack on this path may result in duplicate delivery on a
+// subsequent cron tick that re-fetches the same row. Tracked as a
+// known gap; the Resend path (the production default) is safe.
 func (s *Sender) sendViaSMTPWith(ctx context.Context, host, port, user, password, from, to, subject, htmlBody string) error {
 	if from == "" {
 		from = user
@@ -376,9 +387,15 @@ func (s *Sender) handleTelegramMessage(ctx context.Context, msg seqdomain.Outbou
 const resendMaxAttempts = 3
 
 // resendInitialBackoff is the wait before the second attempt; doubled
-// for the third. Total worst-case wait = 200 + 400 = 600 ms, well
-// under the cron tick budget.
+// for the third. Total worst-case wait = 200 + 400 = 600 ms (plus up
+// to ~50% jitter), well under the cron tick budget.
 const resendInitialBackoff = 200 * time.Millisecond
+
+// idempotencyKeyPrefix namespaces the Resend Idempotency-Key so it is
+// identifiable in the Resend dashboard and so a future second caller
+// (e.g. transactional emails outside the outbound cron) cannot
+// collide with cron-row keys for free.
+const idempotencyKeyPrefix = "outbound:"
 
 // sendViaResend sends email through the Resend API using raw HTTP.
 // idempotencyKey is forwarded as the "Idempotency-Key" header so that
@@ -432,36 +449,54 @@ func (s *Sender) sendViaResend(ctx context.Context, to, subject, htmlBody, idemp
 			if attempt == resendMaxAttempts {
 				return lastErr
 			}
-			if werr := waitWithCtx(ctx, backoff); werr != nil {
+			if werr := waitWithCtx(ctx, jitter(backoff)); werr != nil {
 				return werr
 			}
 			backoff *= 2
 			continue
 		}
-		// Drain + close so the connection can be reused on the next
-		// attempt. Body is small (Resend returns a short JSON ack).
+		// Drain the response body before Close so the underlying TCP
+		// connection can be returned to the keep-alive pool. Resend
+		// 5xx may carry a hundred-byte JSON error envelope; without
+		// the drain the transport opens a fresh TCP+TLS handshake on
+		// every retry attempt.
+		_, _ = io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 
-		if resp.StatusCode >= 500 && resp.StatusCode < 600 {
+		// 429 — transient (rate-limit). Same Idempotency-Key is safe
+		// to retry; Resend will dedup if the original eventually
+		// landed. Handle BEFORE the generic 4xx-terminal branch.
+		retryable := (resp.StatusCode >= 500 && resp.StatusCode < 600) || resp.StatusCode == http.StatusTooManyRequests
+		if retryable {
 			lastErr = &ResendAPIError{StatusCode: resp.StatusCode}
 			if attempt == resendMaxAttempts {
 				return lastErr
 			}
-			if werr := waitWithCtx(ctx, backoff); werr != nil {
+			if werr := waitWithCtx(ctx, jitter(backoff)); werr != nil {
 				return werr
 			}
 			backoff *= 2
 			continue
 		}
 		if resp.StatusCode >= 400 {
-			// 4xx — client error. Same body + same Idempotency-Key
-			// will fail the same way; retry burns rate-limit budget
-			// without changing the outcome.
+			// 4xx (other than 429) — client error. Same body + same
+			// Idempotency-Key will fail the same way; retry burns
+			// rate-limit budget without changing the outcome.
 			return &ResendAPIError{StatusCode: resp.StatusCode}
 		}
 		return nil
 	}
 	return lastErr
+}
+
+// jitter spreads backoffs across [d, d*1.5) so multiple senders (or
+// tenants) restarting after a Resend outage do not synchronise on the
+// retry edge and re-thunder the herd.
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+	return d + time.Duration(rand.Int64N(int64(d)/2))
 }
 
 // waitWithCtx sleeps for d unless the context is cancelled first.

--- a/backend/internal/outbound/sender.go
+++ b/backend/internal/outbound/sender.go
@@ -127,7 +127,7 @@ func (s *Sender) SendPending(ctx context.Context) error {
 		if smtpHost != "" && smtpUser != "" && smtpPassword != "" {
 			sendErr = s.sendViaSMTPWith(ctx, smtpHost, smtpPort, smtpUser, smtpPassword, fromAddr, prospect.Email, subject, htmlBody)
 		} else {
-			sendErr = s.sendViaResend(ctx, prospect.Email, subject, htmlBody)
+			sendErr = s.sendViaResend(ctx, prospect.Email, subject, htmlBody, "outbound:"+msg.ID.String())
 		}
 
 		if sendErr != nil {
@@ -371,7 +371,12 @@ func (s *Sender) handleTelegramMessage(ctx context.Context, msg seqdomain.Outbou
 }
 
 // sendViaResend sends email through the Resend API using raw HTTP.
-func (s *Sender) sendViaResend(ctx context.Context, to, subject, htmlBody string) error {
+// idempotencyKey is forwarded as the "Idempotency-Key" header so that
+// retries of the same outbound row collapse to a single delivery on
+// Resend's side (https://resend.com/docs/api-reference/idempotency).
+// An empty key is allowed but unsafe — callers should always pass a
+// stable per-message value (e.g. "outbound:<message_id>").
+func (s *Sender) sendViaResend(ctx context.Context, to, subject, htmlBody, idempotencyKey string) error {
 	apiKey := s.fallbackKey
 	if cfg, err := s.store.GetConfig(ctx, s.ownerID); err == nil {
 		apiKey = settingsdomain.ResolveConfig(cfg.ResendAPIKey, apiKey)
@@ -393,6 +398,9 @@ func (s *Sender) sendViaResend(ctx context.Context, to, subject, htmlBody string
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
+	if idempotencyKey != "" {
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+	}
 
 	client := s.httpClient
 	if client == nil {

--- a/backend/internal/outbound/sender.go
+++ b/backend/internal/outbound/sender.go
@@ -370,12 +370,26 @@ func (s *Sender) handleTelegramMessage(ctx context.Context, msg seqdomain.Outbou
 	log.Printf("[outbound] sent telegram message to %s (msg %s)", prospect.Phone, msg.ID)
 }
 
+// resendMaxAttempts caps retries at 3 — first try + two backoffs. Any
+// more and the cron tick gets stuck behind a single sticky 5xx; any
+// less and one transient blip surfaces as a hard send failure.
+const resendMaxAttempts = 3
+
+// resendInitialBackoff is the wait before the second attempt; doubled
+// for the third. Total worst-case wait = 200 + 400 = 600 ms, well
+// under the cron tick budget.
+const resendInitialBackoff = 200 * time.Millisecond
+
 // sendViaResend sends email through the Resend API using raw HTTP.
 // idempotencyKey is forwarded as the "Idempotency-Key" header so that
 // retries of the same outbound row collapse to a single delivery on
 // Resend's side (https://resend.com/docs/api-reference/idempotency).
 // An empty key is allowed but unsafe — callers should always pass a
 // stable per-message value (e.g. "outbound:<message_id>").
+//
+// Retries up to resendMaxAttempts on transport errors and 5xx
+// responses with exponential backoff. 4xx is treated as terminal —
+// same body + same key cannot succeed by trying again.
 func (s *Sender) sendViaResend(ctx context.Context, to, subject, htmlBody, idempotencyKey string) error {
 	apiKey := s.fallbackKey
 	if cfg, err := s.store.GetConfig(ctx, s.ownerID); err == nil {
@@ -392,28 +406,72 @@ func (s *Sender) sendViaResend(ctx context.Context, to, subject, htmlBody, idemp
 		"html":    htmlBody,
 	})
 
-	req, err := http.NewRequestWithContext(ctx, "POST", resendAPIURL, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("resend request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	if idempotencyKey != "" {
-		req.Header.Set("Idempotency-Key", idempotencyKey)
-	}
-
 	client := s.httpClient
 	if client == nil {
 		client = http.DefaultClient
 	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("resend send: %w", err)
-	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode >= 400 {
-		return &ResendAPIError{StatusCode: resp.StatusCode}
+	var lastErr error
+	backoff := resendInitialBackoff
+	for attempt := 1; attempt <= resendMaxAttempts; attempt++ {
+		// New Request per attempt — bytes.Reader has an internal
+		// cursor that is exhausted by the previous client.Do.
+		req, err := http.NewRequestWithContext(ctx, "POST", resendAPIURL, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("resend request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		req.Header.Set("Content-Type", "application/json")
+		if idempotencyKey != "" {
+			req.Header.Set("Idempotency-Key", idempotencyKey)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("resend send (attempt %d): %w", attempt, err)
+			if attempt == resendMaxAttempts {
+				return lastErr
+			}
+			if werr := waitWithCtx(ctx, backoff); werr != nil {
+				return werr
+			}
+			backoff *= 2
+			continue
+		}
+		// Drain + close so the connection can be reused on the next
+		// attempt. Body is small (Resend returns a short JSON ack).
+		resp.Body.Close()
+
+		if resp.StatusCode >= 500 && resp.StatusCode < 600 {
+			lastErr = &ResendAPIError{StatusCode: resp.StatusCode}
+			if attempt == resendMaxAttempts {
+				return lastErr
+			}
+			if werr := waitWithCtx(ctx, backoff); werr != nil {
+				return werr
+			}
+			backoff *= 2
+			continue
+		}
+		if resp.StatusCode >= 400 {
+			// 4xx — client error. Same body + same Idempotency-Key
+			// will fail the same way; retry burns rate-limit budget
+			// without changing the outcome.
+			return &ResendAPIError{StatusCode: resp.StatusCode}
+		}
+		return nil
 	}
-	return nil
+	return lastErr
+}
+
+// waitWithCtx sleeps for d unless the context is cancelled first.
+// Lets the retry loop honour cron shutdown without leaving a goroutine
+// blocked in the middle of a backoff.
+func waitWithCtx(ctx context.Context, d time.Duration) error {
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/backend/internal/outbound/sender_test.go
+++ b/backend/internal/outbound/sender_test.go
@@ -1185,7 +1185,7 @@ func TestSendViaResend_NoKey(t *testing.T) {
 		"", "", "", "",
 		nil, nil, nil, nil, nil, nil)
 
-	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body")
+	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body", "")
 	if !errors.Is(err, ErrNoResendAPIKey) {
 		t.Fatalf("expected errors.Is to match ErrNoResendAPIKey, got: %v", err)
 	}
@@ -1197,7 +1197,7 @@ func TestSendViaResend_ConfigStoreError(t *testing.T) {
 		"", "", "", "",
 		nil, nil, nil, nil, nil, nil)
 
-	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body")
+	err := s.sendViaResend(context.Background(), "to@test.com", "subj", "body", "")
 	if !errors.Is(err, ErrNoResendAPIKey) {
 		t.Fatalf("expected errors.Is to match ErrNoResendAPIKey, got: %v", err)
 	}


### PR DESCRIPTION
Closes #56 (P0-4).

## Summary

- Every `POST https://api.resend.com/emails` now carries `Idempotency-Key: outbound:<msg.ID>`. Resend dedups retries server-side per the row UUID, so a network blip between request-sent and response-received no longer double-delivers.
- Bounded retry: up to 3 attempts with exponential backoff (200ms → 400ms, jittered to ~50%) on 5xx, 429, and transport errors. 4xx (other than 429) stays terminal.
- Response body drained before close so TCP keep-alive is preserved between attempts — sticky 5xx no longer opens a fresh TLS handshake every retry.
- Backoff sleep is ctx-interruptible — cron shutdown does not leave a goroutine blocked in `time.After`.
- SMTP fallback path explicitly documents the dedup/retry gap (Message-ID dedup unimplemented; SMTP retry could double-deliver).

## Test plan

- [x] Unit (5 scenarios via httptest tape recorder): header presence + verbatim value, end-to-end through `SendPending` carries `msg.ID`, 503→200 retries to success, 3×503 stops after max attempts, 429 retried (transient), 4xx terminal.
- [x] Full `internal/outbound/` suite (~30 existing tests) green after signature update.
- [x] `go vet -tags=integration ./...` clean.

## Review trail

`superpowers:code-reviewer` round 1: TDD 9 / DDD 9 / CA 9 / Enterprise 7 — fix-up needed for Enterprise ≥9.

Round-1 fix-up landed in `00e068c`:
- `io.Copy(io.Discard, resp.Body)` before Close — preserves keep-alive (must-fix)
- 429 pulled out of 4xx-terminal branch into retryable (must-fix)
- SMTP godoc-block documenting intentional retry/dedup gap (must-fix; acceptance item 4 of #56)
- Backoff jitter spread `[d, d*1.5)` against thundering herd (should-fix)
- `idempotencyKeyPrefix = "outbound:"` const eliminating magic strings (should-fix)