### PR TITLE
feat(audit): GET /api/audit/cost-summary endpoint

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -226,6 +226,7 @@ func main() {
 		settings.RegisterRoutes(r, settingsUC, buildAITester(cfg, httpClient), buildSMTPTester(proxyDialer), buildResendTester(httpClient), buildUsageCounter(leadsRepo))
 		chat.RegisterRoutes(r, chat.NewHandler(chat.NewRepository(pool), newChatAIAdapter(aiClient)))
 		inbox.RegisterPendingReplyRoutes(r, pendingReplyUC, leadsUC, pendingReplyDecideMW)
+		audit.RegisterRoutes(r, audit.NewHandler(audit.NewUseCase(auditRepo)))
 		tgOpts := []tgclient.Option{}
 		if proxyDialer != nil {
 			tgOpts = append(tgOpts, tgclient.WithDialer(proxyDialer))

--- a/backend/internal/audit/cost_summary_integration_test.go
+++ b/backend/internal/audit/cost_summary_integration_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+
+package audit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/daniil/floq/internal/audit"
+	"github.com/daniil/floq/internal/testutil"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedAuditEntry inserts a minimal audit_log row tied to userID with
+// the given request_type / model / cost / token counts. created_at
+// defaults to NOW(); pass an explicit time to control window-filter
+// tests.
+func seedAuditEntry(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID, requestType, model string, costMicro int64, inTokens, outTokens int, createdAt time.Time) {
+	t.Helper()
+	id := uuid.New()
+	totalTokens := inTokens + outTokens
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO audit_log (id, user_id, request_type, provider, model,
+			input_tokens, output_tokens, total_tokens,
+			cost_usd_micro, latency_ms, status, created_at)
+		 VALUES ($1, $2, $3, 'test-provider', $4, $5, $6, $7, $8, 100, 'success', $9)`,
+		id, userID, requestType, model, inTokens, outTokens, totalTokens, costMicro, createdAt)
+	require.NoError(t, err, "seed audit entry")
+}
+
+func TestRepository_CostSummary_AggregatesByRequestTypeAndModel(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := audit.NewRepository(pool)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	// Three qualification calls on haiku (1c, 2c, 3c micro = 6c total)
+	seedAuditEntry(t, pool, userID, "qualification", "claude-haiku-4-5", 1_000_000, 100, 50, now)
+	seedAuditEntry(t, pool, userID, "qualification", "claude-haiku-4-5", 2_000_000, 200, 100, now)
+	seedAuditEntry(t, pool, userID, "qualification", "claude-haiku-4-5", 3_000_000, 300, 150, now)
+	// Two cold-message calls on opus (5c, 7c micro = 12c total)
+	seedAuditEntry(t, pool, userID, "cold_message", "claude-opus-4-7", 5_000_000, 400, 200, now)
+	seedAuditEntry(t, pool, userID, "cold_message", "claude-opus-4-7", 7_000_000, 500, 250, now)
+	// Total: 5 calls, 18 USD micro
+
+	from := now.AddDate(0, 0, -1)
+	to := now.AddDate(0, 0, 1)
+	got, err := repo.CostSummary(ctx, userID, from, to)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Equal(t, 5, got.TotalCalls, "5 entries seeded total")
+	assert.EqualValues(t, 18_000_000, got.TotalUSDMicro, "sum of all costs")
+
+	// by_request_type ordered by spend desc — cold_message (12) before qualification (6)
+	require.Len(t, got.ByRequestType, 2)
+	assert.Equal(t, "cold_message", got.ByRequestType[0].RequestType, "highest-spend type ranks first")
+	assert.Equal(t, 2, got.ByRequestType[0].Calls)
+	assert.EqualValues(t, 12_000_000, got.ByRequestType[0].USDMicro)
+	assert.EqualValues(t, 900, got.ByRequestType[0].InputTokens)
+	assert.EqualValues(t, 450, got.ByRequestType[0].OutputTokens)
+	assert.Equal(t, "qualification", got.ByRequestType[1].RequestType)
+	assert.Equal(t, 3, got.ByRequestType[1].Calls)
+	assert.EqualValues(t, 6_000_000, got.ByRequestType[1].USDMicro)
+
+	// by_model ordered by spend desc — opus (12) before haiku (6)
+	require.Len(t, got.ByModel, 2)
+	assert.Equal(t, "claude-opus-4-7", got.ByModel[0].Model)
+	assert.EqualValues(t, 12_000_000, got.ByModel[0].USDMicro)
+	assert.Equal(t, "claude-haiku-4-5", got.ByModel[1].Model)
+	assert.EqualValues(t, 6_000_000, got.ByModel[1].USDMicro)
+}
+
+func TestRepository_CostSummary_PeriodFiltersOutOfRange(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := audit.NewRepository(pool)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	inWindow := now.Add(-12 * time.Hour)
+	outOfWindow := now.AddDate(0, 0, -10)
+
+	seedAuditEntry(t, pool, userID, "qualification", "m1", 1_000_000, 10, 5, inWindow)
+	seedAuditEntry(t, pool, userID, "qualification", "m1", 9_000_000, 90, 45, outOfWindow)
+
+	// Window: last day only.
+	from := now.AddDate(0, 0, -1)
+	to := now.Add(time.Hour) // include now
+	got, err := repo.CostSummary(ctx, userID, from, to)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.TotalCalls, "out-of-window row must be excluded")
+	assert.EqualValues(t, 1_000_000, got.TotalUSDMicro)
+}
+
+func TestRepository_CostSummary_ScopedByUser(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userA := testutil.SeedUser(t, pool)
+	userB := testutil.SeedUser(t, pool)
+	repo := audit.NewRepository(pool)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	seedAuditEntry(t, pool, userA, "qualification", "m1", 5_000_000, 100, 50, now)
+	seedAuditEntry(t, pool, userB, "qualification", "m1", 99_000_000, 9999, 4999, now)
+
+	from := now.AddDate(0, 0, -1)
+	to := now.Add(time.Hour)
+	got, err := repo.CostSummary(ctx, userA, from, to)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.TotalCalls, "user A sees only their own rows")
+	assert.EqualValues(t, 5_000_000, got.TotalUSDMicro, "cross-tenant cost MUST NOT leak")
+}
+
+func TestRepository_CostSummary_EmptyRangeReturnsZeroBreakdowns(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := audit.NewRepository(pool)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	got, err := repo.CostSummary(ctx, userID, now.AddDate(0, 0, -1), now)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, 0, got.TotalCalls)
+	assert.EqualValues(t, 0, got.TotalUSDMicro)
+	// Empty slices, not nil — JSON edge depends on it.
+	assert.NotNil(t, got.ByRequestType)
+	assert.Len(t, got.ByRequestType, 0)
+	assert.NotNil(t, got.ByModel)
+	assert.Len(t, got.ByModel, 0)
+}

--- a/backend/internal/audit/domain/cost_summary.go
+++ b/backend/internal/audit/domain/cost_summary.go
@@ -1,0 +1,40 @@
+package domain
+
+import "time"
+
+// CostSummary is the per-user aggregated spend ledger over a closed
+// time range [PeriodFrom, PeriodTo). Returned by AuditRepository.
+// CostSummary and surfaced to operators via GET /api/audit/cost-summary.
+//
+// USD values stay in micro-USD (USD * 1_000_000) all the way through
+// the stack and convert only at the JSON edge — integer arithmetic
+// avoids accumulated float error on sums of thousands of rows.
+type CostSummary struct {
+	TotalUSDMicro int64
+	TotalCalls    int
+	ByRequestType []RequestTypeBreakdown
+	ByModel       []ModelBreakdown
+	PeriodFrom    time.Time
+	PeriodTo      time.Time
+}
+
+// RequestTypeBreakdown rolls audit_log rows by request_type. Ordered
+// by total spend desc at the SQL layer so the operator dashboard
+// shows the most expensive surface first.
+type RequestTypeBreakdown struct {
+	RequestType  string
+	Calls        int
+	USDMicro     int64
+	InputTokens  int64
+	OutputTokens int64
+}
+
+// ModelBreakdown rolls audit_log rows by model name, same ordering
+// rationale as RequestTypeBreakdown.
+type ModelBreakdown struct {
+	Model        string
+	Calls        int
+	USDMicro     int64
+	InputTokens  int64
+	OutputTokens int64
+}

--- a/backend/internal/audit/domain/ports.go
+++ b/backend/internal/audit/domain/ports.go
@@ -1,6 +1,11 @@
 package domain
 
-import "context"
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
 
 // AuditRepository persists Entry rows in the audit_log table. The
 // caller hands over already-validated aggregates (constructed via
@@ -12,6 +17,11 @@ import "context"
 // pgx.CopyFrom. An empty slice is a no-op.
 type AuditRepository interface {
 	Save(ctx context.Context, entries []*Entry) error
+	// CostSummary aggregates audit_log rows for one user over a closed
+	// time range [from, to). Returns zero-valued breakdown slices (not
+	// nil) when nothing matches so JSON serialisation produces [] rather
+	// than null.
+	CostSummary(ctx context.Context, userID uuid.UUID, from, to time.Time) (*CostSummary, error)
 }
 
 // Recorder is the port the RecordingProvider decorator uses to hand

--- a/backend/internal/audit/handler.go
+++ b/backend/internal/audit/handler.go
@@ -1,0 +1,142 @@
+package audit
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/daniil/floq/internal/audit/domain"
+	"github.com/daniil/floq/internal/httputil"
+	"github.com/go-chi/chi/v5"
+)
+
+// Handler exposes audit-aggregation read endpoints. Write path stays
+// owned by the async Recorder — handlers never insert into audit_log.
+type Handler struct {
+	uc *UseCase
+}
+
+func NewHandler(uc *UseCase) *Handler {
+	return &Handler{uc: uc}
+}
+
+// RegisterRoutes wires the audit HTTP surface. Today only the cost-
+// summary read endpoint; future endpoints (per-lead breakdown, per-
+// prospect drilldown) attach here.
+func RegisterRoutes(r chi.Router, h *Handler) {
+	r.Get("/api/audit/cost-summary", h.getCostSummary())
+}
+
+// getCostSummary handles GET /api/audit/cost-summary?from=YYYY-MM-DD&to=YYYY-MM-DD.
+// Both query params are optional; defaults fall back to last 30 days.
+func (h *Handler) getCostSummary() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := httputil.UserIDFromContext(r.Context())
+		if !ok {
+			httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		from, ferr := parseDateParam(r, "from")
+		if ferr != nil {
+			httputil.WriteError(w, http.StatusBadRequest, "invalid 'from' (want YYYY-MM-DD)")
+			return
+		}
+		to, terr := parseDateParam(r, "to")
+		if terr != nil {
+			httputil.WriteError(w, http.StatusBadRequest, "invalid 'to' (want YYYY-MM-DD)")
+			return
+		}
+
+		summary, err := h.uc.CostSummary(r.Context(), userID, from, to)
+		if err != nil {
+			if errors.Is(err, ErrInvalidPeriod) {
+				httputil.WriteError(w, http.StatusBadRequest, "invalid period: 'to' must be after 'from'")
+				return
+			}
+			httputil.WriteError(w, http.StatusInternalServerError, "failed to aggregate cost summary")
+			return
+		}
+		httputil.WriteJSON(w, http.StatusOK, costSummaryToResponse(summary))
+	}
+}
+
+// parseDateParam reads a YYYY-MM-DD query parameter. Missing → zero
+// time (handler treats as "use default"); malformed → error.
+func parseDateParam(r *http.Request, key string) (time.Time, error) {
+	raw := r.URL.Query().Get(key)
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	return time.Parse("2006-01-02", raw)
+}
+
+// --- DTO ---
+
+// CostSummaryResponse projects domain.CostSummary onto the wire.
+// Micro-USD ints convert to floating-point USD only here; the
+// aggregation pipeline keeps integer precision everywhere upstream.
+type CostSummaryResponse struct {
+	TotalUSD      float64                       `json:"total_usd"`
+	TotalCalls    int                           `json:"total_calls"`
+	ByRequestType []RequestTypeBreakdownResponse `json:"by_request_type"`
+	ByModel       []ModelBreakdownResponse       `json:"by_model"`
+	Period        CostSummaryPeriodResponse      `json:"period"`
+}
+
+type RequestTypeBreakdownResponse struct {
+	RequestType string  `json:"request_type"`
+	Calls       int     `json:"calls"`
+	USD         float64 `json:"usd"`
+	TokensIn    int64   `json:"tokens_in"`
+	TokensOut   int64   `json:"tokens_out"`
+}
+
+type ModelBreakdownResponse struct {
+	Model     string  `json:"model"`
+	Calls     int     `json:"calls"`
+	USD       float64 `json:"usd"`
+	TokensIn  int64   `json:"tokens_in"`
+	TokensOut int64   `json:"tokens_out"`
+}
+
+type CostSummaryPeriodResponse struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+func costSummaryToResponse(s *domain.CostSummary) CostSummaryResponse {
+	byType := make([]RequestTypeBreakdownResponse, len(s.ByRequestType))
+	for i, b := range s.ByRequestType {
+		byType[i] = RequestTypeBreakdownResponse{
+			RequestType: b.RequestType,
+			Calls:       b.Calls,
+			USD:         microToUSD(b.USDMicro),
+			TokensIn:    b.InputTokens,
+			TokensOut:   b.OutputTokens,
+		}
+	}
+	byModel := make([]ModelBreakdownResponse, len(s.ByModel))
+	for i, b := range s.ByModel {
+		byModel[i] = ModelBreakdownResponse{
+			Model:     b.Model,
+			Calls:     b.Calls,
+			USD:       microToUSD(b.USDMicro),
+			TokensIn:  b.InputTokens,
+			TokensOut: b.OutputTokens,
+		}
+	}
+	return CostSummaryResponse{
+		TotalUSD:      microToUSD(s.TotalUSDMicro),
+		TotalCalls:    s.TotalCalls,
+		ByRequestType: byType,
+		ByModel:       byModel,
+		Period: CostSummaryPeriodResponse{
+			From: s.PeriodFrom.UTC().Format("2006-01-02"),
+			To:   s.PeriodTo.UTC().Format("2006-01-02"),
+		},
+	}
+}
+
+func microToUSD(m int64) float64 {
+	return float64(m) / 1_000_000.0
+}

--- a/backend/internal/audit/recorder_test.go
+++ b/backend/internal/audit/recorder_test.go
@@ -28,6 +28,12 @@ type recordingMockRepo struct {
 	saveCalls int
 }
 
+// CostSummary is unused by the recorder tests — recorder writes only.
+// Returning zero is enough to satisfy the AuditRepository interface.
+func (m *recordingMockRepo) CostSummary(_ context.Context, _ uuid.UUID, _, _ time.Time) (*domain.CostSummary, error) {
+	return &domain.CostSummary{}, nil
+}
+
 func (m *recordingMockRepo) Save(ctx context.Context, entries []*domain.Entry) error {
 	m.mu.Lock()
 	m.saveCalls++

--- a/backend/internal/audit/repository.go
+++ b/backend/internal/audit/repository.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -65,6 +66,19 @@ func (r *Repository) Save(ctx context.Context, entries []*domain.Entry) error {
 		return fmt.Errorf("audit save: %w", err)
 	}
 	return nil
+}
+
+// CostSummary aggregates audit_log rows for one user over the closed
+// time range [from, to). Two grouped queries (by request_type, by
+// model) plus a totals query. STUB — SQL lands in the GREEN commit
+// once integration tests have pinned the contract.
+func (r *Repository) CostSummary(ctx context.Context, userID uuid.UUID, from, to time.Time) (*domain.CostSummary, error) {
+	return &domain.CostSummary{
+		ByRequestType: []domain.RequestTypeBreakdown{},
+		ByModel:       []domain.ModelBreakdown{},
+		PeriodFrom:    from,
+		PeriodTo:      to,
+	}, nil
 }
 
 // nullableUUID converts an optional UUID into the form pgx expects for

--- a/backend/internal/audit/repository.go
+++ b/backend/internal/audit/repository.go
@@ -68,17 +68,71 @@ func (r *Repository) Save(ctx context.Context, entries []*domain.Entry) error {
 	return nil
 }
 
-// CostSummary aggregates audit_log rows for one user over the closed
-// time range [from, to). Two grouped queries (by request_type, by
-// model) plus a totals query. STUB — SQL lands in the GREEN commit
-// once integration tests have pinned the contract.
+// CostSummary aggregates audit_log rows for one user over the half-
+// open interval [from, to). Two grouped queries (by request_type, by
+// model) — totals are derived from the request-type breakdown to
+// avoid a third round-trip and stay consistent by construction.
+//
+// Breakdowns are ordered by USDMicro DESC so the operator dashboard
+// shows the most expensive surface first. Empty slices are returned
+// instead of nil so the JSON wire-shape stays predictable.
 func (r *Repository) CostSummary(ctx context.Context, userID uuid.UUID, from, to time.Time) (*domain.CostSummary, error) {
-	return &domain.CostSummary{
+	summary := &domain.CostSummary{
 		ByRequestType: []domain.RequestTypeBreakdown{},
 		ByModel:       []domain.ModelBreakdown{},
 		PeriodFrom:    from,
 		PeriodTo:      to,
-	}, nil
+	}
+
+	rows, err := r.pool.Query(ctx,
+		`SELECT request_type, COUNT(*), COALESCE(SUM(cost_usd_micro), 0),
+		        COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0)
+		 FROM audit_log
+		 WHERE user_id = $1 AND created_at >= $2 AND created_at < $3
+		 GROUP BY request_type
+		 ORDER BY SUM(cost_usd_micro) DESC`,
+		userID, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("audit cost-summary by request_type: %w", err)
+	}
+	for rows.Next() {
+		var b domain.RequestTypeBreakdown
+		if err := rows.Scan(&b.RequestType, &b.Calls, &b.USDMicro, &b.InputTokens, &b.OutputTokens); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("audit cost-summary scan request_type: %w", err)
+		}
+		summary.ByRequestType = append(summary.ByRequestType, b)
+		summary.TotalCalls += b.Calls
+		summary.TotalUSDMicro += b.USDMicro
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("audit cost-summary by request_type rows: %w", err)
+	}
+
+	rows, err = r.pool.Query(ctx,
+		`SELECT model, COUNT(*), COALESCE(SUM(cost_usd_micro), 0),
+		        COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0)
+		 FROM audit_log
+		 WHERE user_id = $1 AND created_at >= $2 AND created_at < $3
+		 GROUP BY model
+		 ORDER BY SUM(cost_usd_micro) DESC`,
+		userID, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("audit cost-summary by model: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var b domain.ModelBreakdown
+		if err := rows.Scan(&b.Model, &b.Calls, &b.USDMicro, &b.InputTokens, &b.OutputTokens); err != nil {
+			return nil, fmt.Errorf("audit cost-summary scan model: %w", err)
+		}
+		summary.ByModel = append(summary.ByModel, b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("audit cost-summary by model rows: %w", err)
+	}
+	return summary, nil
 }
 
 // nullableUUID converts an optional UUID into the form pgx expects for

--- a/backend/internal/audit/usecase.go
+++ b/backend/internal/audit/usecase.go
@@ -1,0 +1,47 @@
+package audit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/daniil/floq/internal/audit/domain"
+	"github.com/google/uuid"
+)
+
+// ErrInvalidPeriod is returned when the cost-summary request asks for
+// a zero-or-negative span (to <= from). The handler maps this to 400.
+var ErrInvalidPeriod = errors.New("audit: invalid period (to must be after from)")
+
+// defaultLookbackDays is the period that GET /api/audit/cost-summary
+// uses when the caller omits both from and to query parameters.
+// Thirty days mirrors typical monthly billing-review cadence.
+const defaultLookbackDays = 30
+
+// UseCase wraps the audit repository with input validation + sensible
+// defaults so the handler is a pure parse-and-map layer.
+type UseCase struct {
+	repo domain.AuditRepository
+	now  func() time.Time
+}
+
+func NewUseCase(repo domain.AuditRepository) *UseCase {
+	return &UseCase{repo: repo, now: time.Now}
+}
+
+// CostSummary returns the per-user spend ledger over the requested
+// range. Zero-valued from or to (the handler signals "missing query
+// param" with the zero value) default to "last 30 days ending now".
+func (uc *UseCase) CostSummary(ctx context.Context, userID uuid.UUID, from, to time.Time) (*domain.CostSummary, error) {
+	if to.IsZero() {
+		to = uc.now().UTC()
+	}
+	if from.IsZero() {
+		from = to.AddDate(0, 0, -defaultLookbackDays)
+	}
+	if !to.After(from) {
+		return nil, fmt.Errorf("%w: from=%s to=%s", ErrInvalidPeriod, from.Format(time.RFC3339), to.Format(time.RFC3339))
+	}
+	return uc.repo.CostSummary(ctx, userID, from, to)
+}

--- a/backend/internal/audit/usecase_test.go
+++ b/backend/internal/audit/usecase_test.go
@@ -1,0 +1,85 @@
+package audit_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/daniil/floq/internal/audit"
+	"github.com/daniil/floq/internal/audit/domain"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAuditRepo struct {
+	receivedFrom time.Time
+	receivedTo   time.Time
+	summary      *domain.CostSummary
+	saveErr      error
+	summaryErr   error
+}
+
+func (f *fakeAuditRepo) Save(_ context.Context, _ []*domain.Entry) error {
+	return f.saveErr
+}
+
+func (f *fakeAuditRepo) CostSummary(_ context.Context, _ uuid.UUID, from, to time.Time) (*domain.CostSummary, error) {
+	f.receivedFrom = from
+	f.receivedTo = to
+	if f.summaryErr != nil {
+		return nil, f.summaryErr
+	}
+	if f.summary != nil {
+		return f.summary, nil
+	}
+	return &domain.CostSummary{
+		ByRequestType: []domain.RequestTypeBreakdown{},
+		ByModel:       []domain.ModelBreakdown{},
+		PeriodFrom:    from,
+		PeriodTo:      to,
+	}, nil
+}
+
+func TestUseCase_CostSummary_DefaultsToLast30Days(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	uc := audit.NewUseCase(repo)
+	_, err := uc.CostSummary(context.Background(), uuid.New(), time.Time{}, time.Time{})
+	require.NoError(t, err)
+	span := repo.receivedTo.Sub(repo.receivedFrom)
+	// 30 days = 720h; allow a couple of seconds of slop for the clock
+	// read inside the usecase.
+	assert.InDelta(t, (30 * 24 * time.Hour).Seconds(), span.Seconds(), 2,
+		"zero from + zero to must default to a 30-day window ending now")
+}
+
+func TestUseCase_CostSummary_RespectsExplicitRange(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	uc := audit.NewUseCase(repo)
+	from := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	_, err := uc.CostSummary(context.Background(), uuid.New(), from, to)
+	require.NoError(t, err)
+	assert.True(t, repo.receivedFrom.Equal(from), "explicit from must pass through")
+	assert.True(t, repo.receivedTo.Equal(to), "explicit to must pass through")
+}
+
+func TestUseCase_CostSummary_FromAfterToRejected(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	uc := audit.NewUseCase(repo)
+	from := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC) // before from
+	_, err := uc.CostSummary(context.Background(), uuid.New(), from, to)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrInvalidPeriod)
+}
+
+func TestUseCase_CostSummary_PropagatesRepoError(t *testing.T) {
+	repo := &fakeAuditRepo{summaryErr: errors.New("db down")}
+	uc := audit.NewUseCase(repo)
+	from := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	_, err := uc.CostSummary(context.Background(), uuid.New(), from, to)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Closes #58.

## Summary

Surfaces the per-user spend ledger that the `audit_log` table has been collecting since migration 028. Operators can finally answer "why did costs jump this week" without raw SQL access.

**Endpoint:** `GET /api/audit/cost-summary?from=YYYY-MM-DD&to=YYYY-MM-DD`
- Both query params optional; defaults to last 30 days.
- Scoped by JWT user_id like every other protected endpoint.
- Malformed dates → 400; `to <= from` → 400 (`ErrInvalidPeriod`).

**Response shape:**
```json
{
  "total_usd": 12.34,
  "total_calls": 4567,
  "by_request_type": [
    {"request_type": "cold_message", "calls": 567, "usd": 7.0, "tokens_in": 12345, "tokens_out": 6789},
    ...
  ],
  "by_model": [
    {"model": "claude-opus-4-7", "calls": 100, "usd": 6.5, ...},
    ...
  ],
  "period": {"from": "2026-04-19", "to": "2026-05-19"}
}
```

Breakdowns ordered by USDMicro DESC so the highest-spend surface ranks first.

## Architecture

- `audit/domain/cost_summary.go` — `CostSummary` + `RequestTypeBreakdown` + `ModelBreakdown` value types. Micro-USD ints flow through the whole stack and convert to float USD only at the JSON edge — integer arithmetic owns the aggregation path.
- `audit/domain/ports.go` — `AuditRepository.CostSummary(ctx, userID, from, to)` port method.
- `audit/usecase.go` — input validation (`ErrInvalidPeriod` on `to <= from`), defaults (zero from + zero to → last 30 days, clock-injectable via `now` field).
- `audit/handler.go` — HTTP layer + `XxxResponse` DTOs (project convention).
- `audit/repository.go` — two grouped SQL queries (by request_type + by model). Totals accumulated from the request-type breakdown — no third round-trip, consistent by construction.

## Test plan

- [x] Unit (4 scenarios): default 30-day window, explicit range pass-through, `ErrInvalidPeriod` on `to <= from`, repo error propagation.
- [x] Integration (4 scenarios, build tag `integration`): aggregation by request_type + model, period filter excludes out-of-window rows, scoped by user (no cross-tenant leak), empty range returns empty slices (not nil).
- [x] Full backend suite green; build + `go vet -tags=integration` clean.

## TDD trail

- `8f0d045` test RED — domain types + port + recorder mock + UC tests (compile-fail on `audit.NewUseCase` / `audit.ErrInvalidPeriod`).
- `52fc342` feat GREEN — UC + handler + DTO + wire-up; repository.CostSummary still a stub.
- `8d2cdf5` test RED — integration scenarios pin SQL contract.
- `6ee9ea4` feat GREEN — real SQL aggregation in repository.CostSummary.