### PR TITLE
fix(inbox/hitl): Approve re-reads body before dispatch (#81)

### DIFF
--- a/backend/internal/inbox/pending_reply_usecase.go
+++ b/backend/internal/inbox/pending_reply_usecase.go
@@ -147,16 +147,30 @@ func (uc *PendingReplyUseCase) Approve(ctx context.Context, userID, id uuid.UUID
 	if uc.dispatcher == nil {
 		return ErrPendingReplyDispatcherNotConfigured
 	}
-	if err := uc.dispatcher.Dispatch(ctx, pr); err != nil {
+	// Re-read after the optimistic-lock Update so a concurrent edit
+	// that committed in the gap [loadOwned, Update] does not
+	// silently dispatch the pre-edit body (#81). The DB holds the
+	// canonical body; our in-memory pr.Body is the load-time
+	// snapshot. The Update only writes decision columns, never body,
+	// so any edit's body change survives.
+	//
+	// Re-read failure is degraded: fall back to the in-memory
+	// snapshot so a transient DB hiccup does not block delivery of
+	// an already-approved row.
+	dispatchTarget := pr
+	if fresh, ferr := uc.repo.GetByID(ctx, userID, pr.ID); ferr == nil && fresh != nil {
+		dispatchTarget = fresh
+	}
+	if err := uc.dispatcher.Dispatch(ctx, dispatchTarget); err != nil {
 		return fmt.Errorf("dispatch approved pending reply: %w", err)
 	}
-	if err := pr.MarkSent(time.Now().UTC()); err != nil {
+	if err := dispatchTarget.MarkSent(time.Now().UTC()); err != nil {
 		return fmt.Errorf("mark pending reply sent: %w", err)
 	}
 	// The persisted row should still be at status=approved (we just
 	// set it). A NotFound here would be a serious anomaly — log it
 	// rather than convert to AlreadyDecided.
-	if err := uc.repo.Update(ctx, pr, PendingReplyStatusApproved); err != nil {
+	if err := uc.repo.Update(ctx, dispatchTarget, PendingReplyStatusApproved); err != nil {
 		return fmt.Errorf("persist sent pending reply: %w", err)
 	}
 	return nil

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -27,6 +27,12 @@ type fakePendingReplyRepo struct {
 	// for the same (user_id, lead_id, kind, body) tuple. Off by default
 	// so existing tests are unaffected.
 	dedupOnSave bool
+	// postUpdateHook fires after a successful Update / UpdateBody and
+	// receives the stored row (mutable). Tests use this to simulate a
+	// concurrent operation landing between the optimistic-lock Update
+	// and the next read — e.g. an edit racing with Approve (#81).
+	// Lock is already held when the hook runs.
+	postUpdateHook func(stored *PendingReply)
 }
 
 func newFakeRepo() *fakePendingReplyRepo {
@@ -147,6 +153,9 @@ func (f *fakePendingReplyRepo) Update(_ context.Context, pr *PendingReply, expec
 	}
 	copy := *pr
 	f.rows[pr.ID] = &copy
+	if f.postUpdateHook != nil {
+		f.postUpdateHook(f.rows[pr.ID])
+	}
 	return nil
 }
 
@@ -737,5 +746,51 @@ func TestPendingReplyUseCase_UpdateBody_EmptyBodyBubbles(t *testing.T) {
 	_, err = uc.UpdateBody(ctx, userID, pr.ID, "   ")
 	if !errors.Is(err, ErrPendingReplyEmptyBody) {
 		t.Fatalf("want ErrPendingReplyEmptyBody, got %v", err)
+	}
+}
+
+// --- Approve re-reads body before dispatch (#81) ---
+
+func TestPendingReplyUseCase_Approve_DispatchesPostEditBody(t *testing.T) {
+	// Race scenario: operator A clicks Edit → Save while operator B
+	// clicks Approve. A's body lands in the DB before B's Approve
+	// dispatches. Without a post-lock re-read, B's dispatcher would
+	// use the load-time body snapshot — and the customer would
+	// receive A's pre-edit body even though the DB shows the edit.
+	//
+	// The fix: after the optimistic-lock Update succeeds, re-read
+	// the row and dispatch the fresh body. This test pins that
+	// invariant — dispatcher must observe the post-edit body.
+	repo := newFakeRepo()
+	disp := &spyDispatcher{}
+	uc := NewPendingReplyUseCase(repo, disp)
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "original")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate concurrent edit: after Approve's Update commits the
+	// status flip to approved, an edit lands and rewrites the body.
+	// The hook fires inside the same lock — equivalent to an edit
+	// committing while Approve was between Update and Dispatch.
+	repo.postUpdateHook = func(stored *PendingReply) {
+		if stored.Status == PendingReplyStatusApproved {
+			stored.Body = "edited body"
+		}
+	}
+
+	if err := uc.Approve(ctx, userID, pr.ID); err != nil {
+		t.Fatalf("Approve returned error: %v", err)
+	}
+
+	calls := disp.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("dispatcher call count = %d, want 1", len(calls))
+	}
+	if calls[0].Body != "edited body" {
+		t.Errorf("dispatcher received body %q, want 'edited body' — Approve must re-read after the optimistic-lock Update so the dispatched body reflects any concurrent edit, not the load-time snapshot", calls[0].Body)
 	}
 }


### PR DESCRIPTION
## Summary

Race fix: edit lands in DB between Approve's `loadOwned` and `repo.Update(pr, Pending)`; dispatcher used the load-time snapshot so the customer received the pre-edit body even though the DB stored the edit.

Closes #81. Surfaced as a pre-existing issue during #48 review.

## Fix

After the optimistic-lock Update succeeds, re-read the row via `GetByID` and pass the fresh entity through to `Dispatch` → `MarkSent` → second `Update`. Degraded fallback: re-read failure uses the load-time snapshot (transient DB hiccup must not block already-approved delivery).

## TDD

- `89fe847` RED — new `postUpdateHook` on the fake repo simulates a concurrent edit landing inside the optimistic-lock window. Assertion: `disp.Calls()[0].Body == "edited body"`. Pre-fix: receives `"original"`.
- `6fb22ab` GREEN — re-read after Update + thread fresh entity through the rest of the flow.

## Review

Independent code-reviewer pass: Correctness 9/10, TDD 10/10, Robustness 8/10. Ready to merge. One nice-to-have (warn log on degraded fallback) skipped — usecase has no structured logger; adding one for this single line is out of scope for a race fix.

## Test plan

- [x] `go test ./internal/inbox/...` — all inbox tests pass (full backend suite green too)
- [x] RED commit fails with exact assertion message before the fix
- [ ] Integration verifies on CI