### PR TITLE
fix(release): single-eval notes_file into EXIT trap (#70)

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -236,7 +236,9 @@ main() {
   notes_file="$(mktemp -t release-notes-XXXXXX)"
   mv -- "$notes_file" "${notes_file}.md"
   notes_file="${notes_file}.md"
-  trap 'rm -f "$notes_file"' EXIT
+  # Single-eval the path into the trap body so cleanup survives main()'s
+  # local going out of scope when the function returns (issue #70).
+  trap "rm -f -- '$notes_file'" EXIT
   local last_tag
   last_tag="$(git -C "$root" describe --tags --abbrev=0 "v${new_version}^" 2>/dev/null || true)"
   {

--- a/bin/release_test.sh
+++ b/bin/release_test.sh
@@ -166,6 +166,50 @@ fi
 assert_ok    "verify_version_sync robust to dep collision" verify_version_sync "$TMP" "0.20.0"
 
 echo
+echo "notes_file EXIT trap (issue #70):"
+# The release.sh main() registers an EXIT trap to clean up the temp notes
+# file. The trap is set INSIDE main() where notes_file is `local`. Under
+# `set -u`, if the trap body defers the variable lookup until fire time
+# (after main returns and the local is out of scope), the script exits
+# with "notes_file: unbound variable" — observed in production on
+# v0.24.1 release.
+#
+# This test replays the EXACT trap line from release.sh in an isolated
+# subshell so the regression is caught at the source.
+NOTES_TRAP_LINE="$(grep -E "^  trap [\"'].*rm " "$SCRIPT_DIR/release.sh" | head -1)"
+[[ -n "$NOTES_TRAP_LINE" ]] || { echo "ERROR: could not locate trap line in release.sh" >&2; exit 1; }
+
+NOTES_TMP="$(mktemp -t floq-notes-trap.XXXXXX)"
+mv -- "$NOTES_TMP" "${NOTES_TMP}.md"
+NOTES_TMP="${NOTES_TMP}.md"
+
+# Reproduce the main()-shaped scope: notes_file is local; trap is set;
+# function returns; script exits.
+notes_stderr="$(
+  bash -c "
+set -uo pipefail
+f() {
+  local notes_file='$NOTES_TMP'
+  $NOTES_TRAP_LINE
+}
+f
+" 2>&1
+)"
+
+if [[ -z "$notes_stderr" ]]; then
+  pass "no unbound variable after function returns"
+else
+  fail "no unbound variable after function returns" "stderr: $notes_stderr"
+fi
+
+if [[ ! -e "$NOTES_TMP" ]]; then
+  pass "trap removes notes_file on exit"
+else
+  fail "trap removes notes_file on exit" "file still exists: $NOTES_TMP"
+  rm -f "$NOTES_TMP"
+fi
+
+echo
 if [[ "$failures" -gt 0 ]]; then
   printf "FAIL: %d test(s) failed\n" "$failures" >&2
   exit 1


### PR DESCRIPTION
## Summary

- `bin/release.sh:239` registered `trap 'rm -f "$notes_file"' EXIT` against a `local notes_file` inside `main()`. When `main` returned the local went out of scope; the EXIT trap then fired under `set -u` with `notes_file: unbound variable` AND never cleaned up the temp file. Observed in production on v0.24.1.
- Fix: single-eval the path into the trap body at setup time so cleanup survives the function return:
  ```bash
  trap "rm -f -- '$notes_file'" EXIT
  ```
- Regression test in `bin/release_test.sh` extracts the literal trap line via grep, replays it in an isolated subshell, asserts both stderr is empty AND temp file is removed.

Closes #70.

## TDD

- `295496e` test(release): add failing test — RED, both assertions fail with exact production stderr.
- `bcbca36` fix(release): single-eval — GREEN, both assertions pass.

## Review

Independent code-reviewer pass: Correctness 8/10, Test fidelity 9/10, Discipline 10/10 — verdict ready to merge. No must-fix items.

## Test plan

- [x] `bash bin/release_test.sh` — all tests pass on the fix commit
- [x] `bin/release.sh X.Y.Z --dry-run` still works (untouched path, exits at line 198 before trap setup)
- [ ] Next real release (`bin/release.sh 0.24.2`) confirms no trailing `unbound variable` line