### PR TITLE
feat(inbox/hitl): decided_by operator attribution on pending_replies

### DIFF
--- a/backend/internal/inbox/handler.go
+++ b/backend/internal/inbox/handler.go
@@ -149,6 +149,10 @@ func (h *pendingReplyHandler) decide(op func(uc PendingReplyUseCaseAPI, ctx cont
 // is intentionally separate from the domain entity so transport-layer
 // concerns (JSON tags, timestamp formatting) do not bleed into the
 // inbox package surface.
+//
+// DecidedBy is omitempty so rows from before migration 032 (when the
+// column did not exist) stay clean on the wire — a missing field
+// signals "attribution unknown" rather than synthesising a UUID.
 type PendingReplyResponse struct {
 	ID        string  `json:"id"`
 	LeadID    string  `json:"lead_id"`
@@ -158,6 +162,7 @@ type PendingReplyResponse struct {
 	Status    string  `json:"status"`
 	CreatedAt string  `json:"created_at"`
 	DecidedAt *string `json:"decided_at,omitempty"`
+	DecidedBy *string `json:"decided_by,omitempty"`
 	SentAt    *string `json:"sent_at,omitempty"`
 }
 
@@ -174,6 +179,10 @@ func pendingReplyToResponse(pr *PendingReply) PendingReplyResponse {
 	if pr.DecidedAt != nil {
 		s := pr.DecidedAt.UTC().Format(time.RFC3339)
 		resp.DecidedAt = &s
+	}
+	if pr.DecidedBy != nil {
+		s := pr.DecidedBy.String()
+		resp.DecidedBy = &s
 	}
 	if pr.SentAt != nil {
 		s := pr.SentAt.UTC().Format(time.RFC3339)

--- a/backend/internal/inbox/handler_test.go
+++ b/backend/internal/inbox/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/daniil/floq/internal/httputil"
 	"github.com/go-chi/chi/v5"
@@ -71,6 +72,51 @@ func authedRequest(t *testing.T, method, path string, userID uuid.UUID) *http.Re
 	req := httptest.NewRequest(method, path, nil)
 	req = req.WithContext(httputil.WithUserID(req.Context(), userID))
 	return req
+}
+
+// --- Response DTO carries DecidedBy ---
+
+func TestHandler_ListByLead_ResponseIncludesDecidedBy(t *testing.T) {
+	userID := uuid.New()
+	leadID := uuid.New()
+	operator := uuid.New()
+
+	pr, err := NewPendingReply(userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "first")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a row that was approved by 'operator' — the response
+	// must carry decided_by as a string. omitempty would otherwise
+	// drop a non-stamped row's field, but here it MUST be present.
+	if err := pr.Approve(time.Now().UTC(), operator); err != nil {
+		t.Fatal(err)
+	}
+
+	uc := &fakePendingReplyUseCase{
+		listFn: func(_ context.Context, _, _ uuid.UUID) ([]*PendingReply, error) {
+			return []*PendingReply{pr}, nil
+		},
+	}
+	leads := &fakeLeadOwnership{owned: map[uuid.UUID]bool{leadID: true}}
+
+	srv := newTestServer(uc, leads)
+	req := authedRequest(t, http.MethodGet, "/api/leads/"+leadID.String()+"/pending-replies", userID)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	var got []map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("response len = %d, want 1", len(got))
+	}
+	if got[0]["decided_by"] != operator.String() {
+		t.Errorf("decided_by = %v, want %v — DTO must carry attribution for decided rows", got[0]["decided_by"], operator)
+	}
 }
 
 // --- GET /api/leads/{id}/pending-replies ---

--- a/backend/internal/inbox/pending_reply.go
+++ b/backend/internal/inbox/pending_reply.go
@@ -96,6 +96,10 @@ var (
 // approval before being delivered to the lead. It is the aggregate root for
 // the HITL (human-in-the-loop) gate that protects auto-drafted replies from
 // reaching customers without explicit operator consent.
+//
+// DecidedBy is nullable so rows from before migration 032 (which did not
+// capture operator attribution) stay valid; new approves and rejects always
+// stamp it.
 type PendingReply struct {
 	ID        uuid.UUID
 	UserID    uuid.UUID
@@ -106,6 +110,7 @@ type PendingReply struct {
 	Status    PendingReplyStatus
 	CreatedAt time.Time
 	DecidedAt *time.Time
+	DecidedBy *uuid.UUID
 	SentAt    *time.Time
 }
 
@@ -125,26 +130,31 @@ func (p *PendingReply) TransitionTo(target PendingReplyStatus) error {
 }
 
 // Approve moves a pending reply into the Approved status and stamps
-// DecidedAt. Use this when the operator confirms the draft should be sent;
-// the actual delivery is a separate step (MarkSent) so that a failed send
-// does not leave the entity in an inconsistent state.
-func (p *PendingReply) Approve(at time.Time) error {
+// DecidedAt + DecidedBy. Use this when the operator confirms the draft
+// should be sent; the actual delivery is a separate step (MarkSent) so that
+// a failed send does not leave the entity in an inconsistent state.
+func (p *PendingReply) Approve(at time.Time, by uuid.UUID) error {
 	if err := p.TransitionTo(PendingReplyStatusApproved); err != nil {
 		return err
 	}
 	t := at
+	b := by
 	p.DecidedAt = &t
+	p.DecidedBy = &b
 	return nil
 }
 
 // Reject moves a pending reply into the terminal Rejected status and stamps
-// DecidedAt. The draft body is preserved for audit / future reference.
-func (p *PendingReply) Reject(at time.Time) error {
+// DecidedAt + DecidedBy. The draft body is preserved for audit / future
+// reference.
+func (p *PendingReply) Reject(at time.Time, by uuid.UUID) error {
 	if err := p.TransitionTo(PendingReplyStatusRejected); err != nil {
 		return err
 	}
 	t := at
+	b := by
 	p.DecidedAt = &t
+	p.DecidedBy = &b
 	return nil
 }
 

--- a/backend/internal/inbox/pending_reply_repository.go
+++ b/backend/internal/inbox/pending_reply_repository.go
@@ -45,14 +45,14 @@ func (r *PendingReplyRepo) q(ctx context.Context) db.Querier {
 	return db.ConnFromCtx(ctx, r.pool)
 }
 
-const pendingReplyColumns = `id, user_id, lead_id, channel, kind, body, status, created_at, decided_at, sent_at`
+const pendingReplyColumns = `id, user_id, lead_id, channel, kind, body, status, created_at, decided_at, decided_by, sent_at`
 
 func (r *PendingReplyRepo) Save(ctx context.Context, pr *PendingReply) error {
 	_, err := r.q(ctx).Exec(ctx,
 		`INSERT INTO pending_replies (`+pendingReplyColumns+`)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
 		pr.ID, pr.UserID, pr.LeadID, string(pr.Channel), string(pr.Kind), pr.Body,
-		string(pr.Status), pr.CreatedAt, pr.DecidedAt, pr.SentAt)
+		string(pr.Status), pr.CreatedAt, pr.DecidedAt, pr.DecidedBy, pr.SentAt)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == pendingReplyDedupIndex {
@@ -72,7 +72,7 @@ func (r *PendingReplyRepo) GetByID(ctx context.Context, userID, id uuid.UUID) (*
 		 WHERE id = $1 AND user_id = $2`,
 		id, userID).
 		Scan(&pr.ID, &pr.UserID, &pr.LeadID, &channel, &kind, &pr.Body, &status,
-			&pr.CreatedAt, &pr.DecidedAt, &pr.SentAt)
+			&pr.CreatedAt, &pr.DecidedAt, &pr.DecidedBy, &pr.SentAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -102,7 +102,7 @@ func (r *PendingReplyRepo) FindPendingByContent(ctx context.Context, userID, lea
 		 LIMIT 1`,
 		userID, leadID, string(kind), trimmed).
 		Scan(&pr.ID, &pr.UserID, &pr.LeadID, &channel, &kindStr, &pr.Body, &status,
-			&pr.CreatedAt, &pr.DecidedAt, &pr.SentAt)
+			&pr.CreatedAt, &pr.DecidedAt, &pr.DecidedBy, &pr.SentAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -131,7 +131,7 @@ func (r *PendingReplyRepo) ListByLead(ctx context.Context, userID, leadID uuid.U
 		var pr PendingReply
 		var channel, kind, status string
 		if err := rows.Scan(&pr.ID, &pr.UserID, &pr.LeadID, &channel, &kind, &pr.Body, &status,
-			&pr.CreatedAt, &pr.DecidedAt, &pr.SentAt); err != nil {
+			&pr.CreatedAt, &pr.DecidedAt, &pr.DecidedBy, &pr.SentAt); err != nil {
 			return nil, fmt.Errorf("scan pending reply: %w", err)
 		}
 		pr.Channel = Channel(channel)
@@ -150,9 +150,9 @@ func (r *PendingReplyRepo) ListByLead(ctx context.Context, userID, leadID uuid.U
 func (r *PendingReplyRepo) Update(ctx context.Context, pr *PendingReply, expectedStatus PendingReplyStatus) error {
 	tag, err := r.q(ctx).Exec(ctx,
 		`UPDATE pending_replies
-		 SET status = $1, decided_at = $2, sent_at = $3
-		 WHERE id = $4 AND user_id = $5 AND status = $6`,
-		string(pr.Status), pr.DecidedAt, pr.SentAt, pr.ID, pr.UserID, string(expectedStatus))
+		 SET status = $1, decided_at = $2, decided_by = $3, sent_at = $4
+		 WHERE id = $5 AND user_id = $6 AND status = $7`,
+		string(pr.Status), pr.DecidedAt, pr.DecidedBy, pr.SentAt, pr.ID, pr.UserID, string(expectedStatus))
 	if err != nil {
 		return fmt.Errorf("update pending reply: %w", err)
 	}

--- a/backend/internal/inbox/pending_reply_repository_test.go
+++ b/backend/internal/inbox/pending_reply_repository_test.go
@@ -136,7 +136,7 @@ func TestPendingReplyRepository_Update_RowMissingReturnsNotFoundSentinel(t *test
 	// the WHERE clause adds the status filter for optimistic lock).
 	pr, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "ghost")
 	require.NoError(t, err)
-	require.NoError(t, pr.Approve(time.Now().UTC()))
+	require.NoError(t, pr.Approve(time.Now().UTC(), uuid.New()))
 
 	err = repo.Update(ctx, pr, inbox.PendingReplyStatusPending)
 	require.Error(t, err)
@@ -161,7 +161,7 @@ func TestPendingReplyRepository_Update_CrossTenantReturnsNotFoundSentinel(t *tes
 	// as a missing row — uniform 404 contract).
 	stolen := *pr
 	stolen.UserID = userB
-	require.NoError(t, stolen.Reject(time.Now().UTC()))
+	require.NoError(t, stolen.Reject(time.Now().UTC(), uuid.New()))
 	err = repo.Update(ctx, &stolen, inbox.PendingReplyStatusPending)
 	require.ErrorIs(t, err, inbox.ErrPendingReplyNotFound)
 }
@@ -181,14 +181,14 @@ func TestPendingReplyRepository_Update_OptimisticLock_RejectsWhenStatusMoved(t *
 	// and is about to push status=approved. Meanwhile operator B
 	// already approved it — the persisted row is now status=approved.
 	bSnap := *pr
-	require.NoError(t, bSnap.Approve(time.Now().UTC()))
+	require.NoError(t, bSnap.Approve(time.Now().UTC(), uuid.New()))
 	require.NoError(t, repo.Update(ctx, &bSnap, inbox.PendingReplyStatusPending))
 
 	// Operator A's stale snapshot, still expecting status=pending,
 	// must fail the optimistic check rather than overwriting B's
 	// decision.
 	aSnap := *pr
-	require.NoError(t, aSnap.Approve(time.Now().UTC()))
+	require.NoError(t, aSnap.Approve(time.Now().UTC(), uuid.New()))
 	err = repo.Update(ctx, &aSnap, inbox.PendingReplyStatusPending)
 	require.ErrorIs(t, err, inbox.ErrPendingReplyNotFound,
 		"second Update with the same expected-status must fail — the row is no longer pending")
@@ -252,7 +252,7 @@ func TestPendingReplyRepository_Save_AllowsRePeoposeAfterRejection(t *testing.T)
 	first, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "book me")
 	require.NoError(t, err)
 	require.NoError(t, repo.Save(ctx, first))
-	require.NoError(t, first.Reject(time.Now().UTC()))
+	require.NoError(t, first.Reject(time.Now().UTC(), uuid.New()))
 	require.NoError(t, repo.Update(ctx, first, inbox.PendingReplyStatusPending))
 
 	second, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "book me")
@@ -304,7 +304,7 @@ func TestPendingReplyRepository_FindPendingByContent_IgnoresDecidedRows(t *testi
 	pr, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "book me")
 	require.NoError(t, err)
 	require.NoError(t, repo.Save(ctx, pr))
-	require.NoError(t, pr.Reject(time.Now().UTC()))
+	require.NoError(t, pr.Reject(time.Now().UTC(), uuid.New()))
 	require.NoError(t, repo.Update(ctx, pr, inbox.PendingReplyStatusPending))
 
 	got, err := repo.FindPendingByContent(ctx, userID, leadID, inbox.PendingReplyKindBookingLink, "book me")
@@ -341,7 +341,7 @@ func TestPendingReplyRepository_Update_PersistsStatusAndTimestamps(t *testing.T)
 	require.NoError(t, repo.Save(ctx, pr))
 
 	decidedAt := time.Now().UTC().Truncate(time.Microsecond)
-	require.NoError(t, pr.Approve(decidedAt))
+	require.NoError(t, pr.Approve(decidedAt, uuid.New()))
 	require.NoError(t, repo.Update(ctx, pr, inbox.PendingReplyStatusPending))
 
 	got, err := repo.GetByID(ctx, userID, pr.ID)

--- a/backend/internal/inbox/pending_reply_repository_test.go
+++ b/backend/internal/inbox/pending_reply_repository_test.go
@@ -329,6 +329,34 @@ func TestPendingReplyRepository_FindPendingByContent_ScopedByUser(t *testing.T) 
 	assert.Nil(t, got, "cross-tenant FindPendingByContent must return nil — never another user's row")
 }
 
+func TestPendingReplyRepository_Update_PersistsDecidedBy(t *testing.T) {
+	// After Approve(at, by) + Update, GetByID returns the row with
+	// DecidedBy populated. Pins migration 032 + repo round-trip.
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	pr, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "body")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, pr))
+	// Newly-created pending row has no decision yet — both fields nil.
+	got, err := repo.GetByID(ctx, userID, pr.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Nil(t, got.DecidedBy, "freshly Saved pending row must have nil DecidedBy")
+
+	operator := testutil.SeedUser(t, pool)
+	require.NoError(t, pr.Approve(time.Now().UTC(), operator))
+	require.NoError(t, repo.Update(ctx, pr, inbox.PendingReplyStatusPending))
+
+	got, err = repo.GetByID(ctx, userID, pr.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.DecidedBy, "Update must persist DecidedBy")
+	assert.Equal(t, operator, *got.DecidedBy)
+}
+
 func TestPendingReplyRepository_Update_PersistsStatusAndTimestamps(t *testing.T) {
 	pool := testutil.TestDB(t)
 	userID := testutil.SeedUser(t, pool)

--- a/backend/internal/inbox/pending_reply_test.go
+++ b/backend/internal/inbox/pending_reply_test.go
@@ -153,7 +153,7 @@ func TestPendingReply_Reject_StampsDecidedBy(t *testing.T) {
 func TestPendingReply_Approve_FromPending(t *testing.T) {
 	pr := freshPendingReply(t)
 	at := time.Now().UTC()
-	if err := pr.Approve(at); err != nil {
+	if err := pr.Approve(at, uuid.New()); err != nil {
 		t.Fatalf("Approve from pending should succeed, got %v", err)
 	}
 	if pr.Status != PendingReplyStatusApproved {
@@ -167,7 +167,7 @@ func TestPendingReply_Approve_FromPending(t *testing.T) {
 func TestPendingReply_Reject_FromPending(t *testing.T) {
 	pr := freshPendingReply(t)
 	at := time.Now().UTC()
-	if err := pr.Reject(at); err != nil {
+	if err := pr.Reject(at, uuid.New()); err != nil {
 		t.Fatalf("Reject from pending should succeed, got %v", err)
 	}
 	if pr.Status != PendingReplyStatusRejected {
@@ -180,7 +180,7 @@ func TestPendingReply_Reject_FromPending(t *testing.T) {
 
 func TestPendingReply_MarkSent_FromApproved(t *testing.T) {
 	pr := freshPendingReply(t)
-	if err := pr.Approve(time.Now().UTC()); err != nil {
+	if err := pr.Approve(time.Now().UTC(), uuid.New()); err != nil {
 		t.Fatalf("Approve setup failed: %v", err)
 	}
 	sentAt := time.Now().UTC().Add(time.Second)
@@ -208,10 +208,10 @@ func TestPendingReply_IllegalTransitions(t *testing.T) {
 		},
 		{
 			name: "Approve from approved is illegal",
-			op:   func(pr *PendingReply) error { return pr.Approve(time.Now().UTC()) },
+			op:   func(pr *PendingReply) error { return pr.Approve(time.Now().UTC(), uuid.New()) },
 			seed: func(t *testing.T) *PendingReply {
 				pr := freshPendingReply(t)
-				if err := pr.Approve(time.Now().UTC()); err != nil {
+				if err := pr.Approve(time.Now().UTC(), uuid.New()); err != nil {
 					t.Fatalf("seed Approve failed: %v", err)
 				}
 				return pr
@@ -219,10 +219,10 @@ func TestPendingReply_IllegalTransitions(t *testing.T) {
 		},
 		{
 			name: "Reject from approved is illegal",
-			op:   func(pr *PendingReply) error { return pr.Reject(time.Now().UTC()) },
+			op:   func(pr *PendingReply) error { return pr.Reject(time.Now().UTC(), uuid.New()) },
 			seed: func(t *testing.T) *PendingReply {
 				pr := freshPendingReply(t)
-				if err := pr.Approve(time.Now().UTC()); err != nil {
+				if err := pr.Approve(time.Now().UTC(), uuid.New()); err != nil {
 					t.Fatalf("seed Approve failed: %v", err)
 				}
 				return pr
@@ -230,10 +230,10 @@ func TestPendingReply_IllegalTransitions(t *testing.T) {
 		},
 		{
 			name: "Approve from rejected is illegal",
-			op:   func(pr *PendingReply) error { return pr.Approve(time.Now().UTC()) },
+			op:   func(pr *PendingReply) error { return pr.Approve(time.Now().UTC(), uuid.New()) },
 			seed: func(t *testing.T) *PendingReply {
 				pr := freshPendingReply(t)
-				if err := pr.Reject(time.Now().UTC()); err != nil {
+				if err := pr.Reject(time.Now().UTC(), uuid.New()); err != nil {
 					t.Fatalf("seed Reject failed: %v", err)
 				}
 				return pr
@@ -244,7 +244,7 @@ func TestPendingReply_IllegalTransitions(t *testing.T) {
 			op:   func(pr *PendingReply) error { return pr.MarkSent(time.Now().UTC()) },
 			seed: func(t *testing.T) *PendingReply {
 				pr := freshPendingReply(t)
-				if err := pr.Approve(time.Now().UTC()); err != nil {
+				if err := pr.Approve(time.Now().UTC(), uuid.New()); err != nil {
 					t.Fatalf("seed Approve failed: %v", err)
 				}
 				if err := pr.MarkSent(time.Now().UTC()); err != nil {

--- a/backend/internal/inbox/pending_reply_test.go
+++ b/backend/internal/inbox/pending_reply_test.go
@@ -114,6 +114,42 @@ func freshPendingReply(t *testing.T) *PendingReply {
 	return pr
 }
 
+func TestPendingReply_Approve_StampsDecidedBy(t *testing.T) {
+	pr, err := NewPendingReply(uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	operator := uuid.New()
+	at := time.Now().UTC()
+	if err := pr.Approve(at, operator); err != nil {
+		t.Fatalf("Approve must accept (at, by), got %v", err)
+	}
+	if pr.DecidedBy == nil {
+		t.Fatal("Approve must stamp DecidedBy alongside DecidedAt")
+	}
+	if *pr.DecidedBy != operator {
+		t.Errorf("DecidedBy = %v, want %v", *pr.DecidedBy, operator)
+	}
+}
+
+func TestPendingReply_Reject_StampsDecidedBy(t *testing.T) {
+	pr, err := NewPendingReply(uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	operator := uuid.New()
+	at := time.Now().UTC()
+	if err := pr.Reject(at, operator); err != nil {
+		t.Fatalf("Reject must accept (at, by), got %v", err)
+	}
+	if pr.DecidedBy == nil {
+		t.Fatal("Reject must stamp DecidedBy alongside DecidedAt")
+	}
+	if *pr.DecidedBy != operator {
+		t.Errorf("DecidedBy = %v, want %v", *pr.DecidedBy, operator)
+	}
+}
+
 func TestPendingReply_Approve_FromPending(t *testing.T) {
 	pr := freshPendingReply(t)
 	at := time.Now().UTC()

--- a/backend/internal/inbox/pending_reply_usecase.go
+++ b/backend/internal/inbox/pending_reply_usecase.go
@@ -129,7 +129,7 @@ func (uc *PendingReplyUseCase) Approve(ctx context.Context, userID, id uuid.UUID
 	if err != nil {
 		return err
 	}
-	if err := pr.Approve(time.Now().UTC()); err != nil {
+	if err := pr.Approve(time.Now().UTC(), userID); err != nil {
 		if errors.Is(err, ErrPendingReplyInvalidTransition) {
 			return ErrPendingReplyAlreadyDecided
 		}
@@ -170,7 +170,7 @@ func (uc *PendingReplyUseCase) Reject(ctx context.Context, userID, id uuid.UUID)
 	if err != nil {
 		return err
 	}
-	if err := pr.Reject(time.Now().UTC()); err != nil {
+	if err := pr.Reject(time.Now().UTC(), userID); err != nil {
 		if errors.Is(err, ErrPendingReplyInvalidTransition) {
 			return ErrPendingReplyAlreadyDecided
 		}

--- a/backend/migrations/032_pending_replies_decided_by.down.sql
+++ b/backend/migrations/032_pending_replies_decided_by.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pending_replies DROP COLUMN IF EXISTS decided_by;

--- a/backend/migrations/032_pending_replies_decided_by.up.sql
+++ b/backend/migrations/032_pending_replies_decided_by.up.sql
@@ -1,0 +1,9 @@
+-- Capture operator attribution for HITL approve/reject decisions.
+-- Nullable so existing rows (decided pre-migration) stay valid; new
+-- transitions stamp it alongside decided_at via the domain factory.
+-- ON DELETE SET NULL: if an operator account is later deleted, the
+-- audit trail keeps decided_at but drops the dangling FK. The history
+-- is preserved enough for "who decided this?" investigations while
+-- still respecting tenant lifecycle.
+ALTER TABLE pending_replies
+ADD COLUMN decided_by UUID REFERENCES users(id) ON DELETE SET NULL;


### PR DESCRIPTION
Closes #47.

## Summary

- Migration 032: `ALTER TABLE pending_replies ADD COLUMN decided_by UUID REFERENCES users(id) ON DELETE SET NULL`. Nullable so pre-migration decided rows stay valid; new decisions stamp it. `ON DELETE SET NULL` preserves the `decided_at` audit trail when the operator account is later removed.
- Domain: `PendingReply.Approve(at, by)` / `Reject(at, by)` stamp `DecidedBy` atomically with `DecidedAt`. Field is nullable `*uuid.UUID`.
- Repo: every read site (`GetByID`, `ListByLead`, `FindPendingByContent`) scans the new column; `Save` inserts NULL on creation; `Update` writes the operator id alongside the decision.
- Wire: `PendingReplyResponse.decided_by` (omitempty) maps from `*uuid.UUID` to UUID string. Missing on the wire signals attribution unknown.
- UseCase pulls `userID` from the existing `loadOwned` and passes it into the domain — handler layer remains parse-only.

## Test plan

- [x] Unit: `Approve/Reject_StampsDecidedBy` (domain), `ListByLead_ResponseIncludesDecidedBy` (handler).
- [x] Integration (build tag `integration`): `Update_PersistsDecidedBy` round-trip via real Postgres on CI.
- [x] All pre-existing tests still green after Approve/Reject signature ripple.

## TDD trail

Two RED→GREEN pairs:
1. `d16103e` test RED (compile-fail: PendingReply has no DecidedBy, Approve/Reject take only timestamp) → `6da26b7` feat GREEN (field + signature + caller ripple).
2. `3297df9` test RED (repo round-trip returns nil DecidedBy; DTO response missing decided_by) → `c6c5d45` feat GREEN (migration 032 + repo SQL + DTO field).