### PR TITLE
refactor(inbox): wire LeadCard, drop duplicate inline JSX (#13)

### DIFF
--- a/frontend/src/app/(dashboard)/inbox/page.tsx
+++ b/frontend/src/app/(dashboard)/inbox/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { api } from "@/lib/api";
-import Link from "next/link";
-import { Mail, Send, Upload, Download, Link2 } from "lucide-react";
+import { Upload, Download } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { STATUS_STYLES, FILTER_TABS } from "@/components/inbox/constants";
+import { FILTER_TABS } from "@/components/inbox/constants";
 import { PipelineSidebar } from "@/components/inbox/PipelineSidebar";
+import { LeadCard } from "@/components/leads/LeadCard";
 import { useInboxPage } from "@/hooks/useInboxPage";
 
 export default function InboxPage() {
@@ -63,41 +63,19 @@ export default function InboxPage() {
               </div>
             )}
             {filteredLeads.map((lead) => (
-              <Link key={lead.id} href={`/inbox/${lead.id}`}
-                className="group relative flex cursor-pointer rounded-xl border border-transparent bg-white p-5 transition-all hover:border-[#c3c6d7]/10 hover:bg-[#dce9ff]/40">
-                <div className="flex items-start gap-4 flex-1 min-w-0">
-                  <div className={cn("flex size-12 shrink-0 items-center justify-center rounded-xl", lead.channel === "email" ? "bg-[#dbe1ff]" : "bg-[#d5e0f8]")}>
-                    {lead.channel === "email" ? <Mail className="size-5 text-[#004ac6]" /> : <Send className="size-5 text-[#229ED9]" />}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <h4 className="font-bold leading-none text-[#0d1c2e]">{lead.company}</h4>
-                    <p className="mt-1 text-xs font-medium text-[#737686]">{lead.channel === "email" ? "по email" : "через Telegram"} · {lead.contact}</p>
-                    <div className="mt-2 flex items-center gap-2">
-                      {lead.sourceName && <span className="rounded-full bg-[#eff4ff] px-2 py-0.5 text-[10px] font-semibold text-[#004ac6]">{lead.sourceName}</span>}
-                    </div>
-                    <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-[#434655]">{lead.preview}</p>
-                  </div>
-                </div>
-                <div className="ml-4 flex shrink-0 flex-col items-end gap-2">
-                  <span className="text-[10px] font-bold uppercase tracking-wider text-[#737686]">{lead.timeAgo}</span>
-                  <span className={cn("whitespace-nowrap rounded-full px-3 py-1 text-[10px] font-bold", STATUS_STYLES[lead.status])}>{lead.status}</span>
-                  {suggestionCounts[lead.id] > 0 && (
-                    <span className="inline-flex items-center gap-1 rounded-full bg-[#fff3cd] px-2 py-0.5 text-[10px] font-semibold text-[#8a5a00]"
-                      title={`${suggestionCounts[lead.id]} возможных совпадений с проспектом`}>
-                      <Link2 className="size-3" />{suggestionCounts[lead.id]}
-                    </span>
-                  )}
-                  {lead.pendingRepliesCount > 0 && (
-                    <span
-                      aria-label={`${lead.pendingRepliesCount} ожидают подтверждения`}
-                      className="inline-flex items-center gap-1 rounded-full bg-[#f5b73c] px-2 py-0.5 text-[10px] font-bold text-[#0d1c2e]"
-                      title={`${lead.pendingRepliesCount} ожидают подтверждения`}
-                    >
-                      ⏵ {lead.pendingRepliesCount}
-                    </span>
-                  )}
-                </div>
-              </Link>
+              <LeadCard
+                key={lead.id}
+                id={lead.id}
+                company={lead.company}
+                contact={lead.contact}
+                channel={lead.channel}
+                preview={lead.preview}
+                timeAgo={lead.timeAgo}
+                status={lead.status}
+                sourceName={lead.sourceName}
+                pendingRepliesCount={lead.pendingRepliesCount}
+                suggestionCount={suggestionCounts[lead.id]}
+              />
             ))}
           </div>
         </div>

--- a/frontend/src/components/leads/LeadCard.test.tsx
+++ b/frontend/src/components/leads/LeadCard.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { LeadCard, type LeadCardProps } from "./LeadCard";
+import { STATUS_STYLES } from "@/components/inbox/constants";
 
 vi.mock("next/link", () => ({
   default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
@@ -32,22 +33,21 @@ describe("LeadCard", () => {
     expect(screen.getByText(/john@acme\.com/)).toBeInTheDocument();
   });
 
-  it("shows correct badge for 'Новый' status", () => {
-    render(<LeadCard {...defaultProps} status="Новый" />);
-    const badge = screen.getByText("Новый");
-    expect(badge.className).toContain("bg-[#3b6ef6]/10");
-  });
-
-  it("shows correct badge for 'Квалифицирован' status", () => {
-    render(<LeadCard {...defaultProps} status="Квалифицирован" />);
-    const badge = screen.getByText("Квалифицирован");
-    expect(badge.className).toContain("border");
-  });
-
-  it("shows correct badge for 'Нужен фоллоуап' status", () => {
-    render(<LeadCard {...defaultProps} status="Нужен фоллоуап" />);
-    const badge = screen.getByText("Нужен фоллоуап");
-    expect(badge.className).toContain("bg-[#f59e0b]/10");
+  // Table-driven: every status in the inbox STATUS_STYLES map must render
+  // with the exact same style class. This pins LeadCard as a drop-in for
+  // the inline JSX previously in inbox/page.tsx — no visual regression
+  // when swapping. Covers all 6 statuses (was 3 in earlier iteration).
+  it.each([
+    ["Новый"],
+    ["Квалифицирован"],
+    ["В диалоге"],
+    ["Нужен фоллоуап"],
+    ["Закрыт"],
+    ["Выигран"],
+  ] as const)("renders status badge with inbox style for '%s'", (status) => {
+    render(<LeadCard {...defaultProps} status={status} />);
+    const badge = screen.getByText(status);
+    expect(badge.className).toContain(STATUS_STYLES[status]);
   });
 
   it("links to the correct inbox page", () => {
@@ -71,5 +71,29 @@ describe("LeadCard", () => {
     const badge = screen.getByLabelText(/ожидают подтверждения/i);
     expect(badge).toBeInTheDocument();
     expect(badge.textContent).toContain("3");
+  });
+
+  it("renders sourceName chip when provided", () => {
+    render(<LeadCard {...defaultProps} sourceName="LinkedIn" />);
+    expect(screen.getByText("LinkedIn")).toBeInTheDocument();
+  });
+
+  it("omits sourceName chip when not provided", () => {
+    render(<LeadCard {...defaultProps} />);
+    // No source = no chip rendered. We pick a label unlikely to collide
+    // with any other text the card emits.
+    expect(screen.queryByText("LinkedIn")).not.toBeInTheDocument();
+  });
+
+  it("renders suggestion-count badge when count > 0", () => {
+    render(<LeadCard {...defaultProps} suggestionCount={2} />);
+    const badge = screen.getByLabelText(/возможных совпадений/i);
+    expect(badge).toBeInTheDocument();
+    expect(badge.textContent).toContain("2");
+  });
+
+  it("omits suggestion-count badge when count is zero or undefined", () => {
+    render(<LeadCard {...defaultProps} suggestionCount={0} />);
+    expect(screen.queryByLabelText(/возможных совпадений/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/leads/LeadCard.tsx
+++ b/frontend/src/components/leads/LeadCard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { Mail, Send } from "lucide-react";
+import { Mail, Send, Link2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { STATUS_STYLES, type InboxLead } from "@/components/inbox/constants";
 
 export interface LeadCardProps {
   id: string;
@@ -11,17 +12,15 @@ export interface LeadCardProps {
   channel: "email" | "telegram";
   preview: string;
   timeAgo: string;
-  status: "Новый" | "Квалифицирован" | "Нужен фоллоуап";
+  status: InboxLead["status"];
+  sourceName?: string;
   /** Count of HITL drafts on this lead awaiting operator decision.
-   *  Renders a small badge when > 0; absent or 0 means no badge. */
+   *  Renders an amber badge when > 0; absent or 0 means no badge. */
   pendingRepliesCount?: number;
+  /** Count of cross-channel prospect-dedup suggestions for this lead.
+   *  Renders a beige Link2 badge when > 0. */
+  suggestionCount?: number;
 }
-
-const STATUS_STYLES: Record<LeadCardProps["status"], string> = {
-  "Новый": "bg-[#3b6ef6]/10 text-[#3b6ef6]",
-  "Квалифицирован": "border border-[#3b6ef6] text-[#3b6ef6] bg-transparent",
-  "Нужен фоллоуап": "bg-[#f59e0b]/10 text-[#f59e0b]",
-};
 
 export function LeadCard({
   id,
@@ -31,55 +30,72 @@ export function LeadCard({
   preview,
   timeAgo,
   status,
+  sourceName,
   pendingRepliesCount,
+  suggestionCount,
 }: LeadCardProps) {
   return (
     <Link
       href={`/inbox/${id}`}
-      className="group flex items-start gap-4 rounded-xl bg-white p-4 transition-shadow hover:shadow-md"
+      className="group relative flex cursor-pointer rounded-xl border border-transparent bg-white p-5 transition-all hover:border-[#c3c6d7]/10 hover:bg-[#dce9ff]/40"
     >
-      {/* Channel Icon */}
-      <div
-        className={cn(
-          "flex size-12 shrink-0 items-center justify-center rounded-xl",
-          channel === "email" ? "bg-[#3b6ef6]/10" : "bg-[#3b6ef6]/10"
-        )}
-      >
-        {channel === "email" ? (
-          <Mail className="size-5 text-[#3b6ef6]" />
-        ) : (
-          <Send className="size-5 text-[#3b6ef6]" />
-        )}
-      </div>
-
-      {/* Content */}
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <h3 className="text-sm font-semibold text-[#0d1c2e]">{company}</h3>
+      <div className="flex items-start gap-4 flex-1 min-w-0">
+        <div
+          className={cn(
+            "flex size-12 shrink-0 items-center justify-center rounded-xl",
+            channel === "email" ? "bg-[#dbe1ff]" : "bg-[#d5e0f8]"
+          )}
+        >
+          {channel === "email" ? (
+            <Mail className="size-5 text-[#004ac6]" />
+          ) : (
+            <Send className="size-5 text-[#229ED9]" />
+          )}
         </div>
-        <p className="text-xs text-[#6b7280]">
-          {channel === "email" ? "по email" : "через Telegram"} &middot; {contact}
-        </p>
-        <p className="mt-1 truncate text-sm text-[#6b7280]">{preview}</p>
+        <div className="min-w-0 flex-1">
+          <h4 className="font-bold leading-none text-[#0d1c2e]">{company}</h4>
+          <p className="mt-1 text-xs font-medium text-[#737686]">
+            {channel === "email" ? "по email" : "через Telegram"} · {contact}
+          </p>
+          {sourceName && (
+            <div className="mt-2 flex items-center gap-2">
+              <span className="rounded-full bg-[#eff4ff] px-2 py-0.5 text-[10px] font-semibold text-[#004ac6]">
+                {sourceName}
+              </span>
+            </div>
+          )}
+          <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-[#434655]">
+            {preview}
+          </p>
+        </div>
       </div>
-
-      {/* Right: time + badge */}
-      <div className="flex shrink-0 flex-col items-end gap-2">
-        <span className="text-[10px] font-medium tracking-wide text-[#6b7280] uppercase">
+      <div className="ml-4 flex shrink-0 flex-col items-end gap-2">
+        <span className="text-[10px] font-bold uppercase tracking-wider text-[#737686]">
           {timeAgo}
         </span>
         <span
           className={cn(
-            "rounded-full px-2.5 py-0.5 text-[10px] font-semibold whitespace-nowrap",
+            "whitespace-nowrap rounded-full px-3 py-1 text-[10px] font-bold",
             STATUS_STYLES[status]
           )}
         >
           {status}
         </span>
+        {suggestionCount !== undefined && suggestionCount > 0 && (
+          <span
+            aria-label={`${suggestionCount} возможных совпадений с проспектом`}
+            className="inline-flex items-center gap-1 rounded-full bg-[#fff3cd] px-2 py-0.5 text-[10px] font-semibold text-[#8a5a00]"
+            title={`${suggestionCount} возможных совпадений с проспектом`}
+          >
+            <Link2 className="size-3" />
+            {suggestionCount}
+          </span>
+        )}
         {pendingRepliesCount !== undefined && pendingRepliesCount > 0 && (
           <span
             aria-label={`${pendingRepliesCount} ожидают подтверждения`}
             className="inline-flex items-center gap-1 rounded-full bg-[#f5b73c] px-2 py-0.5 text-[10px] font-bold text-[#0d1c2e]"
+            title={`${pendingRepliesCount} ожидают подтверждения`}
           >
             ⏵ {pendingRepliesCount}
           </span>

--- a/frontend/src/components/leads/LeadCard.tsx
+++ b/frontend/src/components/leads/LeadCard.tsx
@@ -57,13 +57,15 @@ export function LeadCard({
           <p className="mt-1 text-xs font-medium text-[#737686]">
             {channel === "email" ? "по email" : "через Telegram"} · {contact}
           </p>
-          {sourceName && (
-            <div className="mt-2 flex items-center gap-2">
+          {/* Wrapper is unconditional to preserve mt-2 spacing even when
+              sourceName is absent — matches the pre-refactor inbox JSX. */}
+          <div className="mt-2 flex items-center gap-2">
+            {sourceName && (
               <span className="rounded-full bg-[#eff4ff] px-2 py-0.5 text-[10px] font-semibold text-[#004ac6]">
                 {sourceName}
               </span>
-            </div>
-          )}
+            )}
+          </div>
           <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-[#434655]">
             {preview}
           </p>


### PR DESCRIPTION
## Summary

Closes the leftover stitch from issue #13 (page-decomposition refactor): `LeadCard.tsx` existed but was never imported. The HITL pending-replies work (#50/#52) had duplicated the amber badge in both the component and the inline JSX. This PR collapses them.

- **Test-first**: extend `LeadCard.test.tsx` with 8 failing contract assertions for the full inbox contract (6-status union via table-driven, sourceName chip, suggestionCount badge).
- **Extend**: `LeadCard.tsx` now mirrors the inbox inline JSX verbatim — same status styles (imported from `inbox/constants`), same channel icon colors, same conditional badges. Adds an a11y `aria-label` on the suggestion badge while at it.
- **Wire**: `inbox/page.tsx` swaps the 37-line inline block for one `<LeadCard />` prop-passing call. Drops now-unused imports (`Link`, `Mail`, `Send`, `Link2`, `STATUS_STYLES`).

Net change in `inbox/page.tsx`: 38 lines removed, 16 added.

## TDD

- `9024264` test(leads): add failing contract tests — RED, 8 fail + 4 TS errors
- `15de822` feat(leads): extend LeadCard with full inbox contract — GREEN
- `e19431e` refactor(inbox): replace inline lead JSX with LeadCard — refactor
- `52200b3` fix(leads): preserve mt-2 spacing when sourceName absent — review fix-up

## Review

Independent code-reviewer pass: Visual parity 8/10, TDD discipline 9/10, DDD/CA 7/10. One must-fix (sourceName wrapper conditional broke spacing for ~half of leads) addressed in commit `52200b3`. Non-blocking DDD direction-of-dependency finding opened as follow-up issue #72.

## Test plan

- [x] `npx vitest run` — all 367 frontend tests green
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean
- [ ] Visual sanity in dev: open `/inbox`, verify cards render with source chip, pending badge, suggestion badge as before

Closes #13 (final stitch). Follow-up: #72.