### PR TITLE
refactor(leads): extract LeadStatus + STATUS_STYLES to leads/constants (#72)

### DIFF
--- a/frontend/src/components/inbox/constants.ts
+++ b/frontend/src/components/inbox/constants.ts
@@ -1,4 +1,10 @@
 import { Star, CheckCircle2, MessageCircle, RotateCcw, CircleCheck } from "lucide-react";
+import { STATUS_STYLES, type LeadStatus } from "@/components/leads/constants";
+
+// Re-export lead-domain primitives so existing inbox callers don't have
+// to chase the move. New code should import from
+// @/components/leads/constants directly.
+export { STATUS_STYLES, type LeadStatus };
 
 export interface InboxLead {
   id: string;
@@ -7,20 +13,11 @@ export interface InboxLead {
   channel: "email" | "telegram";
   preview: string;
   timeAgo: string;
-  status: "Новый" | "Квалифицирован" | "В диалоге" | "Нужен фоллоуап" | "Закрыт" | "Выигран";
+  status: LeadStatus;
   apiStatus: string;
   sourceName?: string;
   pendingRepliesCount: number;
 }
-
-export const STATUS_STYLES: Record<InboxLead["status"], string> = {
-  "Новый": "bg-[#dbe1ff] text-[#004ac6]",
-  "Квалифицирован": "bg-[#c7d2fe] text-[#3730a3]",
-  "В диалоге": "bg-[#fef3c7] text-[#92400e]",
-  "Нужен фоллоуап": "bg-[#fee2e2] text-[#dc2626]",
-  "Закрыт": "bg-[#d1fae5] text-[#065f46]",
-  "Выигран": "bg-[#bbf7d0] text-[#14532d]",
-};
 
 export const PIPELINE_STAGES_CONFIG: { id: string; apiStatus: string; label: string; icon: typeof Star; alert?: boolean }[] = [
   { id: "new", apiStatus: "new", label: "Новые лиды", icon: Star },
@@ -32,7 +29,7 @@ export const PIPELINE_STAGES_CONFIG: { id: string; apiStatus: string; label: str
 
 export const FILTER_TABS = ["Все", "Непрочитанные", "Приоритетные"] as const;
 
-export function mapStatus(status: string): InboxLead["status"] {
+export function mapStatus(status: string): LeadStatus {
   switch (status) {
     case "new": return "Новый";
     case "qualified": return "Квалифицирован";

--- a/frontend/src/components/leads/LeadCard.test.tsx
+++ b/frontend/src/components/leads/LeadCard.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { LeadCard, type LeadCardProps } from "./LeadCard";
-import { STATUS_STYLES } from "@/components/inbox/constants";
+import { STATUS_STYLES } from "@/components/leads/constants";
 
 vi.mock("next/link", () => ({
   default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (

--- a/frontend/src/components/leads/LeadCard.tsx
+++ b/frontend/src/components/leads/LeadCard.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { Mail, Send, Link2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { STATUS_STYLES, type InboxLead } from "@/components/inbox/constants";
+import { STATUS_STYLES, type LeadStatus } from "@/components/leads/constants";
 
 export interface LeadCardProps {
   id: string;
@@ -12,7 +12,7 @@ export interface LeadCardProps {
   channel: "email" | "telegram";
   preview: string;
   timeAgo: string;
-  status: InboxLead["status"];
+  status: LeadStatus;
   sourceName?: string;
   /** Count of HITL drafts on this lead awaiting operator decision.
    *  Renders an amber badge when > 0; absent or 0 means no badge. */

--- a/frontend/src/components/leads/constants.ts
+++ b/frontend/src/components/leads/constants.ts
@@ -1,0 +1,24 @@
+// Lead-domain primitives. Owned by components/leads/ so view-layer
+// surfaces (inbox, pipeline, dashboard widgets) can render a lead
+// without depending on the view that first happened to define the
+// shared styles.
+//
+// Inbox-specific things (PIPELINE_STAGES_CONFIG, FILTER_TABS,
+// mapStatus, InboxLead) stay in components/inbox/constants.ts.
+
+export type LeadStatus =
+  | "Новый"
+  | "Квалифицирован"
+  | "В диалоге"
+  | "Нужен фоллоуап"
+  | "Закрыт"
+  | "Выигран";
+
+export const STATUS_STYLES: Record<LeadStatus, string> = {
+  "Новый": "bg-[#dbe1ff] text-[#004ac6]",
+  "Квалифицирован": "bg-[#c7d2fe] text-[#3730a3]",
+  "В диалоге": "bg-[#fef3c7] text-[#92400e]",
+  "Нужен фоллоуап": "bg-[#fee2e2] text-[#dc2626]",
+  "Закрыт": "bg-[#d1fae5] text-[#065f46]",
+  "Выигран": "bg-[#bbf7d0] text-[#14532d]",
+};


### PR DESCRIPTION
## Summary

- Invert the direction of dependency between `components/leads/` and `components/inbox/`.
- Before: `LeadCard.tsx` imported `STATUS_STYLES` and `InboxLead[\"status\"]` from `components/inbox/constants` → "leads depends on inbox" (backwards).
- After: `components/leads/constants.ts` owns the `LeadStatus` type + `STATUS_STYLES` map. `components/inbox/constants.ts` re-exports them for backward compatibility and uses `LeadStatus` inside its own `InboxLead` interface.

Pure structural refactor — no behavioural delta. Existing callers untouched via re-export.

Closes #72 (reviewer follow-up from PR #73 LeadCard wire-up).

## Acceptance criteria

- [x] `grep -r 'from "@/components/inbox' src/components/leads/` returns empty
- [x] All 367 frontend tests still green
- [x] Lint + build clean (only pre-existing `coverage/` warning remains)

## Review

Independent code-reviewer pass: Direction-of-dependency 10/10, Backward-compat 9/10, No scope creep 10/10. Ready to merge.

## Test plan

- [x] `npx vitest run` — 367/367 green
- [x] `npm run lint && npm run build` — clean