### PR TITLE
fix(vscode): pin workspace settings to prevent phantom Go-export edits (#55)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,9 @@ frontend/.next/
 
 # IDE
 .idea/
-.vscode/
+.vscode/*
+# Allow workspace-pinned safe defaults (#55) without exposing per-user state.
+!.vscode/settings.json
 *.swp
 *.swo
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+{
+  "git.detectSubmodulesLimit": 0,
+  "git.repositoryScanMaxDepth": 0,
+
+  // --- Phantom-edit guardrails (issue #55) ---
+  //
+  // Two incidents (2026-05-17) had an exported Go function silently
+  // removed between commits, breaking the build. Root cause was never
+  // definitively pinned but narrowed to three suspects, all eliminated
+  // by this block:
+  //
+  //   1. files.autoSave: "afterDelay" (user default) → unintended
+  //      writes within ~1s of any keystroke. Force conscious saves.
+  //   2. tabnine.experimentalAutoImports (user default: true) →
+  //      AI-driven auto-rewriting of imports. Disable.
+  //   3. gopls "Refactor: Remove" lightbulb actions on save would
+  //      land silently with autosave on. Kept formatOnSave (gofmt
+  //      only — safe), explicit organize-imports stays "explicit".
+  //
+  // Override user-level settings for this workspace only.
+  "files.autoSave": "off",
+  "tabnine.experimentalAutoImports": false,
+  "[go]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "golang.go",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.vscode/settings.json` with workspace-pinned safe defaults that override user-level settings known (or suspected) to cause silent file mutations.
- `.gitignore` carve-out: `.vscode/*` stays ignored except `settings.json`. Per-user state (workspace storage, history) remains private.

Closes #55.

## Why

Two incidents on 2026-05-17 had an exported Go function silently removed between commits, breaking the build. Static audit narrowed the mutation surface to three suspects (see [#55 discovery comment](https://github.com/VDV001/floq/issues/55#issuecomment-4488518254)), all eliminated by this PR:

1. `files.autoSave: "afterDelay"` (user default) → forced `"off"` for this workspace.
2. `tabnine.experimentalAutoImports: true` (user default) → forced `false`.
3. `gopls` "Refactor: Remove" lightbulb under autoSave → with autoSave off, requires explicit save.

`gofmt`-on-save and `"explicit"` organize-imports stay (safe; `gofmt` does not remove exports).

## Test plan

- [x] `git check-ignore -v .vscode/settings.json` confirms `.gitignore` carve-out works
- [x] No source code changes, no test impact
- [ ] Acceptance from #55: an exported method referenced from a different package survives a Save. Verifies on next signature-change PR.

## Follow-up if incident recurs

Suspect set will have shrunk to "gopls lightbulb under explicit save (misclick)". Next step would be removing `source.organizeImports` from `editor.codeActionsOnSave` entirely.