### PR TITLE
feat(inbox/hitl): edit-before-approve PATCH /api/pending-replies/:id (#48)

### DIFF
--- a/backend/internal/inbox/handler.go
+++ b/backend/internal/inbox/handler.go
@@ -20,6 +20,7 @@ type PendingReplyUseCaseAPI interface {
 	ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error)
 	Approve(ctx context.Context, userID, id uuid.UUID) error
 	Reject(ctx context.Context, userID, id uuid.UUID) error
+	UpdateBody(ctx context.Context, userID, id uuid.UUID, body string) (*PendingReply, error)
 }
 
 // LeadOwnershipChecker is the narrow port the handler needs to gate

--- a/backend/internal/inbox/handler.go
+++ b/backend/internal/inbox/handler.go
@@ -2,6 +2,7 @@ package inbox
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -59,10 +60,14 @@ func RegisterPendingReplyRoutes(r chi.Router, uc PendingReplyUseCaseAPI, leads L
 	if decideMW == nil {
 		r.Post("/api/pending-replies/{id}/approve", h.approve())
 		r.Post("/api/pending-replies/{id}/reject", h.reject())
+		r.Patch("/api/pending-replies/{id}", h.updateBody())
 		return
 	}
 	r.With(decideMW).Post("/api/pending-replies/{id}/approve", h.approve())
 	r.With(decideMW).Post("/api/pending-replies/{id}/reject", h.reject())
+	// PATCH is rate-limited too — operators editing in a tight loop should
+	// hit the same throttle as a tight approve loop.
+	r.With(decideMW).Patch("/api/pending-replies/{id}", h.updateBody())
 }
 
 func (h *pendingReplyHandler) listByLead() http.HandlerFunc {
@@ -105,6 +110,58 @@ func (h *pendingReplyHandler) reject() http.HandlerFunc {
 	return h.decide(func(uc PendingReplyUseCaseAPI, ctx context.Context, userID, id uuid.UUID) error {
 		return uc.Reject(ctx, userID, id)
 	})
+}
+
+// updateBodyRequest is the PATCH request body. Body is required;
+// presence/non-empty is verified at parse time so the handler can
+// answer 400 without a round-trip to the usecase.
+type updateBodyRequest struct {
+	Body *string `json:"body"`
+}
+
+func (h *pendingReplyHandler) updateBody() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := httputil.UserIDFromContext(r.Context())
+		if !ok {
+			httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		id, err := httputil.ParseIDParam(r, "id")
+		if err != nil {
+			httputil.WriteError(w, http.StatusBadRequest, "invalid pending reply id")
+			return
+		}
+		var req updateBodyRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httputil.WriteError(w, http.StatusBadRequest, "invalid json body")
+			return
+		}
+		if req.Body == nil {
+			// Distinguish "missing field" from "empty string" so callers
+			// who forgot the field get a clear hint vs. domain-empty.
+			httputil.WriteError(w, http.StatusBadRequest, "body field is required")
+			return
+		}
+		updated, err := h.uc.UpdateBody(r.Context(), userID, id, *req.Body)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrPendingReplyNotFound):
+				httputil.WriteError(w, http.StatusNotFound, "pending reply not found")
+			case errors.Is(err, ErrPendingReplyAlreadyDecided):
+				httputil.WriteError(w, http.StatusConflict, "pending reply already decided")
+			case errors.Is(err, ErrPendingReplyEmptyBody):
+				httputil.WriteError(w, http.StatusBadRequest, "body is required (non-empty after trim)")
+			default:
+				slog.ErrorContext(r.Context(), "pending reply update body failed",
+					slog.String("pending_reply_id", id.String()),
+					slog.String("user_id", userID.String()),
+					slog.Any("err", err))
+				httputil.WriteError(w, http.StatusInternalServerError, "failed to update pending reply")
+			}
+			return
+		}
+		httputil.WriteJSON(w, http.StatusOK, pendingReplyToResponse(updated))
+	}
 }
 
 // decide is the shared shape of Approve and Reject: parse auth, parse

--- a/backend/internal/inbox/handler_test.go
+++ b/backend/internal/inbox/handler_test.go
@@ -21,9 +21,10 @@ import (
 type fakePendingReplyUseCase struct {
 	mu sync.Mutex
 
-	listFn    func(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error)
-	approveFn func(ctx context.Context, userID, id uuid.UUID) error
-	rejectFn  func(ctx context.Context, userID, id uuid.UUID) error
+	listFn       func(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error)
+	approveFn    func(ctx context.Context, userID, id uuid.UUID) error
+	rejectFn     func(ctx context.Context, userID, id uuid.UUID) error
+	updateBodyFn func(ctx context.Context, userID, id uuid.UUID, body string) (*PendingReply, error)
 }
 
 func (f *fakePendingReplyUseCase) ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error) {
@@ -45,6 +46,13 @@ func (f *fakePendingReplyUseCase) Reject(ctx context.Context, userID, id uuid.UU
 		return f.rejectFn(ctx, userID, id)
 	}
 	return nil
+}
+
+func (f *fakePendingReplyUseCase) UpdateBody(ctx context.Context, userID, id uuid.UUID, body string) (*PendingReply, error) {
+	if f.updateBodyFn != nil {
+		return f.updateBodyFn(ctx, userID, id, body)
+	}
+	return nil, nil
 }
 
 type fakeLeadOwnership struct {
@@ -385,6 +393,100 @@ func TestHandler_Reject_NotFoundAlreadyDecidedAuthAndInvalidID(t *testing.T) {
 			srv.ServeHTTP(rec, req)
 			if rec.Code != tc.wantStatus {
 				t.Fatalf("status = %d, want %d, body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}
+
+// --- UpdateBody (#48) PATCH /api/pending-replies/{id} ---
+
+func TestHandler_UpdateBody_HappyPath_Returns200WithBody(t *testing.T) {
+	userID := uuid.New()
+	prID := uuid.New()
+
+	uc := &fakePendingReplyUseCase{
+		updateBodyFn: func(_ context.Context, _, id uuid.UUID, body string) (*PendingReply, error) {
+			if id != prID {
+				t.Fatalf("path id = %v, want %v", id, prID)
+			}
+			if body != "edited body" {
+				t.Fatalf("body = %q, want 'edited body'", body)
+			}
+			return &PendingReply{
+				ID:        prID,
+				UserID:    userID,
+				LeadID:    uuid.New(),
+				Channel:   ChannelTelegram,
+				Kind:      PendingReplyKindBookingLink,
+				Body:      body,
+				Status:    PendingReplyStatusPending,
+				CreatedAt: time.Now().UTC(),
+			}, nil
+		},
+	}
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/pending-replies/"+prID.String(), strings.NewReader(`{"body":"edited body"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(httputil.WithUserID(req.Context(), userID))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	var got PendingReplyResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Body != "edited body" {
+		t.Errorf("response body = %q, want 'edited body'", got.Body)
+	}
+	if got.Status != string(PendingReplyStatusPending) {
+		t.Errorf("response status = %q, want pending", got.Status)
+	}
+}
+
+func TestHandler_UpdateBody_ErrorMatrix(t *testing.T) {
+	// Table-driven over the 400/404/409/401/400-id matrix. Mirrors the
+	// existing Approve/Reject ErrorMatrix style.
+	type tc struct {
+		name       string
+		ucErr      error
+		body       string
+		userID     uuid.UUID
+		pathID     string
+		wantStatus int
+	}
+	cases := []tc{
+		{name: "not found -> 404", ucErr: ErrPendingReplyNotFound, body: `{"body":"x"}`, userID: uuid.New(), pathID: uuid.New().String(), wantStatus: http.StatusNotFound},
+		{name: "already decided -> 409", ucErr: ErrPendingReplyAlreadyDecided, body: `{"body":"x"}`, userID: uuid.New(), pathID: uuid.New().String(), wantStatus: http.StatusConflict},
+		{name: "empty body domain error -> 400", ucErr: ErrPendingReplyEmptyBody, body: `{"body":"   "}`, userID: uuid.New(), pathID: uuid.New().String(), wantStatus: http.StatusBadRequest},
+		{name: "internal -> 500", ucErr: errors.New("boom"), body: `{"body":"x"}`, userID: uuid.New(), pathID: uuid.New().String(), wantStatus: http.StatusInternalServerError},
+		{name: "no user -> 401", ucErr: nil, body: `{"body":"x"}`, userID: uuid.Nil, pathID: uuid.New().String(), wantStatus: http.StatusUnauthorized},
+		{name: "invalid id -> 400", ucErr: nil, body: `{"body":"x"}`, userID: uuid.New(), pathID: "not-a-uuid", wantStatus: http.StatusBadRequest},
+		{name: "malformed JSON -> 400", ucErr: nil, body: `not json`, userID: uuid.New(), pathID: uuid.New().String(), wantStatus: http.StatusBadRequest},
+		{name: "missing body field -> 400", ucErr: nil, body: `{"other":"x"}`, userID: uuid.New(), pathID: uuid.New().String(), wantStatus: http.StatusBadRequest},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			uc := &fakePendingReplyUseCase{
+				updateBodyFn: func(_ context.Context, _, _ uuid.UUID, _ string) (*PendingReply, error) {
+					return nil, c.ucErr
+				},
+			}
+			srv := newTestServer(uc, &fakeLeadOwnership{})
+
+			path := "/api/pending-replies/" + c.pathID
+			req := httptest.NewRequest(http.MethodPatch, path, strings.NewReader(c.body))
+			req.Header.Set("Content-Type", "application/json")
+			if c.userID != uuid.Nil {
+				req = req.WithContext(httputil.WithUserID(req.Context(), c.userID))
+			}
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+			if rec.Code != c.wantStatus {
+				t.Fatalf("status = %d, want %d, body=%s", rec.Code, c.wantStatus, rec.Body.String())
 			}
 		})
 	}

--- a/backend/internal/inbox/pending_reply.go
+++ b/backend/internal/inbox/pending_reply.go
@@ -96,6 +96,14 @@ var (
 	// so a system-cron caller passing uuid.Nil cannot silently land
 	// rows that would later 500 the repo Update on the decided_by FK.
 	ErrPendingReplyMissingDecider = errors.New("pending reply: decider id is required")
+	// ErrPendingReplyNotEditable rejects UpdateBody on rows that have
+	// left the Pending status. Approved / sent / rejected drafts are
+	// immutable: the operator already committed to the wording when
+	// they took the decision (or the row is terminal). Distinct from
+	// ErrPendingReplyInvalidTransition because UpdateBody is not a
+	// status transition — keeping the sentinel separate lets the
+	// handler answer 409 unambiguously.
+	ErrPendingReplyNotEditable = errors.New("pending reply: not editable")
 )
 
 // PendingReply is an inbox-originated outbound message awaiting human
@@ -178,6 +186,24 @@ func (p *PendingReply) MarkSent(at time.Time) error {
 	}
 	t := at
 	p.SentAt = &t
+	return nil
+}
+
+// UpdateBody replaces the draft body with a trimmed version of input,
+// enforcing the same non-empty invariant as NewPendingReply. Only
+// callable while the reply is in the Pending status — once approved,
+// sent or rejected the body is immutable (operator already committed,
+// or the row is terminal). On any error the existing body is left
+// untouched so partial state never reaches persistence.
+func (p *PendingReply) UpdateBody(body string) error {
+	if p.Status != PendingReplyStatusPending {
+		return ErrPendingReplyNotEditable
+	}
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" {
+		return ErrPendingReplyEmptyBody
+	}
+	p.Body = trimmed
 	return nil
 }
 

--- a/backend/internal/inbox/pending_reply_repository.go
+++ b/backend/internal/inbox/pending_reply_repository.go
@@ -173,6 +173,25 @@ func (r *PendingReplyRepo) CountPendingByUser(ctx context.Context, userID uuid.U
 // somebody else's row even if the caller forgets to re-check ownership.
 // Body, channel, kind and created_at are immutable after Save by
 // contract — the entity exposes no setters for them.
+// UpdateBody implementation lives below; the integration test in
+// pending_reply_repository_test.go (build tag `integration`) drives the
+// SQL contract under #48 step 3. This compile-stub keeps the port
+// satisfied during the usecase TDD pair.
+func (r *PendingReplyRepo) UpdateBody(ctx context.Context, pr *PendingReply, expectedStatus PendingReplyStatus) error {
+	tag, err := r.q(ctx).Exec(ctx,
+		`UPDATE pending_replies
+		 SET body = $1
+		 WHERE id = $2 AND user_id = $3 AND status = $4`,
+		pr.Body, pr.ID, pr.UserID, string(expectedStatus))
+	if err != nil {
+		return fmt.Errorf("update pending reply body: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrPendingReplyNotFound
+	}
+	return nil
+}
+
 func (r *PendingReplyRepo) Update(ctx context.Context, pr *PendingReply, expectedStatus PendingReplyStatus) error {
 	tag, err := r.q(ctx).Exec(ctx,
 		`UPDATE pending_replies

--- a/backend/internal/inbox/pending_reply_repository.go
+++ b/backend/internal/inbox/pending_reply_repository.go
@@ -173,10 +173,11 @@ func (r *PendingReplyRepo) CountPendingByUser(ctx context.Context, userID uuid.U
 // somebody else's row even if the caller forgets to re-check ownership.
 // Body, channel, kind and created_at are immutable after Save by
 // contract — the entity exposes no setters for them.
-// UpdateBody implementation lives below; the integration test in
-// pending_reply_repository_test.go (build tag `integration`) drives the
-// SQL contract under #48 step 3. This compile-stub keeps the port
-// satisfied during the usecase TDD pair.
+// UpdateBody writes the body column only, with the same WHERE
+// (id, user_id, status) optimistic-lock as Update. status is always
+// PendingReplyStatusPending at the call site — Approved / Sent /
+// Rejected rows are immutable per the domain invariant. Integration
+// tests in pending_reply_repository_test.go pin the SQL contract.
 func (r *PendingReplyRepo) UpdateBody(ctx context.Context, pr *PendingReply, expectedStatus PendingReplyStatus) error {
 	tag, err := r.q(ctx).Exec(ctx,
 		`UPDATE pending_replies

--- a/backend/internal/inbox/pending_reply_repository_test.go
+++ b/backend/internal/inbox/pending_reply_repository_test.go
@@ -391,3 +391,91 @@ func TestPendingReplyRepository_Update_PersistsStatusAndTimestamps(t *testing.T)
 	require.NotNil(t, got2.SentAt)
 	assert.WithinDuration(t, sentAt, *got2.SentAt, time.Second)
 }
+
+// --- UpdateBody (#48) ---
+
+func TestPendingReplyRepository_UpdateBody_PersistsBodyOnly(t *testing.T) {
+	// Backfills integration coverage for the body-only column write
+	// shipped alongside the usecase RED commit (#48 plan put the SQL in
+	// before the integration test, so this is honest backfill — not a
+	// fresh TDD RED).
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	pr, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "original")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, pr))
+
+	pr.Body = "edited body"
+	require.NoError(t, repo.UpdateBody(ctx, pr, inbox.PendingReplyStatusPending))
+
+	got, err := repo.GetByID(ctx, userID, pr.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "edited body", got.Body)
+	// Status stays Pending; decided_* columns stay nil — UpdateBody
+	// only touches body, never the decision columns.
+	assert.Equal(t, inbox.PendingReplyStatusPending, got.Status)
+	assert.Nil(t, got.DecidedAt)
+	assert.Nil(t, got.DecidedBy)
+	assert.Nil(t, got.SentAt)
+}
+
+func TestPendingReplyRepository_UpdateBody_OptimisticLockRejectsWhenStatusMoved(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	pr, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "original")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, pr))
+
+	// Simulate concurrent approve before edit lands: directly move
+	// status to approved in the DB.
+	_, err = pool.Exec(ctx,
+		`UPDATE pending_replies SET status = 'approved' WHERE id = $1`, pr.ID)
+	require.NoError(t, err)
+
+	pr.Body = "edit too late"
+	err = repo.UpdateBody(ctx, pr, inbox.PendingReplyStatusPending)
+	require.ErrorIs(t, err, inbox.ErrPendingReplyNotFound)
+
+	// Verify body was not silently written.
+	got, _ := repo.GetByID(ctx, userID, pr.ID)
+	require.NotNil(t, got)
+	assert.Equal(t, "original", got.Body)
+}
+
+func TestPendingReplyRepository_UpdateBody_CrossTenantReturnsNotFound(t *testing.T) {
+	pool := testutil.TestDB(t)
+	owner := testutil.SeedUser(t, pool)
+	attacker := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, owner)
+
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	pr, err := inbox.NewPendingReply(owner, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "victim body")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, pr))
+
+	// Attacker tries to edit with their UserID — repo scopes by user_id
+	// so the row is invisible.
+	pr.UserID = attacker
+	pr.Body = "tampered"
+	err = repo.UpdateBody(ctx, pr, inbox.PendingReplyStatusPending)
+	require.ErrorIs(t, err, inbox.ErrPendingReplyNotFound)
+
+	// Restore owner perspective and verify untouched.
+	pr.UserID = owner
+	got, _ := repo.GetByID(ctx, owner, pr.ID)
+	require.NotNil(t, got)
+	assert.Equal(t, "victim body", got.Body)
+}

--- a/backend/internal/inbox/pending_reply_test.go
+++ b/backend/internal/inbox/pending_reply_test.go
@@ -229,6 +229,78 @@ func TestPendingReply_MarkSent_FromApproved(t *testing.T) {
 	}
 }
 
+func TestPendingReply_UpdateBody_TrimAndReject(t *testing.T) {
+	// Table-driven: input → expected behaviour (matches the trim rule
+	// from NewPendingReply so operators get the same invariant on edit
+	// as on create).
+	cases := []struct {
+		name    string
+		input   string
+		wantErr error
+		wantBody string
+	}{
+		{"empty", "", ErrPendingReplyEmptyBody, ""},
+		{"whitespace only", "   \t\n  ", ErrPendingReplyEmptyBody, ""},
+		{"happy path", "edited body", nil, "edited body"},
+		{"trims surrounding whitespace", "  edited  ", nil, "edited"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr, err := NewPendingReply(uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "original body")
+			if err != nil {
+				t.Fatalf("setup: %v", err)
+			}
+			err = pr.UpdateBody(tc.input)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("want %v, got %v", tc.wantErr, err)
+				}
+				if pr.Body != "original body" {
+					t.Fatalf("body should be unchanged on error, got %q", pr.Body)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if pr.Body != tc.wantBody {
+				t.Fatalf("want body %q, got %q", tc.wantBody, pr.Body)
+			}
+		})
+	}
+}
+
+func TestPendingReply_UpdateBody_RejectedWhenNotPending(t *testing.T) {
+	// Table-driven: every non-Pending status must reject the edit so
+	// already-decided rows are immutable. New sentinel keeps this
+	// distinct from status-transition errors (Approve/Reject use
+	// ErrPendingReplyInvalidTransition).
+	cases := []struct {
+		name   string
+		status PendingReplyStatus
+	}{
+		{"approved", PendingReplyStatusApproved},
+		{"sent", PendingReplyStatusSent},
+		{"rejected", PendingReplyStatusRejected},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr, err := NewPendingReply(uuid.New(), uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "original")
+			if err != nil {
+				t.Fatalf("setup: %v", err)
+			}
+			pr.Status = tc.status
+			err = pr.UpdateBody("new body")
+			if !errors.Is(err, ErrPendingReplyNotEditable) {
+				t.Fatalf("want ErrPendingReplyNotEditable, got %v", err)
+			}
+			if pr.Body != "original" {
+				t.Fatalf("body should be unchanged on error, got %q", pr.Body)
+			}
+		})
+	}
+}
+
 func TestPendingReply_IllegalTransitions(t *testing.T) {
 	cases := []struct {
 		name string

--- a/backend/internal/inbox/pending_reply_usecase.go
+++ b/backend/internal/inbox/pending_reply_usecase.go
@@ -185,6 +185,36 @@ func (uc *PendingReplyUseCase) Reject(ctx context.Context, userID, id uuid.UUID)
 	return nil
 }
 
+// UpdateBody applies a body-only edit on a pending reply scoped by
+// user_id. Returns the updated entity on success so the handler can
+// surface the new body without a second round-trip. Error contract:
+//   - ErrPendingReplyNotFound: missing or cross-tenant id (uniform 404)
+//   - ErrPendingReplyAlreadyDecided: row left Pending (transition or
+//     edit race; 409 in the handler)
+//   - ErrPendingReplyEmptyBody: domain invariant (400 in the handler)
+//
+// Persistence is optimistic-locked on status=Pending so a concurrent
+// approve/reject cannot be silently overwritten.
+func (uc *PendingReplyUseCase) UpdateBody(ctx context.Context, userID, id uuid.UUID, body string) (*PendingReply, error) {
+	pr, err := uc.loadOwned(ctx, userID, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := pr.UpdateBody(body); err != nil {
+		if errors.Is(err, ErrPendingReplyNotEditable) {
+			return nil, ErrPendingReplyAlreadyDecided
+		}
+		return nil, err
+	}
+	if err := uc.repo.UpdateBody(ctx, pr, PendingReplyStatusPending); err != nil {
+		if errors.Is(err, ErrPendingReplyNotFound) {
+			return nil, ErrPendingReplyAlreadyDecided
+		}
+		return nil, fmt.Errorf("persist pending reply body: %w", err)
+	}
+	return pr, nil
+}
+
 // loadOwned fetches a reply scoped by user_id and collapses
 // "not found" and "not owned" into ErrPendingReplyNotFound so callers
 // cannot leak existence cross-tenant by inspecting the error.

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -117,6 +117,21 @@ func (f *fakePendingReplyRepo) ListByLead(_ context.Context, userID, leadID uuid
 	return out, nil
 }
 
+func (f *fakePendingReplyRepo) UpdateBody(_ context.Context, pr *PendingReply, expectedStatus PendingReplyStatus) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.updErr != nil {
+		return f.updErr
+	}
+	existing, ok := f.rows[pr.ID]
+	if !ok || existing.Status != expectedStatus {
+		return ErrPendingReplyNotFound
+	}
+	// Mirror real repo: body-only column write; do not stamp decided_*.
+	existing.Body = pr.Body
+	return nil
+}
+
 func (f *fakePendingReplyRepo) Update(_ context.Context, pr *PendingReply, expectedStatus PendingReplyStatus) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -610,5 +625,117 @@ func TestPendingReplyUseCase_Reject_AlreadyDecided(t *testing.T) {
 	err = uc.Reject(ctx, userID, pr.ID)
 	if !errors.Is(err, ErrPendingReplyAlreadyDecided) {
 		t.Fatalf("second Reject must return ErrPendingReplyAlreadyDecided, got %v", err)
+	}
+}
+
+// --- UpdateBody (#48) ---
+
+func TestPendingReplyUseCase_UpdateBody_HappyPath(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "original")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := uc.UpdateBody(ctx, userID, pr.ID, "  edited  ")
+	if err != nil {
+		t.Fatalf("UpdateBody returned error: %v", err)
+	}
+	if updated.Body != "edited" {
+		t.Fatalf("returned body = %q, want trimmed 'edited'", updated.Body)
+	}
+	// Persistence side-effect: refetch shows new body and unchanged status.
+	stored, err := repo.GetByID(ctx, userID, pr.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Body != "edited" {
+		t.Fatalf("stored body = %q, want 'edited'", stored.Body)
+	}
+	if stored.Status != PendingReplyStatusPending {
+		t.Fatalf("status changed during edit: got %v", stored.Status)
+	}
+}
+
+func TestPendingReplyUseCase_UpdateBody_NotFound(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+
+	_, err := uc.UpdateBody(ctx, uuid.New(), uuid.New(), "anything")
+	if !errors.Is(err, ErrPendingReplyNotFound) {
+		t.Fatalf("want ErrPendingReplyNotFound, got %v", err)
+	}
+}
+
+func TestPendingReplyUseCase_UpdateBody_CrossTenantIsNotFound(t *testing.T) {
+	// Cross-tenant access must collapse to NotFound — never leak existence.
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+	owner := uuid.New()
+	attacker := uuid.New()
+
+	pr, err := uc.Propose(ctx, owner, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "victim body")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = uc.UpdateBody(ctx, attacker, pr.ID, "tampered")
+	if !errors.Is(err, ErrPendingReplyNotFound) {
+		t.Fatalf("cross-tenant must return ErrPendingReplyNotFound, got %v", err)
+	}
+	// Body must remain untouched.
+	stored, _ := repo.GetByID(ctx, owner, pr.ID)
+	if stored.Body != "victim body" {
+		t.Fatalf("body tampered to %q", stored.Body)
+	}
+}
+
+func TestPendingReplyUseCase_UpdateBody_AlreadyDecidedMapsTo409(t *testing.T) {
+	// Domain returns ErrPendingReplyNotEditable on non-Pending; usecase
+	// must surface that as ErrPendingReplyAlreadyDecided so the handler
+	// answers a single 409 for both "decided too late" cases (transition
+	// race and edit race).
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "original")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := uc.Reject(ctx, userID, pr.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = uc.UpdateBody(ctx, userID, pr.ID, "too late")
+	if !errors.Is(err, ErrPendingReplyAlreadyDecided) {
+		t.Fatalf("want ErrPendingReplyAlreadyDecided, got %v", err)
+	}
+}
+
+func TestPendingReplyUseCase_UpdateBody_EmptyBodyBubbles(t *testing.T) {
+	// Domain factory invariant must bubble unchanged so handler can map
+	// to 400 (not 409). The handler distinguishes empty-body input from
+	// already-decided.
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "original")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = uc.UpdateBody(ctx, userID, pr.ID, "   ")
+	if !errors.Is(err, ErrPendingReplyEmptyBody) {
+		t.Fatalf("want ErrPendingReplyEmptyBody, got %v", err)
 	}
 }

--- a/backend/internal/inbox/ports.go
+++ b/backend/internal/inbox/ports.go
@@ -205,4 +205,12 @@ type PendingReplyRepository interface {
 	// this to ErrPendingReplyAlreadyDecided when the row was loaded
 	// in the same operation.
 	Update(ctx context.Context, pr *PendingReply, expectedStatus PendingReplyStatus) error
+	// UpdateBody persists a body-only edit on a pending row, scoped by
+	// user_id and optimistic-locked on expectedStatus (always Pending
+	// at the call site — Approved/Sent/Rejected rows are immutable per
+	// the domain invariant). Other columns are untouched. Missing /
+	// cross-tenant / lock-violated rows return ErrPendingReplyNotFound;
+	// the usecase maps that to ErrPendingReplyAlreadyDecided when the
+	// row was loaded inside the same operation.
+	UpdateBody(ctx context.Context, pr *PendingReply, expectedStatus PendingReplyStatus) error
 }

--- a/frontend/src/components/leads/PendingReplySection.test.tsx
+++ b/frontend/src/components/leads/PendingReplySection.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/lib/api", async () => {
       getPendingReplies: vi.fn(),
       approvePendingReply: vi.fn(),
       rejectPendingReply: vi.fn(),
+      updatePendingReply: vi.fn(),
     },
   };
 });
@@ -182,5 +183,100 @@ describe("PendingReplySection", () => {
     const { container } = render(<PendingReplySection leadId="lead-1" />);
     await waitFor(() => expect(api.getPendingReplies).toHaveBeenCalled());
     expect(container.firstChild).toBeNull();
+  });
+
+  // --- Edit-before-approve (#48) ---
+
+  it("shows an Edit button on each pending row", async () => {
+    vi.mocked(api.getPendingReplies).mockResolvedValue([reply()]);
+    render(<PendingReplySection leadId="lead-1" />);
+    expect(await screen.findByRole("button", { name: /Изменить/i })).toBeInTheDocument();
+  });
+
+  it("clicking Edit shows a textarea pre-filled with the body and Save/Cancel buttons", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.getPendingReplies).mockResolvedValue([reply()]);
+    render(<PendingReplySection leadId="lead-1" />);
+
+    await user.click(await screen.findByRole("button", { name: /Изменить/i }));
+
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveValue("Отлично! Вот ссылка: https://cal.com/x");
+    expect(screen.getByRole("button", { name: /Сохранить/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Отмена/i })).toBeInTheDocument();
+    // Approve / Reject must NOT be shown while editing — operators see
+    // one consistent action set per row at any moment.
+    expect(screen.queryByRole("button", { name: /Одобрить и отправить/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Отклонить$/i })).not.toBeInTheDocument();
+  });
+
+  it("Cancel exits edit mode without calling the API and restores the original body", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.getPendingReplies).mockResolvedValue([reply()]);
+    render(<PendingReplySection leadId="lead-1" />);
+
+    await user.click(await screen.findByRole("button", { name: /Изменить/i }));
+    const textarea = screen.getByRole("textbox");
+    await user.clear(textarea);
+    await user.type(textarea, "draft edits");
+    await user.click(screen.getByRole("button", { name: /Отмена/i }));
+
+    expect(api.updatePendingReply).not.toHaveBeenCalled();
+    // Original body is visible again, edit-mode controls are gone.
+    expect(screen.getByText(/Отлично! Вот ссылка/)).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("Save calls updatePendingReply, then refetches and shows the new body", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.getPendingReplies)
+      .mockResolvedValueOnce([reply()])
+      .mockResolvedValueOnce([reply({ body: "edited" })]);
+    vi.mocked(api.updatePendingReply).mockResolvedValue(reply({ body: "edited" }));
+
+    render(<PendingReplySection leadId="lead-1" />);
+    await user.click(await screen.findByRole("button", { name: /Изменить/i }));
+    const textarea = screen.getByRole("textbox");
+    await user.clear(textarea);
+    await user.type(textarea, "edited");
+    await user.click(screen.getByRole("button", { name: /Сохранить/i }));
+
+    await waitFor(() => expect(api.updatePendingReply).toHaveBeenCalledWith("pr-1", "edited"));
+    await waitFor(() => expect(api.getPendingReplies).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByText(/^edited$/)).toBeInTheDocument());
+    // After save we exit edit mode.
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("Save with empty body is disabled (no API call)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.getPendingReplies).mockResolvedValue([reply()]);
+
+    render(<PendingReplySection leadId="lead-1" />);
+    await user.click(await screen.findByRole("button", { name: /Изменить/i }));
+    await user.clear(screen.getByRole("textbox"));
+
+    const saveBtn = screen.getByRole("button", { name: /Сохранить/i });
+    expect(saveBtn).toBeDisabled();
+    // Clicking a disabled button must not call the API.
+    await user.click(saveBtn);
+    expect(api.updatePendingReply).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error message when updatePendingReply fails and keeps edit mode open", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.getPendingReplies).mockResolvedValue([reply()]);
+    vi.mocked(api.updatePendingReply).mockRejectedValue(new Error("boom"));
+
+    render(<PendingReplySection leadId="lead-1" />);
+    await user.click(await screen.findByRole("button", { name: /Изменить/i }));
+    const textarea = screen.getByRole("textbox");
+    await user.clear(textarea);
+    await user.type(textarea, "edited");
+    await user.click(screen.getByRole("button", { name: /Сохранить/i }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    // Edit mode persists so the operator can retry without re-typing.
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/leads/PendingReplySection.tsx
+++ b/frontend/src/components/leads/PendingReplySection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { ShieldCheck, X, AlertCircle } from "lucide-react";
+import { ShieldCheck, X, AlertCircle, Pencil } from "lucide-react";
 import { api, PendingReply } from "@/lib/api";
 
 interface Props {
@@ -22,11 +22,17 @@ interface Props {
  * already either visible in the conversation thread (sent) or
  * terminated (rejected), so re-displaying them adds noise without
  * value.
+ *
+ * Each row exposes Approve / Reject / Edit. Edit (#48) flips the row
+ * into a textarea + Save/Cancel; Save calls PATCH and refetches so
+ * the row reflects whatever the server stored.
  */
 export function PendingReplySection({ leadId, onApproved }: Props) {
   const [replies, setReplies] = useState<PendingReply[] | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
 
   useEffect(() => {
     let cancelled = false;
@@ -47,12 +53,6 @@ export function PendingReplySection({ leadId, onApproved }: Props) {
   const pending = replies.filter((r) => r.status === "pending");
   if (pending.length === 0) return null;
 
-  // refreshFromServer replaces local state with the server's view of
-  // the queue. Costs one extra round-trip per decision but closes the
-  // 'list reflects truth' invariant: if the dispatcher silently kept
-  // the row at 'approved' (Update→approved succeeded, Update→sent
-  // didn't), the operator sees the row back instead of an
-  // optimistically-stale UI.
   async function refreshFromServer() {
     try {
       const fresh = await api.getPendingReplies(leadId);
@@ -91,6 +91,35 @@ export function PendingReplySection({ leadId, onApproved }: Props) {
     }
   }
 
+  function startEdit(r: PendingReply) {
+    setEditingId(r.id);
+    setDraft(r.body);
+    setError(null);
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setDraft("");
+  }
+
+  async function handleSave(id: string) {
+    const trimmed = draft.trim();
+    if (trimmed === "") return; // Save button is also disabled — belt + suspenders.
+    setBusyId(id);
+    setError(null);
+    try {
+      await api.updatePendingReply(id, trimmed);
+      await refreshFromServer();
+      setEditingId(null);
+      setDraft("");
+    } catch {
+      setError("Не удалось сохранить — попробуйте ещё раз");
+      // Stay in edit mode so the operator can retry without re-typing.
+    } finally {
+      setBusyId(null);
+    }
+  }
+
   return (
     <section
       className="mb-8 rounded-xl border border-[#f5b73c]/40 bg-[#fff8e1] p-5 shadow-sm"
@@ -119,38 +148,80 @@ export function PendingReplySection({ leadId, onApproved }: Props) {
       <ul className="space-y-3">
         {pending.map((r) => {
           const isBusy = busyId === r.id;
+          const isEditing = editingId === r.id;
           return (
             <li
               key={r.id}
               className="rounded-lg border border-[#f5b73c]/30 bg-white p-4"
             >
-              <p className="mb-3 whitespace-pre-wrap text-sm text-[#0d1c2e]">
-                {r.body}
-              </p>
+              {isEditing ? (
+                <textarea
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  disabled={isBusy}
+                  rows={Math.max(3, draft.split("\n").length)}
+                  className="mb-3 w-full resize-y rounded-md border border-[#c3c6d7]/50 bg-white px-3 py-2 text-sm text-[#0d1c2e] focus:border-[#0d7a2c] focus:outline-none disabled:opacity-50"
+                  aria-label="Тело сообщения"
+                />
+              ) : (
+                <p className="mb-3 whitespace-pre-wrap text-sm text-[#0d1c2e]">
+                  {r.body}
+                </p>
+              )}
               <div className="flex items-center justify-between gap-3">
                 <span className="text-[0.65rem] font-medium uppercase tracking-wide text-[#737686]">
                   {kindLabel(r.kind)} · {channelLabel(r.channel)}
                 </span>
-                <div className="flex gap-2">
-                  <button
-                    type="button"
-                    onClick={() => handleReject(r.id)}
-                    disabled={isBusy}
-                    className="inline-flex items-center gap-1.5 rounded-lg border border-[#c3c6d7]/50 bg-white px-3 py-1.5 text-xs font-semibold text-[#434655] transition-colors hover:bg-[#f7f9fd] disabled:opacity-50"
-                  >
-                    <X className="size-3.5" />
-                    Отклонить
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleApprove(r.id)}
-                    disabled={isBusy}
-                    className="inline-flex items-center gap-1.5 rounded-lg bg-[#0d7a2c] px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[#0a6324] disabled:opacity-50"
-                  >
-                    <ShieldCheck className="size-3.5" />
-                    Одобрить и отправить
-                  </button>
-                </div>
+                {isEditing ? (
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={cancelEdit}
+                      disabled={isBusy}
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-[#c3c6d7]/50 bg-white px-3 py-1.5 text-xs font-semibold text-[#434655] transition-colors hover:bg-[#f7f9fd] disabled:opacity-50"
+                    >
+                      Отмена
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleSave(r.id)}
+                      disabled={isBusy || draft.trim() === ""}
+                      className="inline-flex items-center gap-1.5 rounded-lg bg-[#0d7a2c] px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[#0a6324] disabled:opacity-50"
+                    >
+                      Сохранить
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleReject(r.id)}
+                      disabled={isBusy}
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-[#c3c6d7]/50 bg-white px-3 py-1.5 text-xs font-semibold text-[#434655] transition-colors hover:bg-[#f7f9fd] disabled:opacity-50"
+                    >
+                      <X className="size-3.5" />
+                      Отклонить
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => startEdit(r)}
+                      disabled={isBusy}
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-[#c3c6d7]/50 bg-white px-3 py-1.5 text-xs font-semibold text-[#434655] transition-colors hover:bg-[#f7f9fd] disabled:opacity-50"
+                    >
+                      <Pencil className="size-3.5" />
+                      Изменить
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleApprove(r.id)}
+                      disabled={isBusy}
+                      className="inline-flex items-center gap-1.5 rounded-lg bg-[#0d7a2c] px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[#0a6324] disabled:opacity-50"
+                    >
+                      <ShieldCheck className="size-3.5" />
+                      Одобрить и отправить
+                    </button>
+                  </div>
+                )}
               </div>
             </li>
           );

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -375,5 +375,28 @@ describe("api module", () => {
       expect(url).toBe("http://localhost:8080/api/pending-replies/pr-2/reject");
       expect(opts.method).toBe("POST");
     });
+
+    it("updatePendingReply → PATCH /api/pending-replies/:id with body", async () => {
+      const updated = {
+        id: "pr-3",
+        lead_id: "lead-3",
+        channel: "telegram",
+        kind: "booking_link",
+        body: "edited body",
+        status: "pending",
+        created_at: "2026-05-19T10:00:00Z",
+      };
+      fetchMock.mockResolvedValueOnce(mockResponse(updated));
+
+      const result = await api.updatePendingReply("pr-3", "edited body");
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("http://localhost:8080/api/pending-replies/pr-3");
+      expect(opts.method).toBe("PATCH");
+      expect(JSON.parse(opts.body)).toEqual({ body: "edited body" });
+      // PATCH returns 200 + the updated entity (NOT 204), so the API
+      // method must surface the new body to the UI without a refetch.
+      expect(result).toEqual(updated);
+    });
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -191,6 +191,15 @@ export const api = {
     apiFetch<void>(`/api/pending-replies/${id}/approve`, { method: "POST" }),
   rejectPendingReply: (id: string) =>
     apiFetch<void>(`/api/pending-replies/${id}/reject`, { method: "POST" }),
+  // Edit-before-approve (#48). Returns the updated PendingReply so the
+  // caller can render the new body in place without a refetch round-trip.
+  // Only valid while the row is in 'pending' status — backend answers
+  // 409 once approved/sent/rejected.
+  updatePendingReply: (id: string, body: string) =>
+    apiFetch<PendingReply>(`/api/pending-replies/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ body }),
+    }),
 
   // Reminders
   getReminders: () => apiFetch<Reminder[]>("/api/reminders"),


### PR DESCRIPTION
## Summary

Operators get a third action on each pending reply — Edit — alongside Approve / Reject. Clicking Edit flips the row into a textarea pre-filled with the body; Save calls PATCH and refetches.

Closes #48.

## Layers (TDD pairs)

| Layer | RED | GREEN |
|---|---|---|
| Domain | `a7235d8` | `f7445f9` |
| Usecase | `0d599b0` | `f512876` |
| Repo (integration) | — | `f7821c1` (backfill — SQL added with usecase RED to satisfy port; honest commit name per CLAUDE.md gate) |
| Handler | `1aa9758` | `beb5c76` |
| Frontend API | `b7e6738` | `de27bb7` |
| Frontend UI | `c330def` | `4c1eb6f` |
| Review fix-up | — | `a23df06` (clarify comment) |

## Contract

- `PATCH /api/pending-replies/:id` body `{"body": "..."}` → 200 + full PendingReplyResponse JSON.
- 400 if body field missing / malformed JSON / empty-after-trim.
- 404 if missing or cross-tenant (uniform — no info leak).
- 409 if row left `pending` (transition or edit race; both collapse).
- Rate-limited via the same `decideMW` as Approve/Reject.
- Optimistic-locked: `WHERE id = $X AND user_id = $Y AND status = 'pending'` so concurrent decide does not silently overwrite edits in the wrong direction.

## Review

Independent code-reviewer pass: TDD 8/10, DDD 10/10, CA 9/10, Hygiene 9/10. Ready to merge. Two follow-ups opened:
- #81 — Approve dispatcher uses stale body after concurrent edit (pre-existing pattern; not regressed by #48).

## Test plan

- [x] `go test ./...` — full backend unit suite green
- [x] `npx vitest run` — 374 frontend tests green (was 367; +5 contract + edit-mode)
- [x] `npm run lint && npm run build` — clean
- [ ] Integration tests (repo UpdateBody × 3) verify on CI
- [ ] Manual UI: edit a pending reply, Save, verify row reflects new body