### PR TITLE
feat(inbox/hitl): operator queue page at /inbox/pending (#51)

### DIFF
--- a/backend/internal/inbox/handler.go
+++ b/backend/internal/inbox/handler.go
@@ -104,12 +104,39 @@ func (h *pendingReplyHandler) listByLead() http.HandlerFunc {
 	}
 }
 
-// listPendingByUser — stub for the RED step of #51. Real impl lands in
-// the matching GREEN commit; tests fail at runtime so the build stays
-// bisect-friendly.
+// listPendingByUser answers the operator queue: every status='pending'
+// row across every lead the operator owns, joined with the minimum
+// lead snippet the frontend needs to render contact + company without
+// an N+1 lookup.
+//
+// The ?status query param is optional. When absent it defaults to
+// pending so bare /api/pending-replies works for the queue page. When
+// present it MUST be 'pending' — answering 400 to anything else keeps
+// the door open for a future widening (e.g. ?status=approved for a
+// "recent decisions" tab) without silently filtering today.
 func (h *pendingReplyHandler) listPendingByUser() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		httputil.WriteError(w, http.StatusNotImplemented, "listPendingByUser not implemented")
+		userID, ok := httputil.UserIDFromContext(r.Context())
+		if !ok {
+			httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		switch r.URL.Query().Get("status") {
+		case "", "pending":
+			// accepted
+		default:
+			httputil.WriteError(w, http.StatusBadRequest, "unsupported status filter (only 'pending' is supported)")
+			return
+		}
+		rows, err := h.uc.ListPendingByUser(r.Context(), userID)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "pending reply list-by-user failed",
+				slog.String("user_id", userID.String()),
+				slog.Any("err", err))
+			httputil.WriteError(w, http.StatusInternalServerError, "failed to list pending replies")
+			return
+		}
+		httputil.WriteJSON(w, http.StatusOK, operatorQueueToResponse(rows))
 	}
 }
 
@@ -266,6 +293,52 @@ func pendingRepliesToResponse(rows []*PendingReply) []PendingReplyResponse {
 	out := make([]PendingReplyResponse, 0, len(rows))
 	for _, pr := range rows {
 		out = append(out, pendingReplyToResponse(pr))
+	}
+	return out
+}
+
+// LeadSnippetResponse is the wire-shape for the lead context embedded
+// in each operator-queue row. Nullable channel-native identifiers are
+// omitempty so a telegram lead never carries a JSON null email and
+// vice versa — the frontend can branch on field presence.
+type LeadSnippetResponse struct {
+	ContactName    string  `json:"contact_name"`
+	Company        string  `json:"company"`
+	Channel        string  `json:"channel"`
+	TelegramChatID *int64  `json:"telegram_chat_id,omitempty"`
+	EmailAddress   *string `json:"email_address,omitempty"`
+}
+
+// OperatorQueueResponse is the wire-shape for a single row in the
+// operator queue. Embeds PendingReplyResponse so existing top-level
+// fields stay identical to the per-lead endpoint, and adds a nested
+// "lead" object so the queue page can render contact + company in one
+// pass without N+1.
+type OperatorQueueResponse struct {
+	PendingReplyResponse
+	Lead LeadSnippetResponse `json:"lead"`
+}
+
+func leadSnippetToResponse(s LeadSnippet) LeadSnippetResponse {
+	return LeadSnippetResponse{
+		ContactName:    s.ContactName,
+		Company:        s.Company,
+		Channel:        string(s.Channel),
+		TelegramChatID: s.TelegramChatID,
+		EmailAddress:   s.EmailAddress,
+	}
+}
+
+func operatorQueueToResponse(rows []*PendingReplyWithLead) []OperatorQueueResponse {
+	out := make([]OperatorQueueResponse, 0, len(rows))
+	for _, row := range rows {
+		if row == nil || row.Reply == nil {
+			continue
+		}
+		out = append(out, OperatorQueueResponse{
+			PendingReplyResponse: pendingReplyToResponse(row.Reply),
+			Lead:                 leadSnippetToResponse(row.Lead),
+		})
 	}
 	return out
 }

--- a/backend/internal/inbox/handler.go
+++ b/backend/internal/inbox/handler.go
@@ -19,6 +19,7 @@ import (
 // stand up without any persistence backend.
 type PendingReplyUseCaseAPI interface {
 	ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error)
+	ListPendingByUser(ctx context.Context, userID uuid.UUID) ([]*PendingReplyWithLead, error)
 	Approve(ctx context.Context, userID, id uuid.UUID) error
 	Reject(ctx context.Context, userID, id uuid.UUID) error
 	UpdateBody(ctx context.Context, userID, id uuid.UUID, body string) (*PendingReply, error)
@@ -57,6 +58,9 @@ type pendingReplyHandler struct {
 func RegisterPendingReplyRoutes(r chi.Router, uc PendingReplyUseCaseAPI, leads LeadOwnershipChecker, decideMW func(http.Handler) http.Handler) {
 	h := &pendingReplyHandler{uc: uc, leads: leads}
 	r.Get("/api/leads/{id}/pending-replies", h.listByLead())
+	// Operator queue: all pending rows for the current user across
+	// every lead. Idempotent + read-only — not rate-limited.
+	r.Get("/api/pending-replies", h.listPendingByUser())
 	if decideMW == nil {
 		r.Post("/api/pending-replies/{id}/approve", h.approve())
 		r.Post("/api/pending-replies/{id}/reject", h.reject())
@@ -97,6 +101,15 @@ func (h *pendingReplyHandler) listByLead() http.HandlerFunc {
 			return
 		}
 		httputil.WriteJSON(w, http.StatusOK, pendingRepliesToResponse(rows))
+	}
+}
+
+// listPendingByUser — stub for the RED step of #51. Real impl lands in
+// the matching GREEN commit; tests fail at runtime so the build stays
+// bisect-friendly.
+func (h *pendingReplyHandler) listPendingByUser() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		httputil.WriteError(w, http.StatusNotImplemented, "listPendingByUser not implemented")
 	}
 }
 

--- a/backend/internal/inbox/handler_test.go
+++ b/backend/internal/inbox/handler_test.go
@@ -319,6 +319,14 @@ func TestHandler_ListPendingByUser_HappyPath_EnrichedWithLeadSnippet(t *testing.
 	if _, present := lead["email_address"]; present {
 		t.Errorf("lead.email_address must be omitempty when nil, got %v", lead["email_address"])
 	}
+	// Pending rows have no decision yet — the wire DTO must NOT carry
+	// decided_at / decided_by / sent_at to avoid confusing the queue
+	// UI ("why does this row look approved?"). omitempty contract.
+	for _, field := range []string{"decided_at", "decided_by", "sent_at"} {
+		if _, present := row[field]; present {
+			t.Errorf("%s must be omitempty on a pending row, got %v", field, row[field])
+		}
+	}
 }
 
 func TestHandler_ListPendingByUser_DefaultsStatusToPendingWhenAbsent(t *testing.T) {

--- a/backend/internal/inbox/handler_test.go
+++ b/backend/internal/inbox/handler_test.go
@@ -21,15 +21,23 @@ import (
 type fakePendingReplyUseCase struct {
 	mu sync.Mutex
 
-	listFn       func(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error)
-	approveFn    func(ctx context.Context, userID, id uuid.UUID) error
-	rejectFn     func(ctx context.Context, userID, id uuid.UUID) error
-	updateBodyFn func(ctx context.Context, userID, id uuid.UUID, body string) (*PendingReply, error)
+	listFn              func(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error)
+	listPendingByUserFn func(ctx context.Context, userID uuid.UUID) ([]*PendingReplyWithLead, error)
+	approveFn           func(ctx context.Context, userID, id uuid.UUID) error
+	rejectFn            func(ctx context.Context, userID, id uuid.UUID) error
+	updateBodyFn        func(ctx context.Context, userID, id uuid.UUID, body string) (*PendingReply, error)
 }
 
 func (f *fakePendingReplyUseCase) ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error) {
 	if f.listFn != nil {
 		return f.listFn(ctx, userID, leadID)
+	}
+	return nil, nil
+}
+
+func (f *fakePendingReplyUseCase) ListPendingByUser(ctx context.Context, userID uuid.UUID) ([]*PendingReplyWithLead, error) {
+	if f.listPendingByUserFn != nil {
+		return f.listPendingByUserFn(ctx, userID)
 	}
 	return nil, nil
 }
@@ -237,6 +245,166 @@ func TestHandler_ListByLead_CrossTenantReturns404(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404 (uniform — no info leak)", rec.Code)
+	}
+}
+
+// --- GET /api/pending-replies (operator queue) ---
+
+func TestHandler_ListPendingByUser_HappyPath_EnrichedWithLeadSnippet(t *testing.T) {
+	userID := uuid.New()
+	leadID := uuid.New()
+	pr, err := NewPendingReply(userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "queue body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	chat := int64(987654)
+	uc := &fakePendingReplyUseCase{
+		listPendingByUserFn: func(_ context.Context, u uuid.UUID) ([]*PendingReplyWithLead, error) {
+			if u != userID {
+				t.Errorf("usecase received wrong user id: %v", u)
+			}
+			return []*PendingReplyWithLead{{
+				Reply: pr,
+				Lead: LeadSnippet{
+					ContactName:    "Иван Петров",
+					Company:        "ACME",
+					Channel:        ChannelTelegram,
+					TelegramChatID: &chat,
+				},
+			}}, nil
+		},
+	}
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+	req := authedRequest(t, http.MethodGet, "/api/pending-replies?status=pending", userID)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	var got []map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("response len = %d, want 1", len(got))
+	}
+	row := got[0]
+	if row["id"] != pr.ID.String() {
+		t.Errorf("id = %v, want %v", row["id"], pr.ID)
+	}
+	if row["body"] != "queue body" {
+		t.Errorf("body = %v, want queue body", row["body"])
+	}
+	if row["status"] != "pending" {
+		t.Errorf("status = %v, want pending", row["status"])
+	}
+	lead, ok := row["lead"].(map[string]any)
+	if !ok {
+		t.Fatalf("lead field missing or wrong shape: %v", row["lead"])
+	}
+	if lead["contact_name"] != "Иван Петров" {
+		t.Errorf("lead.contact_name = %v", lead["contact_name"])
+	}
+	if lead["company"] != "ACME" {
+		t.Errorf("lead.company = %v", lead["company"])
+	}
+	if lead["channel"] != "telegram" {
+		t.Errorf("lead.channel = %v", lead["channel"])
+	}
+	// JSON numbers decode to float64. Compare via that lens.
+	if got, want := lead["telegram_chat_id"], float64(987654); got != want {
+		t.Errorf("lead.telegram_chat_id = %v, want %v", got, want)
+	}
+	if _, present := lead["email_address"]; present {
+		t.Errorf("lead.email_address must be omitempty when nil, got %v", lead["email_address"])
+	}
+}
+
+func TestHandler_ListPendingByUser_DefaultsStatusToPendingWhenAbsent(t *testing.T) {
+	userID := uuid.New()
+	called := false
+	uc := &fakePendingReplyUseCase{
+		listPendingByUserFn: func(_ context.Context, _ uuid.UUID) ([]*PendingReplyWithLead, error) {
+			called = true
+			return nil, nil
+		},
+	}
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+	// No ?status= param.
+	req := authedRequest(t, http.MethodGet, "/api/pending-replies", userID)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (default to pending) — operators hit this URL with no filter for the queue", rec.Code)
+	}
+	if !called {
+		t.Error("usecase must have been invoked when ?status is absent — handler defaults to pending")
+	}
+}
+
+func TestHandler_ListPendingByUser_EmptyReturnsJSONArrayNotNull(t *testing.T) {
+	uc := &fakePendingReplyUseCase{
+		listPendingByUserFn: func(_ context.Context, _ uuid.UUID) ([]*PendingReplyWithLead, error) {
+			return nil, nil
+		},
+	}
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+	req := authedRequest(t, http.MethodGet, "/api/pending-replies?status=pending", uuid.New())
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := strings.TrimSpace(rec.Body.String())
+	if body != "[]" {
+		t.Errorf("empty list body = %q, want %q (must not be JSON null)", body, "[]")
+	}
+}
+
+func TestHandler_ListPendingByUser_NoUserReturns401(t *testing.T) {
+	srv := newTestServer(&fakePendingReplyUseCase{}, &fakeLeadOwnership{})
+	req := httptest.NewRequest(http.MethodGet, "/api/pending-replies?status=pending", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestHandler_ListPendingByUser_UnsupportedStatusReturns400(t *testing.T) {
+	uc := &fakePendingReplyUseCase{
+		listPendingByUserFn: func(_ context.Context, _ uuid.UUID) ([]*PendingReplyWithLead, error) {
+			t.Fatal("usecase must NOT be called when status filter is rejected")
+			return nil, nil
+		},
+	}
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+	req := authedRequest(t, http.MethodGet, "/api/pending-replies?status=approved", uuid.New())
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (only pending is supported today)", rec.Code)
+	}
+}
+
+func TestHandler_ListPendingByUser_UsecaseErrorReturns500(t *testing.T) {
+	uc := &fakePendingReplyUseCase{
+		listPendingByUserFn: func(_ context.Context, _ uuid.UUID) ([]*PendingReplyWithLead, error) {
+			return nil, errors.New("db hiccup")
+		},
+	}
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+	req := authedRequest(t, http.MethodGet, "/api/pending-replies?status=pending", uuid.New())
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
 	}
 }
 

--- a/backend/internal/inbox/pending_reply_repository.go
+++ b/backend/internal/inbox/pending_reply_repository.go
@@ -142,6 +142,13 @@ func (r *PendingReplyRepo) ListByLead(ctx context.Context, userID, leadID uuid.U
 	return out, rows.Err()
 }
 
+// ListPendingByUser — stub for the RED step of #51. Impl lands in the
+// matching GREEN commit; tests against this method fail at runtime
+// rather than at compile time so the build stays green for bisect.
+func (r *PendingReplyRepo) ListPendingByUser(_ context.Context, _ uuid.UUID) ([]*PendingReplyWithLead, error) {
+	return nil, errors.New("pending reply repo: ListPendingByUser not implemented")
+}
+
 // CountPendingByUser returns the per-lead count of rows still awaiting
 // operator decision (status='pending') for the given user. Used by
 // the leads-context inbox-list badge.

--- a/backend/internal/inbox/pending_reply_repository.go
+++ b/backend/internal/inbox/pending_reply_repository.go
@@ -142,11 +142,50 @@ func (r *PendingReplyRepo) ListByLead(ctx context.Context, userID, leadID uuid.U
 	return out, rows.Err()
 }
 
-// ListPendingByUser — stub for the RED step of #51. Impl lands in the
-// matching GREEN commit; tests against this method fail at runtime
-// rather than at compile time so the build stays green for bisect.
-func (r *PendingReplyRepo) ListPendingByUser(_ context.Context, _ uuid.UUID) ([]*PendingReplyWithLead, error) {
-	return nil, errors.New("pending reply repo: ListPendingByUser not implemented")
+// ListPendingByUser returns every status='pending' row for the user
+// joined with the minimum lead context the operator queue needs to
+// render — contact + company + channel + identifiers — in one query
+// so the frontend avoids N+1 lookups. user_id is enforced on both
+// sides of the join as defense in depth: even though leads.user_id
+// and pending_replies.user_id should match for the same lead_id, an
+// explicit join predicate makes the cross-tenant invariant local to
+// the SQL rather than relying on FK semantics.
+//
+// Returns an empty (non-nil) slice when nothing is pending so callers
+// can iterate without a nil-check.
+func (r *PendingReplyRepo) ListPendingByUser(ctx context.Context, userID uuid.UUID) ([]*PendingReplyWithLead, error) {
+	rows, err := r.q(ctx).Query(ctx,
+		`SELECT pr.id, pr.user_id, pr.lead_id, pr.channel, pr.kind, pr.body, pr.status,
+		        pr.created_at, pr.decided_at, pr.decided_by, pr.sent_at,
+		        l.contact_name, l.company, l.channel, l.telegram_chat_id, l.email_address
+		 FROM pending_replies pr
+		 JOIN leads l ON l.id = pr.lead_id AND l.user_id = pr.user_id
+		 WHERE pr.user_id = $1 AND pr.status = 'pending'
+		 ORDER BY pr.created_at DESC`,
+		userID)
+	if err != nil {
+		return nil, fmt.Errorf("list pending replies by user: %w", err)
+	}
+	defer rows.Close()
+	out := make([]*PendingReplyWithLead, 0)
+	for rows.Next() {
+		var pr PendingReply
+		var channel, kind, status string
+		var leadChannel string
+		var snippet LeadSnippet
+		if err := rows.Scan(&pr.ID, &pr.UserID, &pr.LeadID, &channel, &kind, &pr.Body, &status,
+			&pr.CreatedAt, &pr.DecidedAt, &pr.DecidedBy, &pr.SentAt,
+			&snippet.ContactName, &snippet.Company, &leadChannel,
+			&snippet.TelegramChatID, &snippet.EmailAddress); err != nil {
+			return nil, fmt.Errorf("scan pending reply with lead: %w", err)
+		}
+		pr.Channel = Channel(channel)
+		pr.Kind = PendingReplyKind(kind)
+		pr.Status = PendingReplyStatus(status)
+		snippet.Channel = Channel(leadChannel)
+		out = append(out, &PendingReplyWithLead{Reply: &pr, Lead: snippet})
+	}
+	return out, rows.Err()
 }
 
 // CountPendingByUser returns the per-lead count of rows still awaiting

--- a/backend/internal/inbox/pending_reply_repository_test.go
+++ b/backend/internal/inbox/pending_reply_repository_test.go
@@ -479,3 +479,175 @@ func TestPendingReplyRepository_UpdateBody_CrossTenantReturnsNotFound(t *testing
 	require.NotNil(t, got)
 	assert.Equal(t, "victim body", got.Body)
 }
+
+// seedRichLead inserts a lead with caller-controlled snippet fields so
+// the ListPendingByUser tests can assert the JOIN payload (contact +
+// company + channel + identifiers). Keeps seedLeadForUser as the
+// minimal helper for the rest of the suite.
+func seedRichLead(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID, channel, contactName, company string, tgChatID *int64, email *string) uuid.UUID {
+	t.Helper()
+	leadID := uuid.New()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO leads (id, user_id, channel, contact_name, company, first_message, status, telegram_chat_id, email_address, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, 'hi', 'new', $6, $7, NOW(), NOW())`,
+		leadID, userID, channel, contactName, company, tgChatID, email)
+	require.NoError(t, err, "seed rich test lead")
+	return leadID
+}
+
+func TestPendingReplyRepository_ListPendingByUser_ReturnsJoinedSnippet(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+
+	tgChatID := int64(1234567)
+	email := "lead@example.com"
+	tgLead := seedRichLead(t, pool, userID, "telegram", "Иван Петров", "ACME", &tgChatID, nil)
+	mailLead := seedRichLead(t, pool, userID, "email", "Jane Doe", "Globex", nil, &email)
+
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	tgPR, err := inbox.NewPendingReply(userID, tgLead, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "tg draft")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, tgPR))
+
+	mailPR, err := inbox.NewPendingReply(userID, mailLead, inbox.ChannelEmail, inbox.PendingReplyKindBookingLink, "email draft")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, mailPR))
+
+	got, err := repo.ListPendingByUser(ctx, userID)
+	require.NoError(t, err)
+	require.Len(t, got, 2, "both pending rows must surface")
+
+	byReply := map[uuid.UUID]*inbox.PendingReplyWithLead{}
+	for _, row := range got {
+		require.NotNil(t, row, "no nil entries in the result slice")
+		require.NotNil(t, row.Reply, "Reply must be populated")
+		byReply[row.Reply.ID] = row
+	}
+
+	tgRow := byReply[tgPR.ID]
+	require.NotNil(t, tgRow, "telegram pending row must be present")
+	assert.Equal(t, "Иван Петров", tgRow.Lead.ContactName)
+	assert.Equal(t, "ACME", tgRow.Lead.Company)
+	assert.Equal(t, inbox.ChannelTelegram, tgRow.Lead.Channel)
+	require.NotNil(t, tgRow.Lead.TelegramChatID)
+	assert.Equal(t, int64(1234567), *tgRow.Lead.TelegramChatID)
+	assert.Nil(t, tgRow.Lead.EmailAddress, "telegram lead has no email — column must surface as nil")
+
+	mailRow := byReply[mailPR.ID]
+	require.NotNil(t, mailRow, "email pending row must be present")
+	assert.Equal(t, "Jane Doe", mailRow.Lead.ContactName)
+	assert.Equal(t, "Globex", mailRow.Lead.Company)
+	assert.Equal(t, inbox.ChannelEmail, mailRow.Lead.Channel)
+	assert.Nil(t, mailRow.Lead.TelegramChatID)
+	require.NotNil(t, mailRow.Lead.EmailAddress)
+	assert.Equal(t, "lead@example.com", *mailRow.Lead.EmailAddress)
+}
+
+func TestPendingReplyRepository_ListPendingByUser_FiltersDecidedRows(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	// Pending — must surface.
+	pending, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "still pending")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, pending))
+
+	// Approved — must be filtered.
+	approved, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "already approved")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, approved))
+	_, err = pool.Exec(ctx,
+		`UPDATE pending_replies SET status = 'approved' WHERE id = $1`, approved.ID)
+	require.NoError(t, err)
+
+	// Sent — must be filtered.
+	sent, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "already sent")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, sent))
+	_, err = pool.Exec(ctx,
+		`UPDATE pending_replies SET status = 'sent' WHERE id = $1`, sent.ID)
+	require.NoError(t, err)
+
+	// Rejected — must be filtered.
+	rejected, err := inbox.NewPendingReply(userID, leadID, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "already rejected")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, rejected))
+	_, err = pool.Exec(ctx,
+		`UPDATE pending_replies SET status = 'rejected' WHERE id = $1`, rejected.ID)
+	require.NoError(t, err)
+
+	got, err := repo.ListPendingByUser(ctx, userID)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "only the pending row surfaces — decided rows are out of operator queue scope")
+	assert.Equal(t, pending.ID, got[0].Reply.ID)
+}
+
+func TestPendingReplyRepository_ListPendingByUser_ScopedByUser(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userA := testutil.SeedUser(t, pool)
+	userB := testutil.SeedUser(t, pool)
+	leadA := seedLeadForUser(t, pool, userA)
+
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	prA, err := inbox.NewPendingReply(userA, leadA, inbox.ChannelTelegram, inbox.PendingReplyKindBookingLink, "owned by A")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, prA))
+
+	// userB has no leads and no pending rows.
+	got, err := repo.ListPendingByUser(ctx, userB)
+	require.NoError(t, err, "cross-tenant list must not error — empty is the right shape")
+	assert.Empty(t, got, "userB must never see userA's pending rows")
+}
+
+func TestPendingReplyRepository_ListPendingByUser_OrdersByCreatedAtDesc(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	leadID := seedLeadForUser(t, pool, userID)
+
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	// Insert three rows with distinct created_at to pin ordering. Use
+	// direct SQL so we can control the timestamp — NewPendingReply
+	// stamps time.Now() which would race within a single test.
+	t0 := time.Now().UTC().Add(-3 * time.Hour)
+	t1 := t0.Add(time.Hour)
+	t2 := t1.Add(time.Hour)
+	ids := []uuid.UUID{uuid.New(), uuid.New(), uuid.New()}
+	for i, ts := range []time.Time{t0, t1, t2} {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO pending_replies (id, user_id, lead_id, channel, kind, body, status, created_at)
+			 VALUES ($1, $2, $3, 'telegram', 'booking_link', $4, 'pending', $5)`,
+			ids[i], userID, leadID, "body"+ts.Format("150405"), ts)
+		require.NoError(t, err)
+	}
+
+	got, err := repo.ListPendingByUser(ctx, userID)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	// Newest (t2) first, oldest (t0) last.
+	assert.Equal(t, ids[2], got[0].Reply.ID, "newest pending row must be first")
+	assert.Equal(t, ids[1], got[1].Reply.ID)
+	assert.Equal(t, ids[0], got[2].Reply.ID, "oldest pending row must be last")
+}
+
+func TestPendingReplyRepository_ListPendingByUser_EmptyReturnsEmptySlice(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+
+	repo := inbox.NewPendingReplyRepository(pool)
+	ctx := context.Background()
+
+	got, err := repo.ListPendingByUser(ctx, userID)
+	require.NoError(t, err)
+	require.NotNil(t, got, "empty result must be a non-nil empty slice — callers iterate without nil-check")
+	assert.Empty(t, got)
+}

--- a/backend/internal/inbox/pending_reply_usecase.go
+++ b/backend/internal/inbox/pending_reply_usecase.go
@@ -118,11 +118,13 @@ func (uc *PendingReplyUseCase) ListByLead(ctx context.Context, userID, leadID uu
 	return uc.repo.ListByLead(ctx, userID, leadID)
 }
 
-// ListPendingByUser — stub for the RED step of #51. Impl lands in the
-// matching GREEN commit; tests against this method fail at runtime
-// rather than at compile time so the build stays green for bisect.
-func (uc *PendingReplyUseCase) ListPendingByUser(_ context.Context, _ uuid.UUID) ([]*PendingReplyWithLead, error) {
-	return nil, errors.New("pending reply usecase: ListPendingByUser not implemented")
+// ListPendingByUser returns every status='pending' row for the user
+// joined with the lead snippet the operator queue needs. Passthrough
+// to the repository — there is no per-row authorization to apply
+// because user_id scoping is already enforced inside the SQL query;
+// cross-tenant leakage is impossible at this layer.
+func (uc *PendingReplyUseCase) ListPendingByUser(ctx context.Context, userID uuid.UUID) ([]*PendingReplyWithLead, error) {
+	return uc.repo.ListPendingByUser(ctx, userID)
 }
 
 // Approve transitions the reply into Approved, persists the decision,

--- a/backend/internal/inbox/pending_reply_usecase.go
+++ b/backend/internal/inbox/pending_reply_usecase.go
@@ -118,6 +118,13 @@ func (uc *PendingReplyUseCase) ListByLead(ctx context.Context, userID, leadID uu
 	return uc.repo.ListByLead(ctx, userID, leadID)
 }
 
+// ListPendingByUser — stub for the RED step of #51. Impl lands in the
+// matching GREEN commit; tests against this method fail at runtime
+// rather than at compile time so the build stays green for bisect.
+func (uc *PendingReplyUseCase) ListPendingByUser(_ context.Context, _ uuid.UUID) ([]*PendingReplyWithLead, error) {
+	return nil, errors.New("pending reply usecase: ListPendingByUser not implemented")
+}
+
 // Approve transitions the reply into Approved, persists the decision,
 // dispatches through the channel-native transport, and (on success)
 // marks the entity Sent. A dispatch failure leaves the entity in

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -16,11 +16,12 @@ import (
 type fakePendingReplyRepo struct {
 	mu       sync.Mutex
 	rows     map[uuid.UUID]*PendingReply
-	saveErr  error
-	getErr   error
-	updErr   error
-	listErr  error
-	findErr  error
+	saveErr        error
+	getErr         error
+	updErr         error
+	listErr        error
+	findErr        error
+	listByUserErr  error
 	// dedupOnSave mirrors the partial unique index that production
 	// installs in migration 031: when true, Save returns
 	// ErrPendingReplyDuplicatePending if a pending row already exists
@@ -118,6 +119,26 @@ func (f *fakePendingReplyRepo) ListByLead(_ context.Context, userID, leadID uuid
 		if row.UserID == userID && row.LeadID == leadID {
 			copy := *row
 			out = append(out, &copy)
+		}
+	}
+	return out, nil
+}
+
+// ListPendingByUser — in-memory mirror of the SQL query: filter on
+// user_id + status='pending'. The fake has no lead store so LeadSnippet
+// stays zero-valued; usecase-layer tests only assert passthrough,
+// real JOIN coverage lives in the repository integration suite.
+func (f *fakePendingReplyRepo) ListPendingByUser(_ context.Context, userID uuid.UUID) ([]*PendingReplyWithLead, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listByUserErr != nil {
+		return nil, f.listByUserErr
+	}
+	out := []*PendingReplyWithLead{}
+	for _, row := range f.rows {
+		if row.UserID == userID && row.Status == PendingReplyStatusPending {
+			copy := *row
+			out = append(out, &PendingReplyWithLead{Reply: &copy})
 		}
 	}
 	return out, nil

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -815,3 +815,63 @@ func TestPendingReplyUseCase_Approve_DispatchesPostEditBody(t *testing.T) {
 		t.Errorf("dispatcher received body %q, want 'edited body' — Approve must re-read after the optimistic-lock Update so the dispatched body reflects any concurrent edit, not the load-time snapshot", calls[0].Body)
 	}
 }
+
+// --- ListPendingByUser ---
+
+func TestPendingReplyUseCase_ListPendingByUser_PassesThroughRepoRows(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+	userID := uuid.New()
+	leadID := uuid.New()
+
+	// Two pending rows for our user + one for a different user (must
+	// not surface). The fake's ListPendingByUser mirrors the SQL
+	// status+user_id filter so the usecase passthrough is what
+	// produces the visible behaviour.
+	pr1, err := uc.Propose(ctx, userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "first")
+	if err != nil {
+		t.Fatalf("Propose returned error: %v", err)
+	}
+	pr2, err := uc.Propose(ctx, userID, leadID, ChannelTelegram, PendingReplyKindBookingLink, "second")
+	if err != nil {
+		t.Fatalf("Propose returned error: %v", err)
+	}
+	otherUser := uuid.New()
+	if _, err := uc.Propose(ctx, otherUser, leadID, ChannelTelegram, PendingReplyKindBookingLink, "third"); err != nil {
+		t.Fatalf("Propose returned error: %v", err)
+	}
+
+	got, err := uc.ListPendingByUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("ListPendingByUser returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d rows, want 2 (other user's row must not surface)", len(got))
+	}
+	seen := map[uuid.UUID]bool{}
+	for _, row := range got {
+		if row == nil || row.Reply == nil {
+			t.Fatal("nil entry in result")
+		}
+		seen[row.Reply.ID] = true
+	}
+	if !seen[pr1.ID] || !seen[pr2.ID] {
+		t.Errorf("missing expected pending IDs in result; got %v", seen)
+	}
+}
+
+func TestPendingReplyUseCase_ListPendingByUser_PropagatesRepoError(t *testing.T) {
+	repo := newFakeRepo()
+	sentinel := errors.New("repo went sideways")
+	repo.listByUserErr = sentinel
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+
+	_, err := uc.ListPendingByUser(context.Background(), uuid.New())
+	if err == nil {
+		t.Fatal("expected repo error to propagate, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected wrapped repo error, got %v — usecase must surface the underlying repo failure so callers can introspect", err)
+	}
+}

--- a/backend/internal/inbox/pending_reply_view.go
+++ b/backend/internal/inbox/pending_reply_view.go
@@ -1,7 +1,5 @@
 package inbox
 
-import "github.com/google/uuid"
-
 // LeadSnippet is the minimal lead context the operator queue needs
 // alongside a PendingReply row: who is this draft for, on what
 // channel, and how do we identify them. Public fields — this is a
@@ -29,13 +27,4 @@ type LeadSnippet struct {
 type PendingReplyWithLead struct {
 	Reply *PendingReply
 	Lead  LeadSnippet
-}
-
-// PendingReplyID is a typed accessor so callers don't have to reach
-// through the embedded pointer. Used by the handler when logging.
-func (v *PendingReplyWithLead) PendingReplyID() uuid.UUID {
-	if v == nil || v.Reply == nil {
-		return uuid.Nil
-	}
-	return v.Reply.ID
 }

--- a/backend/internal/inbox/pending_reply_view.go
+++ b/backend/internal/inbox/pending_reply_view.go
@@ -1,0 +1,41 @@
+package inbox
+
+import "github.com/google/uuid"
+
+// LeadSnippet is the minimal lead context the operator queue needs
+// alongside a PendingReply row: who is this draft for, on what
+// channel, and how do we identify them. Public fields — this is a
+// DTO carried between repository and handler, not a domain entity.
+//
+// TelegramChatID / EmailAddress are nullable: a Telegram-channel lead
+// has no email and vice versa. Callers MUST tolerate either being nil.
+type LeadSnippet struct {
+	ContactName    string
+	Company        string
+	Channel        Channel
+	TelegramChatID *int64
+	EmailAddress   *string
+}
+
+// PendingReplyWithLead is the joined read-model returned by the
+// operator-queue endpoint. It bundles a PendingReply with just enough
+// lead context (LeadSnippet) for the queue page to render contact +
+// company without an N+1 fetch on the frontend.
+//
+// The embedded *PendingReply is the same aggregate exposed by the
+// per-lead listing endpoint — keeping the shape identical means the
+// frontend can reuse the existing PendingReplyResponse marshalling and
+// only widen the wire DTO with a nested lead object.
+type PendingReplyWithLead struct {
+	Reply *PendingReply
+	Lead  LeadSnippet
+}
+
+// PendingReplyID is a typed accessor so callers don't have to reach
+// through the embedded pointer. Used by the handler when logging.
+func (v *PendingReplyWithLead) PendingReplyID() uuid.UUID {
+	if v == nil || v.Reply == nil {
+		return uuid.Nil
+	}
+	return v.Reply.ID
+}

--- a/backend/internal/inbox/ports.go
+++ b/backend/internal/inbox/ports.go
@@ -196,6 +196,15 @@ type PendingReplyRepository interface {
 	// inbox-list badge — wired through an adapter so the leads package
 	// stays free of inbox-package imports.
 	CountPendingByUser(ctx context.Context, userID uuid.UUID) (map[uuid.UUID]int, error)
+	// ListPendingByUser returns every pending-status row for the user,
+	// joined with the minimum lead context the operator queue needs to
+	// render contact + company without an N+1 fetch on the frontend.
+	// Scoped by user_id; cross-tenant rows are silently filtered, never
+	// surfaced. Rows are ordered by created_at DESC so the newest draft
+	// floats to the top of the queue — matches the outbound-queue
+	// convention. Returns an empty slice (not nil) when nothing is
+	// pending so callers can iterate without a nil-check.
+	ListPendingByUser(ctx context.Context, userID uuid.UUID) ([]*PendingReplyWithLead, error)
 	// Update writes pr only when the persisted row still matches the
 	// expectedStatus the caller observed at load time — an optimistic
 	// lock that prevents two operators from concurrently approving

--- a/frontend/src/app/(dashboard)/inbox/page.test.tsx
+++ b/frontend/src/app/(dashboard)/inbox/page.test.tsx
@@ -204,9 +204,15 @@ describe("InboxPage", () => {
 
     render(<InboxPage />);
 
+    // PendingQueueTabs adds two nav links (/inbox, /inbox/pending) at
+    // the top of the page; the lead card adds a third. Find the one
+    // pointing at the lead detail by its href to keep this assertion
+    // robust to layout chrome added around the list.
     await waitFor(() => {
-      const link = screen.getByRole("link");
-      expect(link).toHaveAttribute("href", "/inbox/lead-42");
+      const link = screen
+        .getAllByRole("link")
+        .find((a) => a.getAttribute("href") === "/inbox/lead-42");
+      expect(link).toBeDefined();
     });
   });
 });

--- a/frontend/src/app/(dashboard)/inbox/page.tsx
+++ b/frontend/src/app/(dashboard)/inbox/page.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { FILTER_TABS } from "@/components/inbox/constants";
 import { PipelineSidebar } from "@/components/inbox/PipelineSidebar";
 import { LeadCard } from "@/components/leads/LeadCard";
+import { PendingQueueTabs } from "@/components/pending-queue/PendingQueueTabs";
 import { useInboxPage } from "@/hooks/useInboxPage";
 
 export default function InboxPage() {
@@ -22,6 +23,7 @@ export default function InboxPage() {
 
       <section className="flex-1 overflow-y-auto px-4 sm:px-8 lg:px-12 py-8">
         <div className="mx-auto max-w-4xl space-y-8">
+          <PendingQueueTabs />
           <div className="flex items-end justify-between">
             <div>
               <div className="flex items-center gap-3">

--- a/frontend/src/app/(dashboard)/inbox/pending/page.test.tsx
+++ b/frontend/src/app/(dashboard)/inbox/pending/page.test.tsx
@@ -1,0 +1,163 @@
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PendingReplyQueueRow } from "@/lib/api";
+import InboxPendingPage from "./page";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+  usePathname: () => "/inbox/pending",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: { children: ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    listPendingReplies: vi.fn(),
+    approvePendingReply: vi.fn(),
+    rejectPendingReply: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+
+function makeRow(over: Partial<PendingReplyQueueRow> = {}): PendingReplyQueueRow {
+  return {
+    id: over.id ?? "pr-1",
+    lead_id: over.lead_id ?? "lead-1",
+    channel: over.channel ?? "telegram",
+    kind: over.kind ?? "booking_link",
+    body: over.body ?? "Hi, here's my booking link",
+    status: "pending",
+    created_at: over.created_at ?? "2026-05-20T10:00:00Z",
+    lead: over.lead ?? {
+      contact_name: "Иван Петров",
+      company: "ACME",
+      channel: "telegram",
+      telegram_chat_id: 123,
+    },
+  };
+}
+
+describe("InboxPendingPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.listPendingReplies).mockResolvedValue([]);
+    vi.mocked(api.approvePendingReply).mockResolvedValue(undefined);
+    vi.mocked(api.rejectPendingReply).mockResolvedValue(undefined);
+  });
+
+  it("fetches the queue on mount and renders rows with lead context", async () => {
+    vi.mocked(api.listPendingReplies).mockResolvedValueOnce([
+      makeRow({ id: "pr-1", body: "Telegram draft" }),
+      makeRow({
+        id: "pr-2",
+        channel: "email",
+        body: "Email draft",
+        lead: { contact_name: "Jane Doe", company: "Globex", channel: "email", email_address: "j@globex.com" },
+      }),
+    ]);
+
+    render(<InboxPendingPage />);
+
+    await waitFor(() => {
+      expect(api.listPendingReplies).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByText("Telegram draft")).toBeInTheDocument();
+    expect(screen.getByText("Email draft")).toBeInTheDocument();
+    // Lead name + company collapse into one line; assert both halves
+    // appear so a regression in either column is caught.
+    expect(screen.getByText(/Иван Петров/)).toBeInTheDocument();
+    expect(screen.getByText(/ACME/)).toBeInTheDocument();
+    expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
+    expect(screen.getByText(/Globex/)).toBeInTheDocument();
+  });
+
+  it("renders empty state when queue is empty", async () => {
+    vi.mocked(api.listPendingReplies).mockResolvedValueOnce([]);
+
+    render(<InboxPendingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Нет драфтов на одобрение")).toBeInTheDocument();
+    });
+  });
+
+  it("approve button calls api.approvePendingReply and optimistically removes the row", async () => {
+    vi.mocked(api.listPendingReplies).mockResolvedValueOnce([
+      makeRow({ id: "pr-7", body: "Going away" }),
+    ]);
+    const user = userEvent.setup();
+
+    render(<InboxPendingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Going away")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Одобрить/ }));
+
+    await waitFor(() => {
+      expect(api.approvePendingReply).toHaveBeenCalledWith("pr-7");
+    });
+    // Optimistic removal — the row should disappear without a refetch.
+    await waitFor(() => {
+      expect(screen.queryByText("Going away")).not.toBeInTheDocument();
+    });
+  });
+
+  it("reject button calls api.rejectPendingReply", async () => {
+    vi.mocked(api.listPendingReplies).mockResolvedValueOnce([
+      makeRow({ id: "pr-9", body: "Reject me" }),
+    ]);
+    const user = userEvent.setup();
+
+    render(<InboxPendingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Reject me")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Отклонить/ }));
+
+    await waitFor(() => {
+      expect(api.rejectPendingReply).toHaveBeenCalledWith("pr-9");
+    });
+  });
+
+  it("channel filter hides rows from the unselected channel", async () => {
+    vi.mocked(api.listPendingReplies).mockResolvedValueOnce([
+      makeRow({ id: "pr-tg", body: "TG body", channel: "telegram" }),
+      makeRow({
+        id: "pr-em",
+        body: "Email body",
+        channel: "email",
+        lead: { contact_name: "Eve", company: "Hooli", channel: "email" },
+      }),
+    ]);
+    const user = userEvent.setup();
+
+    render(<InboxPendingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("TG body")).toBeInTheDocument();
+      expect(screen.getByText("Email body")).toBeInTheDocument();
+    });
+
+    // Filter pills label "Telegram" / "Email" appear twice — once in
+    // the row metadata, once in the filter bar. Find the filter pill
+    // by its button role to avoid the row-meta span.
+    const tgFilter = screen.getAllByRole("button", { name: /^Telegram$/ })[0];
+    await user.click(tgFilter);
+
+    expect(screen.getByText("TG body")).toBeInTheDocument();
+    expect(screen.queryByText("Email body")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(dashboard)/inbox/pending/page.test.tsx
+++ b/frontend/src/app/(dashboard)/inbox/pending/page.test.tsx
@@ -48,7 +48,7 @@ function makeRow(over: Partial<PendingReplyQueueRow> = {}): PendingReplyQueueRow
 
 describe("InboxPendingPage", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     vi.mocked(api.listPendingReplies).mockResolvedValue([]);
     vi.mocked(api.approvePendingReply).mockResolvedValue(undefined);
     vi.mocked(api.rejectPendingReply).mockResolvedValue(undefined);

--- a/frontend/src/app/(dashboard)/inbox/pending/page.tsx
+++ b/frontend/src/app/(dashboard)/inbox/pending/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { ShieldCheck } from "lucide-react";
+import { FilterPill } from "@/components/outbound/FilterPill";
+import { PendingQueueRow } from "@/components/pending-queue/PendingQueueRow";
+import { PendingQueueTabs } from "@/components/pending-queue/PendingQueueTabs";
+import { usePendingQueue } from "@/hooks/usePendingQueue";
+
+export default function InboxPendingPage() {
+  const q = usePendingQueue();
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  async function withBusy(id: string, op: (id: string) => Promise<void>) {
+    setBusyId(id);
+    try {
+      await op(id);
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <section className="flex-1 overflow-y-auto px-4 sm:px-8 lg:px-12 py-8">
+      <div className="mx-auto max-w-4xl">
+        <div className="mb-6 flex items-end justify-between">
+          <div>
+            <div className="flex items-center gap-3">
+              <h2 className="text-2xl sm:text-3xl font-extrabold tracking-tight text-[#0d1c2e]">
+                Очередь HITL
+              </h2>
+              {q.loading && (
+                <div className="size-5 animate-spin rounded-full border-2 border-[#3b6ef6] border-t-transparent" />
+              )}
+            </div>
+            <p className="mt-1 text-sm text-[#434655]">
+              Auto-черновики, ожидающие вашего одобрения перед отправкой
+            </p>
+          </div>
+          <span className="text-[11px] text-[#737686]">
+            Обновлено: {q.lastUpdated.toLocaleTimeString("ru-RU")}
+          </span>
+        </div>
+
+        <PendingQueueTabs pendingCount={q.rows.length} />
+
+        <div className="mb-6 flex flex-wrap items-center gap-2">
+          <span className="mr-2 text-[11px] font-bold uppercase tracking-wider text-[#737686]">
+            Канал
+          </span>
+          <FilterPill label="Все" value="all" current={q.channelFilter} onChange={q.setChannelFilter} />
+          <FilterPill label="Telegram" value="telegram" current={q.channelFilter} onChange={q.setChannelFilter} />
+          <FilterPill label="Email" value="email" current={q.channelFilter} onChange={q.setChannelFilter} />
+          <span className="ml-6 mr-2 text-[11px] font-bold uppercase tracking-wider text-[#737686]">
+            Тип
+          </span>
+          <FilterPill label="Все" value="all" current={q.kindFilter} onChange={q.setKindFilter} />
+          <FilterPill label="Встреча" value="booking_link" current={q.kindFilter} onChange={q.setKindFilter} />
+        </div>
+
+        {!q.loading && q.filtered.length === 0 && (
+          <div className="flex flex-col items-center justify-center rounded-2xl bg-white py-16 text-center">
+            <ShieldCheck className="mb-4 size-10 text-[#c3c6d7]" />
+            <p className="text-lg font-semibold text-[#434655]">
+              {q.rows.length === 0 ? "Нет драфтов на одобрение" : "Под фильтр ничего не попало"}
+            </p>
+            <p className="mt-1 text-sm text-[#737686]">
+              {q.rows.length === 0
+                ? "AI-черновики появляются здесь, как только подходящее сообщение прилетает от лида"
+                : "Снимите фильтр канала или типа, чтобы увидеть весь список"}
+            </p>
+          </div>
+        )}
+
+        <ul className="space-y-3">
+          {q.filtered.map((row) => (
+            <PendingQueueRow
+              key={row.id}
+              row={row}
+              busy={busyId === row.id}
+              onApprove={(id) => withBusy(id, q.handleApprove)}
+              onReject={(id) => withBusy(id, q.handleReject)}
+            />
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/(dashboard)/inbox/pending/page.tsx
+++ b/frontend/src/app/(dashboard)/inbox/pending/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { ShieldCheck } from "lucide-react";
 import { FilterPill } from "@/components/outbound/FilterPill";
+import { formatTime } from "@/components/outbound/constants";
 import { PendingQueueRow } from "@/components/pending-queue/PendingQueueRow";
 import { PendingQueueTabs } from "@/components/pending-queue/PendingQueueTabs";
 import { usePendingQueue } from "@/hooks/usePendingQueue";
@@ -38,7 +39,7 @@ export default function InboxPendingPage() {
             </p>
           </div>
           <span className="text-[11px] text-[#737686]">
-            Обновлено: {q.lastUpdated.toLocaleTimeString("ru-RU")}
+            Обновлено: {formatTime(q.lastUpdated)}
           </span>
         </div>
 

--- a/frontend/src/components/pending-queue/PendingQueueRow.tsx
+++ b/frontend/src/components/pending-queue/PendingQueueRow.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+import { ShieldCheck, X, Mail, Send } from "lucide-react";
+import type { PendingReplyQueueRow } from "@/lib/api";
+
+interface Props {
+  row: PendingReplyQueueRow;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+  busy?: boolean;
+}
+
+const KIND_LABELS: Record<PendingReplyQueueRow["kind"], string> = {
+  booking_link: "Ссылка на встречу",
+};
+
+const CHANNEL_LABELS: Record<PendingReplyQueueRow["channel"], string> = {
+  telegram: "Telegram",
+  email: "Email",
+};
+
+export function PendingQueueRow({ row, onApprove, onReject, busy = false }: Props) {
+  const isEmail = row.channel === "email";
+  return (
+    <li className="rounded-xl border border-[#f5b73c]/30 bg-white p-5 transition-shadow hover:shadow-sm">
+      <header className="mb-3 flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div
+            className={`flex size-10 items-center justify-center rounded-full ${
+              isEmail ? "bg-[#dbe1ff]" : "bg-[#d5e0f8]"
+            }`}
+            aria-hidden
+          >
+            {isEmail ? (
+              <Mail className="size-5 text-[#0d1c2e]" />
+            ) : (
+              <Send className="size-5 text-[#0d1c2e]" />
+            )}
+          </div>
+          <div className="min-w-0">
+            <Link
+              href={`/inbox/${row.lead_id}`}
+              className="block truncate text-sm font-bold text-[#0d1c2e] hover:text-[#004ac6] hover:underline"
+            >
+              {row.lead.contact_name || "Без имени"}
+              {row.lead.company ? ` · ${row.lead.company}` : ""}
+            </Link>
+            <p className="mt-0.5 text-[11px] font-medium text-[#737686]">
+              {KIND_LABELS[row.kind] ?? row.kind} · {CHANNEL_LABELS[row.channel] ?? row.channel}
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <p className="mb-4 whitespace-pre-wrap text-sm text-[#0d1c2e]">{row.body}</p>
+
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={() => onReject(row.id)}
+          disabled={busy}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-[#c3c6d7]/50 bg-white px-3 py-1.5 text-xs font-semibold text-[#434655] transition-colors hover:bg-[#f7f9fd] disabled:opacity-50"
+        >
+          <X className="size-3.5" />
+          Отклонить
+        </button>
+        <button
+          type="button"
+          onClick={() => onApprove(row.id)}
+          disabled={busy}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-[#0d7a2c] px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[#0a6324] disabled:opacity-50"
+        >
+          <ShieldCheck className="size-3.5" />
+          Одобрить и отправить
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/frontend/src/components/pending-queue/PendingQueueTabs.tsx
+++ b/frontend/src/components/pending-queue/PendingQueueTabs.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  /** Optional pending count shown in the second tab. Undefined hides
+   *  the badge — call sites that already know the count (queue page)
+   *  pass it; callers that don't (leads list) omit it. */
+  pendingCount?: number;
+}
+
+/**
+ * PendingQueueTabs renders the inbox sub-navigation: all leads vs
+ * pending-approval queue. Sits at the top of /inbox and /inbox/pending
+ * so operators can flip between the two without leaving the section.
+ *
+ * Active tab is derived from usePathname; nested routes under /inbox
+ * (e.g. /inbox/[leadId]) keep the "All leads" tab highlighted because
+ * /inbox/pending is the only sibling that flips it.
+ */
+export function PendingQueueTabs({ pendingCount }: Props) {
+  const pathname = usePathname();
+  const onPending = pathname === "/inbox/pending";
+
+  return (
+    <div className="mb-6 flex gap-1 rounded-xl bg-[#eff4ff] p-1">
+      <Link
+        href="/inbox"
+        className={cn(
+          "flex-1 rounded-lg px-4 py-2 text-center text-sm font-bold transition-all",
+          !onPending
+            ? "bg-white text-[#0d1c2e] shadow-sm"
+            : "text-[#434655] hover:text-[#0d1c2e]"
+        )}
+      >
+        Все лиды
+      </Link>
+      <Link
+        href="/inbox/pending"
+        className={cn(
+          "flex-1 rounded-lg px-4 py-2 text-center text-sm font-bold transition-all",
+          onPending
+            ? "bg-white text-[#0d1c2e] shadow-sm"
+            : "text-[#434655] hover:text-[#0d1c2e]"
+        )}
+      >
+        Очередь HITL{pendingCount !== undefined ? ` (${pendingCount})` : ""}
+      </Link>
+    </div>
+  );
+}

--- a/frontend/src/hooks/usePendingQueue.test.ts
+++ b/frontend/src/hooks/usePendingQueue.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { PendingReplyQueueRow } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    listPendingReplies: vi.fn(),
+    approvePendingReply: vi.fn(),
+    rejectPendingReply: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { POLL_INTERVAL_MS, usePendingQueue } from "./usePendingQueue";
+
+function row(over: Partial<PendingReplyQueueRow> = {}): PendingReplyQueueRow {
+  return {
+    id: over.id ?? "pr-1",
+    lead_id: over.lead_id ?? "lead-1",
+    channel: over.channel ?? "telegram",
+    kind: over.kind ?? "booking_link",
+    body: over.body ?? "draft",
+    status: "pending",
+    created_at: over.created_at ?? "2026-05-20T10:00:00Z",
+    lead: over.lead ?? {
+      contact_name: "X",
+      company: "Y",
+      channel: "telegram",
+    },
+  };
+}
+
+describe("usePendingQueue", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("fetches once on mount and stops loading", async () => {
+    vi.mocked(api.listPendingReplies).mockResolvedValueOnce([row({ id: "a" })]);
+
+    const { result } = renderHook(() => usePendingQueue());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(api.listPendingReplies).toHaveBeenCalledTimes(1);
+    expect(result.current.rows).toHaveLength(1);
+    expect(result.current.lastUpdated).toBeInstanceOf(Date);
+  });
+
+  it("polls every POLL_INTERVAL_MS", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      vi.mocked(api.listPendingReplies).mockResolvedValue([]);
+      renderHook(() => usePendingQueue());
+
+      // Initial fetch — microtasks flush via shouldAdvanceTime.
+      await waitFor(() => {
+        expect(api.listPendingReplies).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      });
+      expect(api.listPendingReplies).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 2);
+      });
+      expect(api.listPendingReplies).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps last-good state when polling errors out", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      vi.mocked(api.listPendingReplies)
+        .mockResolvedValueOnce([row({ id: "alpha" })])
+        .mockRejectedValueOnce(new Error("5xx"));
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { result } = renderHook(() => usePendingQueue());
+
+      await waitFor(() => {
+        expect(result.current.rows).toHaveLength(1);
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      });
+
+      // Last-good row stays — operator never sees an empty screen on a
+      // transient backend hiccup. console.warn fires for ops visibility.
+      expect(result.current.rows).toHaveLength(1);
+      expect(result.current.rows[0]!.id).toBe("alpha");
+      expect(warn).toHaveBeenCalled();
+      warn.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refetches when approve fails (recovery path)", async () => {
+    vi.mocked(api.listPendingReplies)
+      .mockResolvedValueOnce([row({ id: "a" })])
+      .mockResolvedValueOnce([row({ id: "a" }), row({ id: "b" })]);
+    vi.mocked(api.approvePendingReply).mockRejectedValueOnce(new Error("boom"));
+
+    const { result } = renderHook(() => usePendingQueue());
+
+    await waitFor(() => {
+      expect(result.current.rows).toHaveLength(1);
+    });
+
+    await act(async () => {
+      await result.current.handleApprove("a");
+    });
+
+    expect(api.approvePendingReply).toHaveBeenCalledWith("a");
+    expect(api.listPendingReplies).toHaveBeenCalledTimes(2);
+    expect(result.current.rows).toHaveLength(2);
+  });
+
+  it("kind filter narrows visible rows", async () => {
+    vi.mocked(api.listPendingReplies).mockResolvedValueOnce([
+      row({ id: "a", kind: "booking_link" }),
+    ]);
+
+    const { result } = renderHook(() => usePendingQueue());
+
+    await waitFor(() => {
+      expect(result.current.filtered).toHaveLength(1);
+    });
+
+    act(() => {
+      result.current.setKindFilter("booking_link");
+    });
+    expect(result.current.filtered).toHaveLength(1);
+
+    // No "other" kind exists yet on the type side; cast through unknown
+    // to exercise the negative branch. When a second kind ships, swap
+    // for a real value.
+    act(() => {
+      (result.current.setKindFilter as (k: string) => void)("__no_match__");
+    });
+    expect(result.current.filtered).toHaveLength(0);
+  });
+
+  it("channel filter excludes rows from the other channel", async () => {
+    vi.mocked(api.listPendingReplies).mockResolvedValueOnce([
+      row({ id: "tg", channel: "telegram" }),
+      row({
+        id: "em",
+        channel: "email",
+        lead: { contact_name: "E", company: "F", channel: "email" },
+      }),
+    ]);
+
+    const { result } = renderHook(() => usePendingQueue());
+
+    await waitFor(() => {
+      expect(result.current.rows).toHaveLength(2);
+    });
+
+    act(() => {
+      result.current.setChannelFilter("telegram");
+    });
+    expect(result.current.filtered.map((r) => r.id)).toEqual(["tg"]);
+
+    act(() => {
+      result.current.setChannelFilter("email");
+    });
+    expect(result.current.filtered.map((r) => r.id)).toEqual(["em"]);
+  });
+});

--- a/frontend/src/hooks/usePendingQueue.ts
+++ b/frontend/src/hooks/usePendingQueue.ts
@@ -1,0 +1,77 @@
+import { useState, useEffect, useCallback } from "react";
+import { api, type PendingReplyQueueRow, type PendingReplyKind } from "@/lib/api";
+
+type ChannelFilter = "all" | "telegram" | "email";
+type KindFilter = "all" | PendingReplyKind;
+
+export function usePendingQueue() {
+  const [rows, setRows] = useState<PendingReplyQueueRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [channelFilter, setChannelFilter] = useState<ChannelFilter>("all");
+  const [kindFilter, setKindFilter] = useState<KindFilter>("all");
+  const [lastUpdated, setLastUpdated] = useState<Date>(new Date());
+
+  const fetchData = useCallback(async (isInitial: boolean) => {
+    try {
+      const data = await api.listPendingReplies();
+      setRows(data);
+      setLastUpdated(new Date());
+    } catch {
+      // Keep last-good state; the interval will retry.
+    } finally {
+      if (isInitial) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchData(true); }, [fetchData]);
+  useEffect(() => {
+    const id = setInterval(() => fetchData(false), 10_000);
+    return () => clearInterval(id);
+  }, [fetchData]);
+
+  // Optimistic remove on approve/reject so the queue feels instant.
+  // On error refetch to recover; the dispatcher may have actually
+  // succeeded even when the wire returned 5xx, so the source of truth
+  // is the next list response, not local state.
+  const handleApprove = async (id: string) => {
+    try {
+      await api.approvePendingReply(id);
+      setRows((prev) => prev.filter((r) => r.id !== id));
+    } catch {
+      await fetchData(false);
+    }
+  };
+
+  const handleReject = async (id: string) => {
+    try {
+      await api.rejectPendingReply(id);
+      setRows((prev) => prev.filter((r) => r.id !== id));
+    } catch {
+      await fetchData(false);
+    }
+  };
+
+  const handleEdited = (id: string, newBody: string) => {
+    setRows((prev) => prev.map((r) => (r.id === id ? { ...r, body: newBody } : r)));
+  };
+
+  const filtered = rows.filter((r) => {
+    if (channelFilter !== "all" && r.channel !== channelFilter) return false;
+    if (kindFilter !== "all" && r.kind !== kindFilter) return false;
+    return true;
+  });
+
+  return {
+    rows,
+    filtered,
+    loading,
+    lastUpdated,
+    channelFilter,
+    setChannelFilter,
+    kindFilter,
+    setKindFilter,
+    handleApprove,
+    handleReject,
+    handleEdited,
+  };
+}

--- a/frontend/src/hooks/usePendingQueue.ts
+++ b/frontend/src/hooks/usePendingQueue.ts
@@ -4,6 +4,8 @@ import { api, type PendingReplyQueueRow, type PendingReplyKind } from "@/lib/api
 type ChannelFilter = "all" | "telegram" | "email";
 type KindFilter = "all" | PendingReplyKind;
 
+export const POLL_INTERVAL_MS = 10_000;
+
 export function usePendingQueue() {
   const [rows, setRows] = useState<PendingReplyQueueRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -16,8 +18,10 @@ export function usePendingQueue() {
       const data = await api.listPendingReplies();
       setRows(data);
       setLastUpdated(new Date());
-    } catch {
-      // Keep last-good state; the interval will retry.
+    } catch (e) {
+      // Keep last-good state; the interval will retry. Surface to the
+      // console so a silent 5xx loop is debuggable from the browser.
+      console.warn("pending queue refetch failed", e);
     } finally {
       if (isInitial) setLoading(false);
     }
@@ -25,7 +29,7 @@ export function usePendingQueue() {
 
   useEffect(() => { fetchData(true); }, [fetchData]);
   useEffect(() => {
-    const id = setInterval(() => fetchData(false), 10_000);
+    const id = setInterval(() => fetchData(false), POLL_INTERVAL_MS);
     return () => clearInterval(id);
   }, [fetchData]);
 
@@ -51,10 +55,6 @@ export function usePendingQueue() {
     }
   };
 
-  const handleEdited = (id: string, newBody: string) => {
-    setRows((prev) => prev.map((r) => (r.id === id ? { ...r, body: newBody } : r)));
-  };
-
   const filtered = rows.filter((r) => {
     if (channelFilter !== "all" && r.channel !== channelFilter) return false;
     if (kindFilter !== "all" && r.kind !== kindFilter) return false;
@@ -72,6 +72,5 @@ export function usePendingQueue() {
     setKindFilter,
     handleApprove,
     handleReject,
-    handleEdited,
   };
 }

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -376,6 +376,34 @@ describe("api module", () => {
       expect(opts.method).toBe("POST");
     });
 
+    it("listPendingReplies → GET /api/pending-replies?status=pending with joined lead snippet", async () => {
+      const sample = [
+        {
+          id: "pr-1",
+          lead_id: "lead-1",
+          channel: "telegram",
+          kind: "booking_link",
+          body: "queue body",
+          status: "pending",
+          created_at: "2026-05-20T10:00:00Z",
+          lead: {
+            contact_name: "Иван Петров",
+            company: "ACME",
+            channel: "telegram",
+            telegram_chat_id: 987654,
+          },
+        },
+      ];
+      fetchMock.mockResolvedValueOnce(mockResponse(sample));
+
+      const result = await api.listPendingReplies();
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("http://localhost:8080/api/pending-replies?status=pending");
+      expect(opts.method).toBeUndefined();
+      expect(result).toEqual(sample);
+    });
+
     it("updatePendingReply → PATCH /api/pending-replies/:id with body", async () => {
       const updated = {
         id: "pr-3",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -187,11 +187,13 @@ export const api = {
   // re-listing.
   getPendingReplies: (leadId: string) =>
     apiFetch<PendingReply[]>(`/api/leads/${leadId}/pending-replies`),
-  // listPendingReplies — stub for the RED step of #51. Real impl
-  // lands in the matching GREEN commit so the contract test fails
-  // at runtime while the TS build stays green for bisect.
-  listPendingReplies: (): Promise<PendingReplyQueueRow[]> =>
-    Promise.reject(new Error("listPendingReplies not implemented")),
+  // listPendingReplies — operator queue: every pending row across
+  // every lead the operator owns, with the joined lead snippet so the
+  // page renders contact + company in one request (no N+1). The
+  // status filter is explicit on the wire — keeps room for a future
+  // ?status=approved tab without silently widening the contract.
+  listPendingReplies: () =>
+    apiFetch<PendingReplyQueueRow[]>("/api/pending-replies?status=pending"),
   approvePendingReply: (id: string) =>
     apiFetch<void>(`/api/pending-replies/${id}/approve`, { method: "POST" }),
   rejectPendingReply: (id: string) =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -187,6 +187,11 @@ export const api = {
   // re-listing.
   getPendingReplies: (leadId: string) =>
     apiFetch<PendingReply[]>(`/api/leads/${leadId}/pending-replies`),
+  // listPendingReplies — stub for the RED step of #51. Real impl
+  // lands in the matching GREEN commit so the contract test fails
+  // at runtime while the TS build stays green for bisect.
+  listPendingReplies: (): Promise<PendingReplyQueueRow[]> =>
+    Promise.reject(new Error("listPendingReplies not implemented")),
   approvePendingReply: (id: string) =>
     apiFetch<void>(`/api/pending-replies/${id}/approve`, { method: "POST" }),
   rejectPendingReply: (id: string) =>
@@ -461,6 +466,26 @@ export interface PendingReply {
   created_at: string;
   decided_at?: string;
   sent_at?: string;
+}
+
+// PendingReplyLeadSnippet is the minimal lead context the operator
+// queue needs per row — contact + company + channel + identifiers.
+// telegram_chat_id / email_address are omitempty on the wire so a
+// telegram lead never carries a null email and vice versa.
+export interface PendingReplyLeadSnippet {
+  contact_name: string;
+  company: string;
+  channel: "telegram" | "email";
+  telegram_chat_id?: number;
+  email_address?: string;
+}
+
+// PendingReplyQueueRow is the wire-shape returned by
+// GET /api/pending-replies — every pending row across every lead the
+// operator owns, joined with the lead snippet so the queue UI avoids
+// an N+1 lookup.
+export interface PendingReplyQueueRow extends PendingReply {
+  lead: PendingReplyLeadSnippet;
 }
 
 export interface Reminder {


### PR DESCRIPTION
## Summary
- Backend: `GET /api/pending-replies?status=pending` returns every pending HITL draft for the user, joined with the lead snippet (contact + company + channel + identifiers) so the queue page renders in one round-trip with no N+1
- Frontend: `/inbox/pending` page surfaces all pending drafts across every lead in one list with channel/kind filters + inline Approve/Reject; `PendingQueueTabs` lets operators flip between the all-leads view and the queue without leaving inbox
- 12-commit TDD cascade: RED → GREEN pairs for repo / usecase / handler / frontend-api, then hook + page + tests + reviewer fixes

## Trade-offs
- `?status` query param is explicit on the wire — accepts empty or `pending`, rejects anything else with 400 to leave room for a future `?status=approved` tab without silent contract widening
- Channel / kind filters are client-side today (in-hook `.filter()`). Fine at current volumes; server-side filtering is a clean extension when the queue depth warrants

## Internal review pass
Eight axes, all ≥ 8/10: TDD 9, DDD 9, CA 9, Security 10, Wire 9, Test Quality 8, Code Quality 8, Floq Conventions 8. Important issues fixed before this PR opens (dead-code deletion, hook unit test, `vi.resetAllMocks` per `frontend/TESTING.md`, omitempty assertion on decided/sent fields, ops-visible `console.warn` on poll-refetch failure).

## Test plan
- [ ] `cd backend && go test ./...`
- [ ] `cd backend && go test -tags=integration -run "TestPendingReplyRepository_ListPendingByUser|TestHandler_ListPendingByUser" ./internal/inbox/`
- [ ] `cd frontend && npm test -- --run`
- [ ] Manually: log in, navigate to `/inbox/pending`, confirm queue renders with contact + company per row; approve a draft and confirm the row disappears optimistically and the `pending_replies_count` badge on `/inbox` decrements after the next inbox-list refresh

## Notes
- Pre-existing integration test `TestPendingReplyRepository_Update_PersistsStatusAndTimestamps` fails on main (FK violation on `decided_by` after migration 032 — the test seeds an operator UUID without a matching user row). Not introduced here; verified on a fresh `main` checkout. Recommended follow-up issue: seed the operator via `testutil.SeedUser` before stamping.
- Sidebar `Sidebar.tsx` is untouched — `/inbox/pending` is a sub-route, the existing "Входящие" item stays highlighted on both via `pathname.startsWith('/inbox')`.

Closes #51.