### PR TITLE
fix(inbox/hitl): nil-guard Approve/Reject + DecidedBy stamping coverage

### DIFF
--- a/backend/internal/inbox/pending_reply.go
+++ b/backend/internal/inbox/pending_reply.go
@@ -90,6 +90,12 @@ var (
 	// usecase translates this into a silent return of the previously-
 	// enqueued entity so the caller treats re-Propose as idempotent.
 	ErrPendingReplyDuplicatePending = errors.New("pending reply: duplicate pending row for same content")
+	// ErrPendingReplyMissingDecider rejects Approve/Reject with a nil
+	// operator UUID. The domain factory already guards UserID/LeadID
+	// symmetrically; this closes the same gap for the operator stamp
+	// so a system-cron caller passing uuid.Nil cannot silently land
+	// rows that would later 500 the repo Update on the decided_by FK.
+	ErrPendingReplyMissingDecider = errors.New("pending reply: decider id is required")
 )
 
 // PendingReply is an inbox-originated outbound message awaiting human
@@ -134,6 +140,9 @@ func (p *PendingReply) TransitionTo(target PendingReplyStatus) error {
 // should be sent; the actual delivery is a separate step (MarkSent) so that
 // a failed send does not leave the entity in an inconsistent state.
 func (p *PendingReply) Approve(at time.Time, by uuid.UUID) error {
+	if by == uuid.Nil {
+		return ErrPendingReplyMissingDecider
+	}
 	if err := p.TransitionTo(PendingReplyStatusApproved); err != nil {
 		return err
 	}
@@ -148,6 +157,9 @@ func (p *PendingReply) Approve(at time.Time, by uuid.UUID) error {
 // DecidedAt + DecidedBy. The draft body is preserved for audit / future
 // reference.
 func (p *PendingReply) Reject(at time.Time, by uuid.UUID) error {
+	if by == uuid.Nil {
+		return ErrPendingReplyMissingDecider
+	}
 	if err := p.TransitionTo(PendingReplyStatusRejected); err != nil {
 		return err
 	}

--- a/backend/internal/inbox/pending_reply_test.go
+++ b/backend/internal/inbox/pending_reply_test.go
@@ -114,6 +114,40 @@ func freshPendingReply(t *testing.T) *PendingReply {
 	return pr
 }
 
+func TestPendingReply_Approve_RejectsNilDecider(t *testing.T) {
+	pr, err := NewPendingReply(uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = pr.Approve(time.Now().UTC(), uuid.Nil)
+	if !errors.Is(err, ErrPendingReplyMissingDecider) {
+		t.Fatalf("Approve with uuid.Nil decider must return ErrPendingReplyMissingDecider, got %v", err)
+	}
+	// State must NOT have transitioned: a partial stamp leaves us with
+	// status=approved but DecidedBy=nil, which would later 500 the
+	// repo Update due to the FK constraint.
+	if pr.Status != PendingReplyStatusPending {
+		t.Errorf("rejected Approve must leave status pending, got %v", pr.Status)
+	}
+	if pr.DecidedBy != nil {
+		t.Errorf("rejected Approve must leave DecidedBy nil, got %v", pr.DecidedBy)
+	}
+}
+
+func TestPendingReply_Reject_RejectsNilDecider(t *testing.T) {
+	pr, err := NewPendingReply(uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = pr.Reject(time.Now().UTC(), uuid.Nil)
+	if !errors.Is(err, ErrPendingReplyMissingDecider) {
+		t.Fatalf("Reject with uuid.Nil decider must return ErrPendingReplyMissingDecider, got %v", err)
+	}
+	if pr.Status != PendingReplyStatusPending {
+		t.Errorf("rejected Reject must leave status pending, got %v", pr.Status)
+	}
+}
+
 func TestPendingReply_Approve_StampsDecidedBy(t *testing.T) {
 	pr, err := NewPendingReply(uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "body")
 	if err != nil {

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -395,6 +395,9 @@ func TestPendingReplyUseCase_Approve_TransitionsThenDispatchesThenMarksSent(t *t
 	if stored.SentAt == nil {
 		t.Error("SentAt should be set after successful dispatch")
 	}
+	if stored.DecidedBy == nil || *stored.DecidedBy != userID {
+		t.Errorf("DecidedBy = %v, want userID %v — usecase must pass operator id into domain stamp", stored.DecidedBy, userID)
+	}
 }
 
 func TestPendingReplyUseCase_Approve_NotFoundReturnsSentinel(t *testing.T) {
@@ -530,6 +533,9 @@ func TestPendingReplyUseCase_Reject_HappyPath(t *testing.T) {
 	}
 	if stored.DecidedAt == nil || stored.DecidedAt.Before(before) || stored.DecidedAt.After(after) {
 		t.Errorf("DecidedAt = %v, want within [%v, %v]", stored.DecidedAt, before, after)
+	}
+	if stored.DecidedBy == nil || *stored.DecidedBy != userID {
+		t.Errorf("DecidedBy = %v, want userID %v — usecase must pass operator id into domain stamp on Reject too", stored.DecidedBy, userID)
 	}
 	if len(disp.Calls()) != 0 {
 		t.Error("Reject must NOT dispatch")


### PR DESCRIPTION
Closes #66.

## Summary

Closes the two follow-up items the async code-reviewer flagged on PR #64 (#47) after merge:

1. **Domain nil-guard**: `Approve(at, by)` and `Reject(at, by)` now return new sentinel `ErrPendingReplyMissingDecider` when `by == uuid.Nil`. State transition is gated by the check so a failed call leaves the entity exactly as it was — no partial stamp that would 500 the repo Update on the `decided_by` FK constraint.

2. **Usecase-layer coverage backfill**: pre-existing `Approve_TransitionsThenDispatchesThenMarksSent` and `Reject_HappyPath` asserted status/DecidedAt/SentAt but not `DecidedBy`. Added assertions pin that the usecase passes `userID` into the domain stamp.

## Test plan

- [x] Domain unit (2 new RED→GREEN scenarios): nil-decider rejection for Approve + Reject.
- [x] Usecase unit: DecidedBy stamping pinned on both happy paths.
- [x] Full inbox suite green; build clean; `go vet -tags=integration` clean.

## TDD trail

- `f6575e8` test RED — compile-fail, sentinel not yet defined.
- `844687e` feat GREEN — sentinel + Approve/Reject guards.
- `6e77455` test backfill — usecase coverage for DecidedBy = userID (test-after, not TDD; commit message reflects that).