### PR TITLE
feat(hitl): inbox-list badge + post-decision refetch (UX quick wins)

### DIFF
--- a/backend/cmd/server/adapters.go
+++ b/backend/cmd/server/adapters.go
@@ -532,3 +532,19 @@ func (s *sqlBackfillSource) ProspectsForBackfill(ctx context.Context) ([]leads.P
 	return out, rows.Err()
 }
 
+
+// pendingReplyCounterAdapter bridges inbox.PendingReplyRepository to
+// leads.PendingReplyCounter so the leads inbox-list view can render
+// the badge count without the leads context importing the inbox
+// package directly.
+type pendingReplyCounterAdapter struct {
+	repo inbox.PendingReplyRepository
+}
+
+func newPendingReplyCounterAdapter(repo inbox.PendingReplyRepository) *pendingReplyCounterAdapter {
+	return &pendingReplyCounterAdapter{repo: repo}
+}
+
+func (a *pendingReplyCounterAdapter) CountPendingByUser(ctx context.Context, userID uuid.UUID) (map[uuid.UUID]int, error) {
+	return a.repo.CountPendingByUser(ctx, userID)
+}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -183,6 +183,7 @@ func main() {
 	leadsUC := leads.NewUseCase(leadsRepo, leadsAI, nil,
 		leads.WithSuggestionFinder(suggestionFinder),
 		leads.WithIdentityReader(identityRepo),
+		leads.WithPendingReplyCounter(newPendingReplyCounterAdapter(pendingReplyRepo)),
 		leads.WithLogger(slog.Default())) // sender set after bot init
 	prospectsUC := prospects.NewUseCase(prospectsRepo,
 		prospects.WithLeadChecker(newLeadCheckerAdapter(leadsRepo)),

--- a/backend/internal/inbox/pending_reply_repository.go
+++ b/backend/internal/inbox/pending_reply_repository.go
@@ -142,6 +142,32 @@ func (r *PendingReplyRepo) ListByLead(ctx context.Context, userID, leadID uuid.U
 	return out, rows.Err()
 }
 
+// CountPendingByUser returns the per-lead count of rows still awaiting
+// operator decision (status='pending') for the given user. Used by
+// the leads-context inbox-list badge.
+func (r *PendingReplyRepo) CountPendingByUser(ctx context.Context, userID uuid.UUID) (map[uuid.UUID]int, error) {
+	rows, err := r.q(ctx).Query(ctx,
+		`SELECT lead_id, COUNT(*)
+		 FROM pending_replies
+		 WHERE user_id = $1 AND status = 'pending'
+		 GROUP BY lead_id`,
+		userID)
+	if err != nil {
+		return nil, fmt.Errorf("count pending replies by user: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[uuid.UUID]int)
+	for rows.Next() {
+		var leadID uuid.UUID
+		var count int
+		if err := rows.Scan(&leadID, &count); err != nil {
+			return nil, fmt.Errorf("scan pending count: %w", err)
+		}
+		out[leadID] = count
+	}
+	return out, rows.Err()
+}
+
 // Update persists status, decided_at and sent_at for an existing row.
 // Scoped by user_id and id to prevent a malformed entity from updating
 // somebody else's row even if the caller forgets to re-check ownership.

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -55,6 +55,18 @@ func (f *fakePendingReplyRepo) Save(_ context.Context, pr *PendingReply) error {
 	return nil
 }
 
+func (f *fakePendingReplyRepo) CountPendingByUser(_ context.Context, userID uuid.UUID) (map[uuid.UUID]int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[uuid.UUID]int)
+	for _, row := range f.rows {
+		if row.UserID == userID && row.Status == PendingReplyStatusPending {
+			out[row.LeadID]++
+		}
+	}
+	return out, nil
+}
+
 func (f *fakePendingReplyRepo) FindPendingByContent(_ context.Context, userID, leadID uuid.UUID, kind PendingReplyKind, body string) (*PendingReply, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/backend/internal/inbox/ports.go
+++ b/backend/internal/inbox/ports.go
@@ -190,6 +190,12 @@ type PendingReplyRepository interface {
 	// enqueued entity to the caller. body is matched against the
 	// trimmed value the factory stored.
 	FindPendingByContent(ctx context.Context, userID, leadID uuid.UUID, kind PendingReplyKind, body string) (*PendingReply, error)
+	// CountPendingByUser returns the number of pending rows per lead
+	// for the given user. Leads with no pending rows are absent from
+	// the map (callers default to zero). Used by the leads-context
+	// inbox-list badge — wired through an adapter so the leads package
+	// stays free of inbox-package imports.
+	CountPendingByUser(ctx context.Context, userID uuid.UUID) (map[uuid.UUID]int, error)
 	// Update writes pr only when the persisted row still matches the
 	// expectedStatus the caller observed at load time — an optimistic
 	// lock that prevents two operators from concurrently approving

--- a/backend/internal/leads/dto.go
+++ b/backend/internal/leads/dto.go
@@ -10,20 +10,26 @@ import (
 // --- Response DTOs ---
 
 type LeadResponse struct {
-	ID             uuid.UUID                `json:"id"`
-	UserID         uuid.UUID                `json:"user_id"`
-	Channel        string                   `json:"channel"`
-	ContactName    string                   `json:"contact_name"`
-	Company        string                   `json:"company"`
-	FirstMessage   string                   `json:"first_message"`
-	Status         string                   `json:"status"`
-	TelegramChatID *int64                   `json:"telegram_chat_id,omitempty"`
-	EmailAddress   *string                  `json:"email_address,omitempty"`
-	SourceID       *uuid.UUID               `json:"source_id,omitempty"`
-	SourceName     string                   `json:"source_name,omitempty"`
-	CreatedAt      time.Time                `json:"created_at"`
-	UpdatedAt      time.Time                `json:"updated_at"`
-	Identity       *IdentitySummaryResponse `json:"identity,omitempty"`
+	ID                  uuid.UUID                `json:"id"`
+	UserID              uuid.UUID                `json:"user_id"`
+	Channel             string                   `json:"channel"`
+	ContactName         string                   `json:"contact_name"`
+	Company             string                   `json:"company"`
+	FirstMessage        string                   `json:"first_message"`
+	Status              string                   `json:"status"`
+	TelegramChatID      *int64                   `json:"telegram_chat_id,omitempty"`
+	EmailAddress        *string                  `json:"email_address,omitempty"`
+	SourceID            *uuid.UUID               `json:"source_id,omitempty"`
+	SourceName          string                   `json:"source_name,omitempty"`
+	CreatedAt           time.Time                `json:"created_at"`
+	UpdatedAt           time.Time                `json:"updated_at"`
+	Identity            *IdentitySummaryResponse `json:"identity,omitempty"`
+	// PendingRepliesCount badges the inbox-list UI when an operator
+	// has HITL drafts awaiting decision on this lead. Omitted from
+	// the wire when zero so the field is absent rather than carrying
+	// noise. The /api/leads list endpoint is the only path that
+	// populates this — single-lead detail endpoints leave it zero.
+	PendingRepliesCount int                      `json:"pending_replies_count,omitempty"`
 }
 
 // IdentitySummaryResponse projects the unified-identity context onto
@@ -121,6 +127,18 @@ func LeadsToResponse(leads []domain.LeadWithSource) []LeadResponse {
 	resp := make([]LeadResponse, len(leads))
 	for i := range leads {
 		resp[i] = LeadWithSourceToResponse(&leads[i])
+	}
+	return resp
+}
+
+// LeadsWithPendingCountToResponse maps the inbox-list projection
+// (lead + per-lead pending-reply count) onto the wire DTO. Counts of
+// zero are omitted via the json:",omitempty" tag on the DTO field.
+func LeadsWithPendingCountToResponse(leads []LeadWithPendingCount) []LeadResponse {
+	resp := make([]LeadResponse, len(leads))
+	for i := range leads {
+		resp[i] = LeadWithSourceToResponse(&leads[i].LeadWithSource)
+		resp[i].PendingRepliesCount = leads[i].PendingCount
 	}
 	return resp
 }

--- a/backend/internal/leads/handler.go
+++ b/backend/internal/leads/handler.go
@@ -74,15 +74,15 @@ func (h *Handler) listLeads() http.HandlerFunc {
 			httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
-		leads, err := h.uc.ListLeads(r.Context(), userID)
+		leads, err := h.uc.ListLeadsWithPendingCounts(r.Context(), userID)
 		if err != nil {
 			httputil.WriteError(w, http.StatusInternalServerError, "failed to list leads")
 			return
 		}
 		if leads == nil {
-			leads = []domain.LeadWithSource{}
+			leads = []LeadWithPendingCount{}
 		}
-		httputil.WriteJSON(w, http.StatusOK, LeadsToResponse(leads))
+		httputil.WriteJSON(w, http.StatusOK, LeadsWithPendingCountToResponse(leads))
 	}
 }
 

--- a/backend/internal/leads/pending_replies_view.go
+++ b/backend/internal/leads/pending_replies_view.go
@@ -1,0 +1,70 @@
+package leads
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/daniil/floq/internal/leads/domain"
+	"github.com/google/uuid"
+)
+
+// PendingReplyCounter is the narrow port the inbox-list view needs from
+// the HITL/inbox context: how many drafts are still in the 'pending'
+// status awaiting operator action per lead, scoped to a user. Kept
+// outside domain.Repository so the leads context does not depend on the
+// inbox package — the composition root supplies an adapter.
+type PendingReplyCounter interface {
+	CountPendingByUser(ctx context.Context, userID uuid.UUID) (map[uuid.UUID]int, error)
+}
+
+// LeadWithPendingCount is the read-projection returned by
+// ListLeadsWithPendingCounts: the lead list row plus its pending-
+// reply badge count. PendingCount is zero when no rows match, when
+// the counter port is not wired, or when the counter returned an
+// error — the inbox list itself is too critical to 500 over a missing
+// badge.
+type LeadWithPendingCount struct {
+	LeadWithSource domain.LeadWithSource
+	PendingCount   int
+}
+
+// WithPendingReplyCounter wires the optional counter. Omit (or pass
+// nil) to keep ListLeadsWithPendingCounts in zero-badge mode.
+func WithPendingReplyCounter(c PendingReplyCounter) Option {
+	return func(uc *UseCase) { uc.pendingCounter = c }
+}
+
+// ListLeadsWithPendingCounts returns the same lead list as ListLeads,
+// each row augmented with the count of pending HITL replies tied to
+// the lead. A nil counter or a counter error degrades to zero —
+// callers see no badges but the list itself stays usable.
+func (uc *UseCase) ListLeadsWithPendingCounts(ctx context.Context, userID uuid.UUID) ([]LeadWithPendingCount, error) {
+	leads, err := uc.repo.ListLeads(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]LeadWithPendingCount, len(leads))
+	if uc.pendingCounter == nil {
+		for i := range leads {
+			out[i] = LeadWithPendingCount{LeadWithSource: leads[i]}
+		}
+		return out, nil
+	}
+	counts, cerr := uc.pendingCounter.CountPendingByUser(ctx, userID)
+	if cerr != nil {
+		// Degrade — badges hidden, list still works.
+		uc.logger.WarnContext(ctx, "pending-reply counter failed; rendering inbox without badges",
+			slog.Any("err", cerr))
+		for i := range leads {
+			out[i] = LeadWithPendingCount{LeadWithSource: leads[i]}
+		}
+		return out, nil
+	}
+	for i := range leads {
+		out[i] = LeadWithPendingCount{
+			LeadWithSource: leads[i],
+			PendingCount:   counts[leads[i].ID],
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/leads/pending_replies_view_test.go
+++ b/backend/internal/leads/pending_replies_view_test.go
@@ -1,0 +1,82 @@
+package leads
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/daniil/floq/internal/leads/domain"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakePendingCounter struct {
+	counts map[uuid.UUID]int
+	err    error
+}
+
+func (f *fakePendingCounter) CountPendingByUser(_ context.Context, _ uuid.UUID) (map[uuid.UUID]int, error) {
+	return f.counts, f.err
+}
+
+func TestUseCase_ListLeadsWithPendingCounts_AttachesCounts(t *testing.T) {
+	repo := newMockRepo()
+	userID := uuid.New()
+	leadA := uuid.New()
+	leadB := uuid.New()
+	leadC := uuid.New()
+	repo.leads[leadA] = &domain.Lead{ID: leadA, UserID: userID, ContactName: "A"}
+	repo.leads[leadB] = &domain.Lead{ID: leadB, UserID: userID, ContactName: "B"}
+	repo.leads[leadC] = &domain.Lead{ID: leadC, UserID: userID, ContactName: "C"}
+
+	counter := &fakePendingCounter{counts: map[uuid.UUID]int{leadA: 2, leadB: 0}}
+	uc := NewUseCase(repo, &mockAI{}, nil, WithPendingReplyCounter(counter))
+
+	out, err := uc.ListLeadsWithPendingCounts(context.Background(), userID)
+	require.NoError(t, err)
+	require.Len(t, out, 3)
+
+	byLead := map[uuid.UUID]int{}
+	for _, lwpc := range out {
+		byLead[lwpc.LeadWithSource.ID] = lwpc.PendingCount
+	}
+	assert.Equal(t, 2, byLead[leadA], "leadA has 2 pending — must surface")
+	assert.Equal(t, 0, byLead[leadB], "leadB has 0 in the map — must serialise as 0")
+	assert.Equal(t, 0, byLead[leadC], "leadC absent from the counter map — default 0")
+}
+
+func TestUseCase_ListLeadsWithPendingCounts_NoCounterWired_AllZero(t *testing.T) {
+	// Without a counter wired (composition root opted out, or boot
+	// order issue), every lead gets count=0 rather than 500.
+	// Defensive degrade — UI shows no badges, no operator visibility,
+	// but the list endpoint stays usable.
+	repo := newMockRepo()
+	userID := uuid.New()
+	leadID := uuid.New()
+	repo.leads[leadID] = &domain.Lead{ID: leadID, UserID: userID, ContactName: "A"}
+
+	uc := NewUseCase(repo, &mockAI{}, nil) // no WithPendingReplyCounter
+
+	out, err := uc.ListLeadsWithPendingCounts(context.Background(), userID)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, 0, out[0].PendingCount)
+}
+
+func TestUseCase_ListLeadsWithPendingCounts_CounterErrorDegrades(t *testing.T) {
+	// Counter failure must not 500 the inbox list — the lead list
+	// itself is critical operator surface. Degrade to count=0.
+	repo := newMockRepo()
+	userID := uuid.New()
+	leadID := uuid.New()
+	repo.leads[leadID] = &domain.Lead{ID: leadID, UserID: userID, ContactName: "A"}
+
+	counter := &fakePendingCounter{err: errors.New("db down")}
+	uc := NewUseCase(repo, &mockAI{}, nil, WithPendingReplyCounter(counter))
+
+	out, err := uc.ListLeadsWithPendingCounts(context.Background(), userID)
+	require.NoError(t, err, "counter error must NOT bubble up — degrade to zero badges instead of 500'ing the inbox")
+	require.Len(t, out, 1)
+	assert.Equal(t, 0, out[0].PendingCount)
+}

--- a/backend/internal/leads/usecase.go
+++ b/backend/internal/leads/usecase.go
@@ -21,6 +21,7 @@ type UseCase struct {
 	sender           domain.MessageSender
 	suggestionFinder domain.ProspectSuggestionFinder
 	identityReader   IdentityReader
+	pendingCounter   PendingReplyCounter
 	logger           *slog.Logger
 }
 

--- a/frontend/src/app/(dashboard)/inbox/page.tsx
+++ b/frontend/src/app/(dashboard)/inbox/page.tsx
@@ -87,6 +87,15 @@ export default function InboxPage() {
                       <Link2 className="size-3" />{suggestionCounts[lead.id]}
                     </span>
                   )}
+                  {lead.pendingRepliesCount > 0 && (
+                    <span
+                      aria-label={`${lead.pendingRepliesCount} ожидают подтверждения`}
+                      className="inline-flex items-center gap-1 rounded-full bg-[#f5b73c] px-2 py-0.5 text-[10px] font-bold text-[#0d1c2e]"
+                      title={`${lead.pendingRepliesCount} ожидают подтверждения`}
+                    >
+                      ⏵ {lead.pendingRepliesCount}
+                    </span>
+                  )}
                 </div>
               </Link>
             ))}

--- a/frontend/src/components/inbox/constants.ts
+++ b/frontend/src/components/inbox/constants.ts
@@ -10,6 +10,7 @@ export interface InboxLead {
   status: "Новый" | "Квалифицирован" | "В диалоге" | "Нужен фоллоуап" | "Закрыт" | "Выигран";
   apiStatus: string;
   sourceName?: string;
+  pendingRepliesCount: number;
 }
 
 export const STATUS_STYLES: Record<InboxLead["status"], string> = {

--- a/frontend/src/components/leads/LeadCard.test.tsx
+++ b/frontend/src/components/leads/LeadCard.test.tsx
@@ -60,4 +60,16 @@ describe("LeadCard", () => {
     render(<LeadCard {...defaultProps} channel="telegram" />);
     expect(screen.getByText(/через Telegram/)).toBeInTheDocument();
   });
+
+  it("shows no pending-reply badge when count is zero or undefined", () => {
+    render(<LeadCard {...defaultProps} pendingRepliesCount={0} />);
+    expect(screen.queryByLabelText(/ожидают подтверждения/i)).not.toBeInTheDocument();
+  });
+
+  it("shows pending-reply badge with count when greater than zero", () => {
+    render(<LeadCard {...defaultProps} pendingRepliesCount={3} />);
+    const badge = screen.getByLabelText(/ожидают подтверждения/i);
+    expect(badge).toBeInTheDocument();
+    expect(badge.textContent).toContain("3");
+  });
 });

--- a/frontend/src/components/leads/LeadCard.tsx
+++ b/frontend/src/components/leads/LeadCard.tsx
@@ -12,6 +12,9 @@ export interface LeadCardProps {
   preview: string;
   timeAgo: string;
   status: "Новый" | "Квалифицирован" | "Нужен фоллоуап";
+  /** Count of HITL drafts on this lead awaiting operator decision.
+   *  Renders a small badge when > 0; absent or 0 means no badge. */
+  pendingRepliesCount?: number;
 }
 
 const STATUS_STYLES: Record<LeadCardProps["status"], string> = {
@@ -28,6 +31,7 @@ export function LeadCard({
   preview,
   timeAgo,
   status,
+  pendingRepliesCount,
 }: LeadCardProps) {
   return (
     <Link
@@ -72,6 +76,14 @@ export function LeadCard({
         >
           {status}
         </span>
+        {pendingRepliesCount !== undefined && pendingRepliesCount > 0 && (
+          <span
+            aria-label={`${pendingRepliesCount} ожидают подтверждения`}
+            className="inline-flex items-center gap-1 rounded-full bg-[#f5b73c] px-2 py-0.5 text-[10px] font-bold text-[#0d1c2e]"
+          >
+            ⏵ {pendingRepliesCount}
+          </span>
+        )}
       </div>
     </Link>
   );

--- a/frontend/src/components/leads/PendingReplySection.test.tsx
+++ b/frontend/src/components/leads/PendingReplySection.test.tsx
@@ -29,7 +29,9 @@ const reply = (over: Partial<PendingReply> = {}): PendingReply => ({
 
 describe("PendingReplySection", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // resetAllMocks (not clearAllMocks) so mockResolvedValueOnce
+    // queues set in one test do not leak into the next.
+    vi.resetAllMocks();
   });
 
   it("renders nothing while the fetch is in-flight", () => {
@@ -129,6 +131,44 @@ describe("PendingReplySection", () => {
     expect(rejectBtn).toBeDisabled();
 
     resolve();
+  });
+
+  it("refetches from the server after a successful approve (self-heal)", async () => {
+    // Optimistic-remove can drift from server state: dispatcher fails
+    // between Update→approved and Update→sent, so the row stays at
+    // approved on disk even though the UI dropped it. After approve
+    // we MUST refetch so the list reflects truth.
+    const user = userEvent.setup();
+    vi.mocked(api.getPendingReplies)
+      .mockResolvedValueOnce([reply()])
+      // After approve: server still has the row at status=approved
+      // (dispatcher failed silently). Operator must see it back.
+      .mockResolvedValueOnce([reply({ status: "approved" })]);
+    vi.mocked(api.approvePendingReply).mockResolvedValue(undefined);
+
+    render(<PendingReplySection leadId="lead-1" />);
+    const btn = await screen.findByRole("button", { name: /Одобрить и отправить/i });
+    await user.click(btn);
+
+    // Two calls expected: initial mount + post-approve refetch.
+    await waitFor(() => expect(api.getPendingReplies).toHaveBeenCalledTimes(2));
+    // No 'Отлично' row because the refetch saw status=approved
+    // (which the section filters out of the pending list).
+    await waitFor(() => expect(screen.queryByText(/Отлично! Вот ссылка/)).not.toBeInTheDocument());
+  });
+
+  it("refetches from the server after a successful reject (self-heal)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.getPendingReplies)
+      .mockResolvedValueOnce([reply()])
+      .mockResolvedValueOnce([]);
+    vi.mocked(api.rejectPendingReply).mockResolvedValue(undefined);
+
+    render(<PendingReplySection leadId="lead-1" />);
+    const btn = await screen.findByRole("button", { name: /Отклонить/i });
+    await user.click(btn);
+
+    await waitFor(() => expect(api.getPendingReplies).toHaveBeenCalledTimes(2));
   });
 
   it("renders nothing when the fetch fails", async () => {

--- a/frontend/src/components/leads/PendingReplySection.test.tsx
+++ b/frontend/src/components/leads/PendingReplySection.test.tsx
@@ -67,9 +67,13 @@ describe("PendingReplySection", () => {
     expect(screen.getByText(/Telegram/i)).toBeInTheDocument();
   });
 
-  it("approves on click, removes the row, and calls onApproved", async () => {
+  it("approves on click, refetches, and calls onApproved", async () => {
     const user = userEvent.setup();
-    vi.mocked(api.getPendingReplies).mockResolvedValue([reply()]);
+    // Initial mount returns the pending row; the post-approve refetch
+    // returns an empty list (server confirmed sent).
+    vi.mocked(api.getPendingReplies)
+      .mockResolvedValueOnce([reply()])
+      .mockResolvedValueOnce([]);
     vi.mocked(api.approvePendingReply).mockResolvedValue(undefined);
     const onApproved = vi.fn();
     render(<PendingReplySection leadId="lead-1" onApproved={onApproved} />);
@@ -82,9 +86,11 @@ describe("PendingReplySection", () => {
     expect(onApproved).toHaveBeenCalledOnce();
   });
 
-  it("rejects on click and removes the row without calling onApproved", async () => {
+  it("rejects on click, refetches, and does not call onApproved", async () => {
     const user = userEvent.setup();
-    vi.mocked(api.getPendingReplies).mockResolvedValue([reply()]);
+    vi.mocked(api.getPendingReplies)
+      .mockResolvedValueOnce([reply()])
+      .mockResolvedValueOnce([]);
     vi.mocked(api.rejectPendingReply).mockResolvedValue(undefined);
     const onApproved = vi.fn();
     render(<PendingReplySection leadId="lead-1" onApproved={onApproved} />);

--- a/frontend/src/components/leads/PendingReplySection.tsx
+++ b/frontend/src/components/leads/PendingReplySection.tsx
@@ -47,12 +47,29 @@ export function PendingReplySection({ leadId, onApproved }: Props) {
   const pending = replies.filter((r) => r.status === "pending");
   if (pending.length === 0) return null;
 
+  // refreshFromServer replaces local state with the server's view of
+  // the queue. Costs one extra round-trip per decision but closes the
+  // 'list reflects truth' invariant: if the dispatcher silently kept
+  // the row at 'approved' (Update→approved succeeded, Update→sent
+  // didn't), the operator sees the row back instead of an
+  // optimistically-stale UI.
+  async function refreshFromServer() {
+    try {
+      const fresh = await api.getPendingReplies(leadId);
+      setReplies(fresh);
+    } catch {
+      // Best-effort; if the refetch itself fails, leave the optimistic
+      // state in place so the operator still sees the action took
+      // effect locally. The next page-level refresh will catch up.
+    }
+  }
+
   async function handleApprove(id: string) {
     setBusyId(id);
     setError(null);
     try {
       await api.approvePendingReply(id);
-      setReplies((prev) => prev?.filter((r) => r.id !== id) ?? []);
+      await refreshFromServer();
       onApproved?.();
     } catch {
       setError("Не удалось одобрить — попробуйте ещё раз");
@@ -66,7 +83,7 @@ export function PendingReplySection({ leadId, onApproved }: Props) {
     setError(null);
     try {
       await api.rejectPendingReply(id);
-      setReplies((prev) => prev?.filter((r) => r.id !== id) ?? []);
+      await refreshFromServer();
     } catch {
       setError("Не удалось отклонить — попробуйте ещё раз");
     } finally {

--- a/frontend/src/hooks/useInboxPage.ts
+++ b/frontend/src/hooks/useInboxPage.ts
@@ -20,6 +20,7 @@ export function useInboxPage() {
           channel: l.channel as "email" | "telegram",
           preview: l.first_message === "/start" ? "Загрузка..." : (l.first_message || "Нет сообщений"),
           timeAgo: getTimeAgo(l.created_at), status: mapStatus(l.status), apiStatus: l.status, sourceName: l.source_name,
+          pendingRepliesCount: l.pending_replies_count ?? 0,
         }));
         setLeads(mapped);
         data.forEach((l) => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -380,6 +380,9 @@ export interface Lead {
   created_at: string;
   updated_at: string;
   identity?: IdentitySummary;
+  /** Count of HITL drafts on this lead awaiting operator decision.
+   *  Omitted by the backend when zero; clients default to 0. */
+  pending_replies_count?: number;
 }
 
 // IdentitySummary surfaces the unified Identity attached to a lead via


### PR DESCRIPTION
Closes #50, closes #52.

## Summary

**#50 — inbox-list badge**
- `GET /api/leads` response gains optional `pending_replies_count`. Single grouped query in inbox repo: `SELECT lead_id, COUNT(*) FROM pending_replies WHERE user_id = $1 AND status = 'pending' GROUP BY lead_id`.
- `leads.PendingReplyCounter` port keeps the leads context free of inbox-package imports; `pendingReplyCounterAdapter` in `cmd/server/adapters.go` bridges it. Degrades cleanly when counter port is nil or errors (warn log + zero badges, list still works).
- Frontend: `LeadCard` gains optional `pendingRepliesCount`; inbox page renders an amber badge with the count + aria-label when > 0.

**#52 — post-approve refetch**
- `PendingReplySection.handleApprove/handleReject` now refetch `getPendingReplies(leadId)` after the decision lands and replace local state. Closes the optimistic-filter gap: if the dispatcher silently kept the row at 'approved' (Update→approved success, Update→sent failed), operator now sees the row reappear instead of drifting.
- `refreshFromServer` swallows fetch errors on purpose (best-effort, next page refresh catches up).

## Test plan

- [x] Backend unit: `ListLeadsWithPendingCounts` attaches counts + degrades on nil counter + degrades on counter error (3 scenarios).
- [x] Frontend unit: `LeadCard` badge present/absent (2 scenarios); `PendingReplySection` refetches after approve/reject (2 new + 2 updated).
- [x] Full vitest 360/360 green; full Go test suite green; `go vet -tags=integration` clean.

## TDD trail

Backend pair: `346fcd3` RED unit (UC method undefined) → `c4ef0ad` GREEN (port + view-model + DTO + handler + adapter + inbox-repo SQL).
Frontend wire-up: `ab38687` chore (Lead type → InboxLead → useInboxPage → page.tsx). LeadCard.tsx from issue #13 refactor not yet wired here, so the inline template in inbox/page.tsx carries the same badge for now.
Frontend #50 pair: `f69fb2c` RED → `b57d443` GREEN.
Frontend #52 pair: `982c8ff` RED + drive-by mock-leak fix (vi.clearAllMocks → resetAllMocks) → `3c92c22` GREEN.

## Note

A separate review on PR #64 (decided_by, just merged) flagged two follow-ups that I'll file as a small follow-up issue: (1) `Approve/Reject` should guard `by == uuid.Nil` with a domain sentinel; (2) usecase tests should assert the stored row has DecidedBy = userID after Approve/Reject. Out of scope here.