### PR TITLE
feat(inbox/hitl): bulk approve/reject for power operators (#49)

### DIFF
--- a/backend/internal/inbox/bulk_decide.go
+++ b/backend/internal/inbox/bulk_decide.go
@@ -1,0 +1,51 @@
+package inbox
+
+import (
+	"errors"
+
+	"github.com/google/uuid"
+)
+
+// BulkDecision enumerates the two terminal decisions the operator can
+// apply en-masse to a slice of pending replies. The single-row Approve
+// and Reject usecases each map to one of these values; nothing else is
+// valid in the bulk API today.
+type BulkDecision string
+
+const (
+	BulkDecisionApprove BulkDecision = "approve"
+	BulkDecisionReject  BulkDecision = "reject"
+)
+
+// IsValid reports whether the decision matches a known BulkDecision.
+func (d BulkDecision) IsValid() bool {
+	switch d {
+	case BulkDecisionApprove, BulkDecisionReject:
+		return true
+	default:
+		return false
+	}
+}
+
+// ErrBulkDecideEmptyIDs rejects bulk calls with an empty id slice —
+// the handler answers 400 because no work to do is more likely a UI
+// bug than a valid intent. Sentinel so the handler can distinguish
+// "bad request shape" from "per-row failure".
+var ErrBulkDecideEmptyIDs = errors.New("bulk decide: ids must be non-empty")
+
+// ErrBulkDecideInvalidDecision rejects bulk calls with an unknown
+// decision string. Sentinel so the handler can answer 400 with a
+// clear message instead of conflating with per-row failures.
+var ErrBulkDecideInvalidDecision = errors.New("bulk decide: decision must be 'approve' or 'reject'")
+
+// BulkDecideResult is the per-row outcome of a BulkDecide call. Err
+// is nil on success; otherwise it carries the same sentinel the
+// single-row usecase returns (ErrPendingReplyNotFound,
+// ErrPendingReplyAlreadyDecided, dispatcher failures, …) so the
+// handler can map it to a stable wire string without reconstructing
+// taxonomy. The slice returned by the usecase preserves input order
+// 1-to-1 so callers can correlate by index.
+type BulkDecideResult struct {
+	ID  uuid.UUID
+	Err error
+}

--- a/backend/internal/inbox/handler.go
+++ b/backend/internal/inbox/handler.go
@@ -230,11 +230,11 @@ func (h *pendingReplyHandler) bulkDecide() http.HandlerFunc {
 			return
 		}
 		out := bulkDecideResponse{Results: make([]bulkDecideResultWire, 0, len(results))}
-		for _, r := range results {
+		for _, res := range results {
 			out.Results = append(out.Results, bulkDecideResultWire{
-				ID:    r.ID.String(),
-				OK:    r.Err == nil,
-				Error: perRowErrorString(r.Err),
+				ID:    res.ID.String(),
+				OK:    res.Err == nil,
+				Error: perRowErrorString(res.Err),
 			})
 		}
 		httputil.WriteJSON(w, http.StatusOK, out)

--- a/backend/internal/inbox/handler.go
+++ b/backend/internal/inbox/handler.go
@@ -192,6 +192,14 @@ func perRowErrorString(err error) string {
 	}
 }
 
+// bulkDecideMaxBodyBytes caps the bulk request payload. 256 KiB
+// comfortably holds a few thousand UUIDs (each ~40 bytes on the wire
+// inside a JSON array), which is far beyond any realistic operator
+// batch. Caps DoS surface: bulk is the only inbox endpoint with a
+// variable-size body, so we limit it explicitly here rather than
+// waiting for a project-wide JSON-body cap.
+const bulkDecideMaxBodyBytes = 256 * 1024
+
 func (h *pendingReplyHandler) bulkDecide() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		userID, ok := httputil.UserIDFromContext(r.Context())
@@ -199,6 +207,7 @@ func (h *pendingReplyHandler) bulkDecide() http.HandlerFunc {
 			httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
+		r.Body = http.MaxBytesReader(w, r.Body, bulkDecideMaxBodyBytes)
 		var req bulkDecideRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			httputil.WriteError(w, http.StatusBadRequest, "invalid json body")

--- a/backend/internal/inbox/handler.go
+++ b/backend/internal/inbox/handler.go
@@ -23,6 +23,7 @@ type PendingReplyUseCaseAPI interface {
 	Approve(ctx context.Context, userID, id uuid.UUID) error
 	Reject(ctx context.Context, userID, id uuid.UUID) error
 	UpdateBody(ctx context.Context, userID, id uuid.UUID, body string) (*PendingReply, error)
+	BulkDecide(ctx context.Context, userID uuid.UUID, ids []uuid.UUID, decision BulkDecision) ([]BulkDecideResult, error)
 }
 
 // LeadOwnershipChecker is the narrow port the handler needs to gate
@@ -65,6 +66,7 @@ func RegisterPendingReplyRoutes(r chi.Router, uc PendingReplyUseCaseAPI, leads L
 		r.Post("/api/pending-replies/{id}/approve", h.approve())
 		r.Post("/api/pending-replies/{id}/reject", h.reject())
 		r.Patch("/api/pending-replies/{id}", h.updateBody())
+		r.Post("/api/pending-replies/bulk", h.bulkDecide())
 		return
 	}
 	r.With(decideMW).Post("/api/pending-replies/{id}/approve", h.approve())
@@ -72,6 +74,12 @@ func RegisterPendingReplyRoutes(r chi.Router, uc PendingReplyUseCaseAPI, leads L
 	// PATCH is rate-limited too — operators editing in a tight loop should
 	// hit the same throttle as a tight approve loop.
 	r.With(decideMW).Patch("/api/pending-replies/{id}", h.updateBody())
+	// Bulk decide consumes one rate-limit slot per call regardless of
+	// how many ids it carries. This is a deliberate power-operator
+	// affordance: the alternative — charging N slots per bulk — would
+	// neutralise the whole point of the endpoint. If abuse becomes a
+	// problem, swap to len(ids) accounting in the middleware key fn.
+	r.With(decideMW).Post("/api/pending-replies/bulk", h.bulkDecide())
 }
 
 func (h *pendingReplyHandler) listByLead() http.HandlerFunc {
@@ -137,6 +145,15 @@ func (h *pendingReplyHandler) listPendingByUser() http.HandlerFunc {
 			return
 		}
 		httputil.WriteJSON(w, http.StatusOK, operatorQueueToResponse(rows))
+	}
+}
+
+// bulkDecide — stub for the RED step of #49. Real impl lands in the
+// matching GREEN commit; tests fail at runtime so the build stays
+// bisect-friendly.
+func (h *pendingReplyHandler) bulkDecide() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		httputil.WriteError(w, http.StatusNotImplemented, "bulkDecide not implemented")
 	}
 }
 

--- a/backend/internal/inbox/handler.go
+++ b/backend/internal/inbox/handler.go
@@ -148,12 +148,96 @@ func (h *pendingReplyHandler) listPendingByUser() http.HandlerFunc {
 	}
 }
 
-// bulkDecide — stub for the RED step of #49. Real impl lands in the
-// matching GREEN commit; tests fail at runtime so the build stays
-// bisect-friendly.
+// bulkDecideRequest is the JSON request body. Both fields are
+// required; emptiness / unknown decision is detected by the usecase
+// and surfaced as a 400, while malformed JSON / non-uuid ids are
+// rejected at parse time without reaching the usecase.
+type bulkDecideRequest struct {
+	IDs      []string `json:"ids"`
+	Decision string   `json:"decision"`
+}
+
+// bulkDecideResultWire mirrors the per-row outcome on the wire.
+// `error` is omitempty so success rows carry only {id, ok:true},
+// keeping the response compact for the typical happy-path bulk.
+type bulkDecideResultWire struct {
+	ID    string `json:"id"`
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+// bulkDecideResponse wraps the per-row results under a "results" key
+// so the response shape is forward-compatible with future top-level
+// metadata (counts, partial-failure summaries) without breaking
+// existing clients.
+type bulkDecideResponse struct {
+	Results []bulkDecideResultWire `json:"results"`
+}
+
+// perRowErrorString maps a per-row usecase error to a stable wire
+// string. Unknown errors collapse to a generic "internal error" so
+// upstream taxonomy (dispatcher 5xx, db hiccup, …) doesn't leak.
+func perRowErrorString(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, ErrPendingReplyNotFound):
+		return "not found"
+	case errors.Is(err, ErrPendingReplyAlreadyDecided):
+		return "already decided"
+	case errors.Is(err, ErrPendingReplyDispatcherNotConfigured):
+		return "dispatcher not configured"
+	default:
+		return "internal error"
+	}
+}
+
 func (h *pendingReplyHandler) bulkDecide() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		httputil.WriteError(w, http.StatusNotImplemented, "bulkDecide not implemented")
+		userID, ok := httputil.UserIDFromContext(r.Context())
+		if !ok {
+			httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		var req bulkDecideRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httputil.WriteError(w, http.StatusBadRequest, "invalid json body")
+			return
+		}
+		ids := make([]uuid.UUID, 0, len(req.IDs))
+		for _, raw := range req.IDs {
+			parsed, err := uuid.Parse(raw)
+			if err != nil {
+				httputil.WriteError(w, http.StatusBadRequest, "invalid id in ids[]")
+				return
+			}
+			ids = append(ids, parsed)
+		}
+		results, err := h.uc.BulkDecide(r.Context(), userID, ids, BulkDecision(req.Decision))
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrBulkDecideEmptyIDs):
+				httputil.WriteError(w, http.StatusBadRequest, "ids must be non-empty")
+			case errors.Is(err, ErrBulkDecideInvalidDecision):
+				httputil.WriteError(w, http.StatusBadRequest, "decision must be 'approve' or 'reject'")
+			default:
+				slog.ErrorContext(r.Context(), "pending reply bulk decide failed",
+					slog.String("user_id", userID.String()),
+					slog.Int("ids_count", len(ids)),
+					slog.Any("err", err))
+				httputil.WriteError(w, http.StatusInternalServerError, "failed to process bulk decide")
+			}
+			return
+		}
+		out := bulkDecideResponse{Results: make([]bulkDecideResultWire, 0, len(results))}
+		for _, r := range results {
+			out.Results = append(out.Results, bulkDecideResultWire{
+				ID:    r.ID.String(),
+				OK:    r.Err == nil,
+				Error: perRowErrorString(r.Err),
+			})
+		}
+		httputil.WriteJSON(w, http.StatusOK, out)
 	}
 }
 

--- a/backend/internal/inbox/handler_test.go
+++ b/backend/internal/inbox/handler_test.go
@@ -26,6 +26,14 @@ type fakePendingReplyUseCase struct {
 	approveFn           func(ctx context.Context, userID, id uuid.UUID) error
 	rejectFn            func(ctx context.Context, userID, id uuid.UUID) error
 	updateBodyFn        func(ctx context.Context, userID, id uuid.UUID, body string) (*PendingReply, error)
+	bulkDecideFn        func(ctx context.Context, userID uuid.UUID, ids []uuid.UUID, decision BulkDecision) ([]BulkDecideResult, error)
+}
+
+func (f *fakePendingReplyUseCase) BulkDecide(ctx context.Context, userID uuid.UUID, ids []uuid.UUID, decision BulkDecision) ([]BulkDecideResult, error) {
+	if f.bulkDecideFn != nil {
+		return f.bulkDecideFn(ctx, userID, ids, decision)
+	}
+	return nil, nil
 }
 
 func (f *fakePendingReplyUseCase) ListByLead(ctx context.Context, userID, leadID uuid.UUID) ([]*PendingReply, error) {
@@ -665,5 +673,155 @@ func TestHandler_UpdateBody_ErrorMatrix(t *testing.T) {
 				t.Fatalf("status = %d, want %d, body=%s", rec.Code, c.wantStatus, rec.Body.String())
 			}
 		})
+	}
+}
+
+// --- POST /api/pending-replies/bulk ---
+
+func TestHandler_BulkDecide_HappyPath_PartialResultsPreserveOrder(t *testing.T) {
+	userID := uuid.New()
+	idOK := uuid.New()
+	idMissing := uuid.New()
+	idDecided := uuid.New()
+
+	uc := &fakePendingReplyUseCase{
+		bulkDecideFn: func(_ context.Context, _ uuid.UUID, ids []uuid.UUID, decision BulkDecision) ([]BulkDecideResult, error) {
+			if decision != BulkDecisionApprove {
+				t.Errorf("decision = %v, want approve", decision)
+			}
+			if len(ids) != 3 {
+				t.Errorf("ids len = %d, want 3", len(ids))
+			}
+			return []BulkDecideResult{
+				{ID: ids[0], Err: nil},
+				{ID: ids[1], Err: ErrPendingReplyNotFound},
+				{ID: ids[2], Err: ErrPendingReplyAlreadyDecided},
+			}, nil
+		},
+	}
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+
+	body := `{"ids":["` + idOK.String() + `","` + idMissing.String() + `","` + idDecided.String() + `"],"decision":"approve"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/pending-replies/bulk", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(httputil.WithUserID(req.Context(), userID))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Results []map[string]any `json:"results"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Results) != 3 {
+		t.Fatalf("results len = %d, want 3", len(got.Results))
+	}
+	// Row 0: success — ok=true, no error field.
+	if got.Results[0]["id"] != idOK.String() {
+		t.Errorf("results[0].id = %v, want %v — order must be preserved", got.Results[0]["id"], idOK)
+	}
+	if got.Results[0]["ok"] != true {
+		t.Errorf("results[0].ok = %v, want true", got.Results[0]["ok"])
+	}
+	if _, present := got.Results[0]["error"]; present {
+		t.Errorf("results[0].error must be omitempty on success, got %v", got.Results[0]["error"])
+	}
+	// Row 1: not-found.
+	if got.Results[1]["ok"] != false {
+		t.Errorf("results[1].ok = %v, want false", got.Results[1]["ok"])
+	}
+	if got.Results[1]["error"] != "not found" {
+		t.Errorf("results[1].error = %v, want 'not found'", got.Results[1]["error"])
+	}
+	// Row 2: already-decided.
+	if got.Results[2]["ok"] != false {
+		t.Errorf("results[2].ok = %v, want false", got.Results[2]["ok"])
+	}
+	if got.Results[2]["error"] != "already decided" {
+		t.Errorf("results[2].error = %v, want 'already decided'", got.Results[2]["error"])
+	}
+}
+
+func TestHandler_BulkDecide_EmptyIDsReturns400(t *testing.T) {
+	uc := &fakePendingReplyUseCase{
+		bulkDecideFn: func(_ context.Context, _ uuid.UUID, _ []uuid.UUID, _ BulkDecision) ([]BulkDecideResult, error) {
+			return nil, ErrBulkDecideEmptyIDs
+		},
+	}
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/pending-replies/bulk", strings.NewReader(`{"ids":[],"decision":"approve"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(httputil.WithUserID(req.Context(), uuid.New()))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandler_BulkDecide_UnknownDecisionReturns400(t *testing.T) {
+	uc := &fakePendingReplyUseCase{
+		bulkDecideFn: func(_ context.Context, _ uuid.UUID, _ []uuid.UUID, _ BulkDecision) ([]BulkDecideResult, error) {
+			return nil, ErrBulkDecideInvalidDecision
+		},
+	}
+	srv := newTestServer(uc, &fakeLeadOwnership{})
+
+	body := `{"ids":["` + uuid.New().String() + `"],"decision":"explode"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/pending-replies/bulk", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(httputil.WithUserID(req.Context(), uuid.New()))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandler_BulkDecide_MalformedJSONReturns400(t *testing.T) {
+	srv := newTestServer(&fakePendingReplyUseCase{}, &fakeLeadOwnership{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/pending-replies/bulk", strings.NewReader(`{not json}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(httputil.WithUserID(req.Context(), uuid.New()))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 on malformed JSON", rec.Code)
+	}
+}
+
+func TestHandler_BulkDecide_InvalidUUIDInIDsReturns400(t *testing.T) {
+	srv := newTestServer(&fakePendingReplyUseCase{}, &fakeLeadOwnership{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/pending-replies/bulk", strings.NewReader(`{"ids":["not-a-uuid"],"decision":"approve"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(httputil.WithUserID(req.Context(), uuid.New()))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 on bad uuid", rec.Code)
+	}
+}
+
+func TestHandler_BulkDecide_NoUserReturns401(t *testing.T) {
+	srv := newTestServer(&fakePendingReplyUseCase{}, &fakeLeadOwnership{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/pending-replies/bulk", strings.NewReader(`{"ids":["`+uuid.New().String()+`"],"decision":"approve"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
 	}
 }

--- a/backend/internal/inbox/handler_test.go
+++ b/backend/internal/inbox/handler_test.go
@@ -813,6 +813,24 @@ func TestHandler_BulkDecide_InvalidUUIDInIDsReturns400(t *testing.T) {
 	}
 }
 
+func TestHandler_BulkDecide_BodyTooLargeReturns400(t *testing.T) {
+	srv := newTestServer(&fakePendingReplyUseCase{}, &fakeLeadOwnership{})
+
+	// Exceed bulkDecideMaxBodyBytes (256 KiB) by a wide margin. Use a
+	// repeated padding string inside an otherwise-valid envelope; the
+	// payload-size cap fires before JSON decode finishes.
+	body := `{"ids":["` + uuid.New().String() + `"],"decision":"approve","_pad":"` + strings.Repeat("x", 300*1024) + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/pending-replies/bulk", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(httputil.WithUserID(req.Context(), uuid.New()))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 on oversized body — bulk endpoint must cap payload to bound DoS surface", rec.Code)
+	}
+}
+
 func TestHandler_BulkDecide_NoUserReturns401(t *testing.T) {
 	srv := newTestServer(&fakePendingReplyUseCase{}, &fakeLeadOwnership{})
 

--- a/backend/internal/inbox/pending_reply_usecase.go
+++ b/backend/internal/inbox/pending_reply_usecase.go
@@ -127,11 +127,36 @@ func (uc *PendingReplyUseCase) ListPendingByUser(ctx context.Context, userID uui
 	return uc.repo.ListPendingByUser(ctx, userID)
 }
 
-// BulkDecide — stub for the RED step of #49. Real impl lands in the
-// matching GREEN commit; tests fail at runtime so the build stays
-// bisect-friendly.
-func (uc *PendingReplyUseCase) BulkDecide(_ context.Context, _ uuid.UUID, _ []uuid.UUID, _ BulkDecision) ([]BulkDecideResult, error) {
-	return nil, errors.New("pending reply usecase: BulkDecide not implemented")
+// BulkDecide applies the same decision to every id in the slice,
+// delegating per-row to the existing Approve/Reject usecase methods
+// so the optimistic-lock + dispatcher contract is preserved. Per-row
+// failures (NotFound, AlreadyDecided, dispatcher 5xx, …) are
+// collected into the result slice and do NOT abort the rest — one
+// Telegram outage shouldn't poison a fifty-row bulk. The result
+// order matches the input order 1-to-1 so callers can correlate.
+//
+// Top-level error is reserved for request-shape problems
+// (ErrBulkDecideEmptyIDs, ErrBulkDecideInvalidDecision) that prevent
+// any per-row work from starting; per-row issues never surface here.
+func (uc *PendingReplyUseCase) BulkDecide(ctx context.Context, userID uuid.UUID, ids []uuid.UUID, decision BulkDecision) ([]BulkDecideResult, error) {
+	if len(ids) == 0 {
+		return nil, ErrBulkDecideEmptyIDs
+	}
+	if !decision.IsValid() {
+		return nil, ErrBulkDecideInvalidDecision
+	}
+	results := make([]BulkDecideResult, 0, len(ids))
+	for _, id := range ids {
+		var err error
+		switch decision {
+		case BulkDecisionApprove:
+			err = uc.Approve(ctx, userID, id)
+		case BulkDecisionReject:
+			err = uc.Reject(ctx, userID, id)
+		}
+		results = append(results, BulkDecideResult{ID: id, Err: err})
+	}
+	return results, nil
 }
 
 // Approve transitions the reply into Approved, persists the decision,

--- a/backend/internal/inbox/pending_reply_usecase.go
+++ b/backend/internal/inbox/pending_reply_usecase.go
@@ -127,6 +127,13 @@ func (uc *PendingReplyUseCase) ListPendingByUser(ctx context.Context, userID uui
 	return uc.repo.ListPendingByUser(ctx, userID)
 }
 
+// BulkDecide — stub for the RED step of #49. Real impl lands in the
+// matching GREEN commit; tests fail at runtime so the build stays
+// bisect-friendly.
+func (uc *PendingReplyUseCase) BulkDecide(_ context.Context, _ uuid.UUID, _ []uuid.UUID, _ BulkDecision) ([]BulkDecideResult, error) {
+	return nil, errors.New("pending reply usecase: BulkDecide not implemented")
+}
+
 // Approve transitions the reply into Approved, persists the decision,
 // dispatches through the channel-native transport, and (on success)
 // marks the entity Sent. A dispatch failure leaves the entity in

--- a/backend/internal/inbox/pending_reply_usecase.go
+++ b/backend/internal/inbox/pending_reply_usecase.go
@@ -147,6 +147,16 @@ func (uc *PendingReplyUseCase) BulkDecide(ctx context.Context, userID uuid.UUID,
 	}
 	results := make([]BulkDecideResult, 0, len(ids))
 	for _, id := range ids {
+		// Honour client disconnect mid-bulk: pad remaining ids with
+		// the context error so the result slice stays 1-to-1 with the
+		// input and the caller can see which rows did not run.
+		// Continuing the loop after a cancel would still fire DB
+		// updates + dispatcher I/O on a dead context (50 wasted
+		// round-trips for a 50-row bulk in the worst case).
+		if err := ctx.Err(); err != nil {
+			results = append(results, BulkDecideResult{ID: id, Err: err})
+			continue
+		}
 		var err error
 		switch decision {
 		case BulkDecisionApprove:

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -971,6 +971,66 @@ func TestPendingReplyUseCase_BulkDecide_MixedSuccessAndFailureSurfacesPerRow(t *
 	}
 }
 
+func TestPendingReplyUseCase_BulkDecide_SecondBulkOnSameRowReportsAlreadyDecided(t *testing.T) {
+	// Two operators (or two browser tabs) racing on the same pending
+	// id: tab 1's bulk-approve wins, tab 2 sees the row in approved
+	// status and the per-row optimistic-lock translates into
+	// ErrPendingReplyAlreadyDecided. The bulk path inherits this
+	// contract via the single-row Approve delegation — this test pins
+	// it directly so a future refactor that bypasses single-row
+	// Approve does not silently lose the lock.
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "race row")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := uc.BulkDecide(ctx, userID, []uuid.UUID{pr.ID}, BulkDecisionApprove)
+	if err != nil {
+		t.Fatalf("first BulkDecide returned top-level error: %v", err)
+	}
+	if first[0].Err != nil {
+		t.Fatalf("first bulk row Err = %v, want nil", first[0].Err)
+	}
+
+	second, err := uc.BulkDecide(ctx, userID, []uuid.UUID{pr.ID}, BulkDecisionApprove)
+	if err != nil {
+		t.Fatalf("second BulkDecide returned top-level error: %v", err)
+	}
+	if !errors.Is(second[0].Err, ErrPendingReplyAlreadyDecided) {
+		t.Errorf("second bulk row Err = %v, want ErrPendingReplyAlreadyDecided — second operator on the same row must observe the optimistic lock", second[0].Err)
+	}
+}
+
+func TestPendingReplyUseCase_BulkDecide_HonorsContextCancellation(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	userID := uuid.New()
+
+	pr1, _ := uc.Propose(context.Background(), userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "one")
+	pr2, _ := uc.Propose(context.Background(), userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "two")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // dead context from the start
+
+	results, err := uc.BulkDecide(ctx, userID, []uuid.UUID{pr1.ID, pr2.ID}, BulkDecisionApprove)
+	if err != nil {
+		t.Fatalf("BulkDecide returned top-level error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2 — order must stay 1-to-1 even on cancel", len(results))
+	}
+	for i, r := range results {
+		if !errors.Is(r.Err, context.Canceled) {
+			t.Errorf("results[%d].Err = %v, want context.Canceled — cancelled context must surface per-row, not run wasted work", i, r.Err)
+		}
+	}
+}
+
 func TestPendingReplyUseCase_BulkDecide_RejectDecisionDoesNotDispatch(t *testing.T) {
 	repo := newFakeRepo()
 	disp := &spyDispatcher{}

--- a/backend/internal/inbox/pending_reply_usecase_test.go
+++ b/backend/internal/inbox/pending_reply_usecase_test.go
@@ -875,3 +875,122 @@ func TestPendingReplyUseCase_ListPendingByUser_PropagatesRepoError(t *testing.T)
 		t.Errorf("expected wrapped repo error, got %v — usecase must surface the underlying repo failure so callers can introspect", err)
 	}
 }
+
+// --- BulkDecide ---
+
+func TestPendingReplyUseCase_BulkDecide_RejectsEmptyIDs(t *testing.T) {
+	uc := NewPendingReplyUseCase(newFakeRepo(), &spyDispatcher{})
+
+	_, err := uc.BulkDecide(context.Background(), uuid.New(), nil, BulkDecisionApprove)
+	if !errors.Is(err, ErrBulkDecideEmptyIDs) {
+		t.Fatalf("err = %v, want ErrBulkDecideEmptyIDs — empty ids is a request-shape error, not a per-row failure", err)
+	}
+}
+
+func TestPendingReplyUseCase_BulkDecide_RejectsInvalidDecision(t *testing.T) {
+	uc := NewPendingReplyUseCase(newFakeRepo(), &spyDispatcher{})
+
+	_, err := uc.BulkDecide(context.Background(), uuid.New(), []uuid.UUID{uuid.New()}, BulkDecision("nope"))
+	if !errors.Is(err, ErrBulkDecideInvalidDecision) {
+		t.Fatalf("err = %v, want ErrBulkDecideInvalidDecision", err)
+	}
+}
+
+func TestPendingReplyUseCase_BulkDecide_AllApproveSucceeds(t *testing.T) {
+	repo := newFakeRepo()
+	disp := &spyDispatcher{}
+	uc := NewPendingReplyUseCase(repo, disp)
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr1, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "one")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr2, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "two")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := uc.BulkDecide(ctx, userID, []uuid.UUID{pr1.ID, pr2.ID}, BulkDecisionApprove)
+	if err != nil {
+		t.Fatalf("BulkDecide returned top-level error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	for i, want := range []uuid.UUID{pr1.ID, pr2.ID} {
+		if results[i].ID != want {
+			t.Errorf("results[%d].ID = %v, want %v — input order must be preserved 1-to-1", i, results[i].ID, want)
+		}
+		if results[i].Err != nil {
+			t.Errorf("results[%d].Err = %v, want nil", i, results[i].Err)
+		}
+	}
+	if got := len(disp.Calls()); got != 2 {
+		t.Errorf("dispatcher call count = %d, want 2 — each approved row must fire one dispatch", got)
+	}
+}
+
+func TestPendingReplyUseCase_BulkDecide_MixedSuccessAndFailureSurfacesPerRow(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewPendingReplyUseCase(repo, &spyDispatcher{})
+	ctx := context.Background()
+	userID := uuid.New()
+
+	// Row 1: will succeed.
+	pr1, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "ok row")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Row 2: never existed — cross-tenant indistinguishable from missing.
+	missing := uuid.New()
+	// Row 3: belongs to another user — must also report NotFound (per
+	// the project's uniform-404 contract on cross-tenant access).
+	otherUser := uuid.New()
+	prOther, err := uc.Propose(ctx, otherUser, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "owned by other")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := uc.BulkDecide(ctx, userID, []uuid.UUID{pr1.ID, missing, prOther.ID}, BulkDecisionApprove)
+	if err != nil {
+		t.Fatalf("BulkDecide must return nil top-level error when only per-row failures occur: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(results))
+	}
+	if results[0].Err != nil {
+		t.Errorf("row 1 (own valid id) Err = %v, want nil", results[0].Err)
+	}
+	if !errors.Is(results[1].Err, ErrPendingReplyNotFound) {
+		t.Errorf("row 2 (missing id) Err = %v, want ErrPendingReplyNotFound", results[1].Err)
+	}
+	if !errors.Is(results[2].Err, ErrPendingReplyNotFound) {
+		t.Errorf("row 3 (cross-tenant id) Err = %v, want ErrPendingReplyNotFound — cross-tenant must collapse to not-found", results[2].Err)
+	}
+}
+
+func TestPendingReplyUseCase_BulkDecide_RejectDecisionDoesNotDispatch(t *testing.T) {
+	repo := newFakeRepo()
+	disp := &spyDispatcher{}
+	uc := NewPendingReplyUseCase(repo, disp)
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pr, err := uc.Propose(ctx, userID, uuid.New(), ChannelTelegram, PendingReplyKindBookingLink, "reject me")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := uc.BulkDecide(ctx, userID, []uuid.UUID{pr.ID}, BulkDecisionReject)
+	if err != nil {
+		t.Fatalf("BulkDecide returned: %v", err)
+	}
+	if results[0].Err != nil {
+		t.Errorf("Err = %v, want nil", results[0].Err)
+	}
+	if got := len(disp.Calls()); got != 0 {
+		t.Errorf("dispatcher fired %d times on reject — reject is terminal, must NOT dispatch", got)
+	}
+}

--- a/frontend/src/app/(dashboard)/inbox/pending/page.test.tsx
+++ b/frontend/src/app/(dashboard)/inbox/pending/page.test.tsx
@@ -215,7 +215,7 @@ describe("InboxPendingPage", () => {
       expect(screen.queryByText("winner")).not.toBeInTheDocument();
     });
     expect(screen.getByText("loser")).toBeInTheDocument();
-    expect(screen.getByText(/1 применено, 1 ошибок/)).toBeInTheDocument();
+    expect(screen.getByText(/1 применено, 1 ошибка/)).toBeInTheDocument();
   });
 
   it("channel filter hides rows from the unselected channel", async () => {

--- a/frontend/src/app/(dashboard)/inbox/pending/page.test.tsx
+++ b/frontend/src/app/(dashboard)/inbox/pending/page.test.tsx
@@ -23,6 +23,7 @@ vi.mock("@/lib/api", () => ({
     listPendingReplies: vi.fn(),
     approvePendingReply: vi.fn(),
     rejectPendingReply: vi.fn(),
+    bulkPendingReplies: vi.fn(),
   },
 }));
 
@@ -52,6 +53,7 @@ describe("InboxPendingPage", () => {
     vi.mocked(api.listPendingReplies).mockResolvedValue([]);
     vi.mocked(api.approvePendingReply).mockResolvedValue(undefined);
     vi.mocked(api.rejectPendingReply).mockResolvedValue(undefined);
+    vi.mocked(api.bulkPendingReplies).mockResolvedValue({ results: [] });
   });
 
   it("fetches the queue on mount and renders rows with lead context", async () => {
@@ -130,6 +132,90 @@ describe("InboxPendingPage", () => {
     await waitFor(() => {
       expect(api.rejectPendingReply).toHaveBeenCalledWith("pr-9");
     });
+  });
+
+  it("selecting rows reveals bulk toolbar; Approve selected fires bulk api with chosen ids", async () => {
+    vi.mocked(api.listPendingReplies).mockResolvedValueOnce([
+      makeRow({ id: "pr-1", body: "first" }),
+      makeRow({ id: "pr-2", body: "second" }),
+    ]);
+    vi.mocked(api.bulkPendingReplies).mockResolvedValueOnce({
+      results: [
+        { id: "pr-1", ok: true },
+        { id: "pr-2", ok: true },
+      ],
+    });
+    const user = userEvent.setup();
+
+    render(<InboxPendingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("first")).toBeInTheDocument();
+    });
+
+    // Toolbar is hidden before any selection.
+    expect(screen.queryByRole("region", { name: /Массовые действия/ })).toBeNull();
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[0]!);
+    await user.click(checkboxes[1]!);
+
+    expect(screen.getByRole("region", { name: /Массовые действия/ })).toBeInTheDocument();
+    expect(screen.getByText(/Выбрано: 2/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Одобрить выбранные/ }));
+
+    await waitFor(() => {
+      expect(api.bulkPendingReplies).toHaveBeenCalledWith({
+        ids: expect.arrayContaining(["pr-1", "pr-2"]),
+        decision: "approve",
+      });
+    });
+    // Both rows succeeded → both removed; toolbar disappears (count back to 0).
+    await waitFor(() => {
+      expect(screen.queryByText("first")).not.toBeInTheDocument();
+      expect(screen.queryByText("second")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/Готово: 2 применено/)).toBeInTheDocument();
+  });
+
+  it("bulk partial failure leaves failed row visible with summary", async () => {
+    vi.mocked(api.listPendingReplies).mockResolvedValueOnce([
+      makeRow({ id: "pr-1", body: "winner" }),
+      makeRow({ id: "pr-2", body: "loser" }),
+    ]);
+    vi.mocked(api.bulkPendingReplies).mockResolvedValueOnce({
+      results: [
+        { id: "pr-1", ok: true },
+        { id: "pr-2", ok: false, error: "not found" },
+      ],
+    });
+    const user = userEvent.setup();
+
+    render(<InboxPendingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("loser")).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[0]!);
+    await user.click(checkboxes[1]!);
+
+    await user.click(screen.getByRole("button", { name: /Отклонить выбранные/ }));
+
+    await waitFor(() => {
+      expect(api.bulkPendingReplies).toHaveBeenCalledWith({
+        ids: expect.arrayContaining(["pr-1", "pr-2"]),
+        decision: "reject",
+      });
+    });
+    // Winner row removed; loser row stays so the operator can read the error.
+    await waitFor(() => {
+      expect(screen.queryByText("winner")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("loser")).toBeInTheDocument();
+    expect(screen.getByText(/1 применено, 1 ошибок/)).toBeInTheDocument();
   });
 
   it("channel filter hides rows from the unselected channel", async () => {

--- a/frontend/src/app/(dashboard)/inbox/pending/page.tsx
+++ b/frontend/src/app/(dashboard)/inbox/pending/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ShieldCheck } from "lucide-react";
+import { ShieldCheck, X } from "lucide-react";
 import { FilterPill } from "@/components/outbound/FilterPill";
 import { formatTime } from "@/components/outbound/constants";
 import { PendingQueueRow } from "@/components/pending-queue/PendingQueueRow";
@@ -11,6 +11,7 @@ import { usePendingQueue } from "@/hooks/usePendingQueue";
 export default function InboxPendingPage() {
   const q = usePendingQueue();
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [bulkBusy, setBulkBusy] = useState(false);
 
   async function withBusy(id: string, op: (id: string) => Promise<void>) {
     setBusyId(id);
@@ -20,6 +21,17 @@ export default function InboxPendingPage() {
       setBusyId(null);
     }
   }
+
+  async function withBulkBusy(op: () => Promise<void>) {
+    setBulkBusy(true);
+    try {
+      await op();
+    } finally {
+      setBulkBusy(false);
+    }
+  }
+
+  const selectedCount = q.selectedIds.size;
 
   return (
     <section className="flex-1 overflow-y-auto px-4 sm:px-8 lg:px-12 py-8">
@@ -73,12 +85,73 @@ export default function InboxPendingPage() {
           </div>
         )}
 
+        {selectedCount > 0 && (
+          <div
+            role="region"
+            aria-label="Массовые действия"
+            className="mb-4 flex items-center justify-between rounded-xl border border-[#004ac6]/20 bg-[#eff4ff] px-4 py-3"
+          >
+            <span className="text-sm font-bold text-[#0d1c2e]">
+              Выбрано: {selectedCount}
+            </span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={q.clearSelected}
+                disabled={bulkBusy}
+                className="rounded-lg border border-[#c3c6d7]/50 bg-white px-3 py-1.5 text-xs font-semibold text-[#434655] transition-colors hover:bg-[#f7f9fd] disabled:opacity-50"
+              >
+                Снять выбор
+              </button>
+              <button
+                type="button"
+                onClick={() => withBulkBusy(q.bulkReject)}
+                disabled={bulkBusy}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-[#c3c6d7]/50 bg-white px-3 py-1.5 text-xs font-semibold text-[#434655] transition-colors hover:bg-[#f7f9fd] disabled:opacity-50"
+              >
+                <X className="size-3.5" />
+                Отклонить выбранные
+              </button>
+              <button
+                type="button"
+                onClick={() => withBulkBusy(q.bulkApprove)}
+                disabled={bulkBusy}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-[#0d7a2c] px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[#0a6324] disabled:opacity-50"
+              >
+                <ShieldCheck className="size-3.5" />
+                Одобрить выбранные
+              </button>
+            </div>
+          </div>
+        )}
+
+        {q.bulkSummary && (
+          <div
+            role="status"
+            className="mb-4 flex items-center justify-between rounded-xl bg-[#e8f6ec] px-4 py-3 text-sm text-[#0d1c2e]"
+          >
+            <span>
+              Готово: {q.bulkSummary.ok} применено
+              {q.bulkSummary.failed > 0 ? `, ${q.bulkSummary.failed} ошибок` : ""}
+            </span>
+            <button
+              type="button"
+              onClick={q.dismissBulkSummary}
+              className="text-xs font-semibold text-[#434655] hover:text-[#0d1c2e]"
+            >
+              Скрыть
+            </button>
+          </div>
+        )}
+
         <ul className="space-y-3">
           {q.filtered.map((row) => (
             <PendingQueueRow
               key={row.id}
               row={row}
-              busy={busyId === row.id}
+              busy={busyId === row.id || bulkBusy}
+              selected={q.selectedIds.has(row.id)}
+              onToggleSelect={q.toggleSelected}
               onApprove={(id) => withBusy(id, q.handleApprove)}
               onReject={(id) => withBusy(id, q.handleReject)}
             />

--- a/frontend/src/app/(dashboard)/inbox/pending/page.tsx
+++ b/frontend/src/app/(dashboard)/inbox/pending/page.tsx
@@ -7,6 +7,7 @@ import { formatTime } from "@/components/outbound/constants";
 import { PendingQueueRow } from "@/components/pending-queue/PendingQueueRow";
 import { PendingQueueTabs } from "@/components/pending-queue/PendingQueueTabs";
 import { usePendingQueue } from "@/hooks/usePendingQueue";
+import { pluralRu } from "@/lib/format";
 
 export default function InboxPendingPage() {
   const q = usePendingQueue();
@@ -132,7 +133,9 @@ export default function InboxPendingPage() {
           >
             <span>
               Готово: {q.bulkSummary.ok} применено
-              {q.bulkSummary.failed > 0 ? `, ${q.bulkSummary.failed} ошибок` : ""}
+              {q.bulkSummary.failed > 0
+                ? `, ${q.bulkSummary.failed} ${pluralRu(q.bulkSummary.failed, "ошибка", "ошибки", "ошибок")}`
+                : ""}
             </span>
             <button
               type="button"

--- a/frontend/src/components/pending-queue/PendingQueueRow.tsx
+++ b/frontend/src/components/pending-queue/PendingQueueRow.tsx
@@ -9,6 +9,8 @@ interface Props {
   onApprove: (id: string) => void;
   onReject: (id: string) => void;
   busy?: boolean;
+  selected?: boolean;
+  onToggleSelect?: (id: string) => void;
 }
 
 const KIND_LABELS: Record<PendingReplyQueueRow["kind"], string> = {
@@ -20,12 +22,29 @@ const CHANNEL_LABELS: Record<PendingReplyQueueRow["channel"], string> = {
   email: "Email",
 };
 
-export function PendingQueueRow({ row, onApprove, onReject, busy = false }: Props) {
+export function PendingQueueRow({
+  row,
+  onApprove,
+  onReject,
+  busy = false,
+  selected,
+  onToggleSelect,
+}: Props) {
   const isEmail = row.channel === "email";
+  const selectable = onToggleSelect !== undefined;
   return (
     <li className="rounded-xl border border-[#f5b73c]/30 bg-white p-5 transition-shadow hover:shadow-sm">
       <header className="mb-3 flex items-start justify-between gap-3">
         <div className="flex items-center gap-3">
+          {selectable && (
+            <input
+              type="checkbox"
+              checked={!!selected}
+              onChange={() => onToggleSelect!(row.id)}
+              aria-label={`Выбрать драфт для ${row.lead.contact_name || "лида"}`}
+              className="size-4 cursor-pointer accent-[#004ac6]"
+            />
+          )}
           <div
             className={`flex size-10 items-center justify-center rounded-full ${
               isEmail ? "bg-[#dbe1ff]" : "bg-[#d5e0f8]"

--- a/frontend/src/hooks/usePendingQueue.test.ts
+++ b/frontend/src/hooks/usePendingQueue.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/lib/api", () => ({
     listPendingReplies: vi.fn(),
     approvePendingReply: vi.fn(),
     rejectPendingReply: vi.fn(),
+    bulkPendingReplies: vi.fn(),
   },
 }));
 
@@ -146,6 +147,102 @@ describe("usePendingQueue", () => {
       (result.current.setKindFilter as (k: string) => void)("__no_match__");
     });
     expect(result.current.filtered).toHaveLength(0);
+  });
+
+  it("toggleSelected adds and removes ids from the selection set", async () => {
+    vi.mocked(api.listPendingReplies).mockResolvedValueOnce([
+      row({ id: "a" }),
+      row({ id: "b" }),
+    ]);
+
+    const { result } = renderHook(() => usePendingQueue());
+
+    await waitFor(() => {
+      expect(result.current.rows).toHaveLength(2);
+    });
+
+    act(() => result.current.toggleSelected("a"));
+    expect(result.current.selectedIds.has("a")).toBe(true);
+
+    act(() => result.current.toggleSelected("b"));
+    expect(result.current.selectedIds.size).toBe(2);
+
+    act(() => result.current.toggleSelected("a"));
+    expect(result.current.selectedIds.has("a")).toBe(false);
+    expect(result.current.selectedIds.has("b")).toBe(true);
+
+    act(() => result.current.clearSelected());
+    expect(result.current.selectedIds.size).toBe(0);
+  });
+
+  it("bulkApprove with empty selection is a no-op (no API call)", async () => {
+    vi.mocked(api.listPendingReplies).mockResolvedValueOnce([row({ id: "a" })]);
+
+    const { result } = renderHook(() => usePendingQueue());
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.bulkApprove();
+    });
+    expect(api.bulkPendingReplies).not.toHaveBeenCalled();
+  });
+
+  it("bulkApprove sends selected ids, removes ok rows, keeps failed, clears selection", async () => {
+    vi.mocked(api.listPendingReplies).mockResolvedValueOnce([
+      row({ id: "a" }),
+      row({ id: "b" }),
+      row({ id: "c" }),
+    ]);
+    vi.mocked(api.bulkPendingReplies).mockResolvedValueOnce({
+      results: [
+        { id: "a", ok: true },
+        { id: "b", ok: false, error: "not found" },
+        { id: "c", ok: true },
+      ],
+    });
+
+    const { result } = renderHook(() => usePendingQueue());
+    await waitFor(() => expect(result.current.rows).toHaveLength(3));
+
+    act(() => {
+      result.current.toggleSelected("a");
+      result.current.toggleSelected("b");
+      result.current.toggleSelected("c");
+    });
+
+    await act(async () => {
+      await result.current.bulkApprove();
+    });
+
+    expect(api.bulkPendingReplies).toHaveBeenCalledWith({
+      ids: expect.arrayContaining(["a", "b", "c"]),
+      decision: "approve",
+    });
+    // Failed row "b" stays; "a" and "c" are removed.
+    expect(result.current.rows.map((r) => r.id)).toEqual(["b"]);
+    expect(result.current.selectedIds.size).toBe(0);
+    expect(result.current.bulkSummary).toEqual({ ok: 2, failed: 1 });
+  });
+
+  it("bulkApprove refetches on top-level error", async () => {
+    vi.mocked(api.listPendingReplies)
+      .mockResolvedValueOnce([row({ id: "a" })])
+      .mockResolvedValueOnce([row({ id: "a" }), row({ id: "b" })]);
+    vi.mocked(api.bulkPendingReplies).mockRejectedValueOnce(new Error("5xx"));
+
+    const { result } = renderHook(() => usePendingQueue());
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+
+    act(() => result.current.toggleSelected("a"));
+
+    await act(async () => {
+      await result.current.bulkApprove();
+    });
+
+    // Refetch landed; selection cleared.
+    expect(api.listPendingReplies).toHaveBeenCalledTimes(2);
+    expect(result.current.rows).toHaveLength(2);
+    expect(result.current.selectedIds.size).toBe(0);
   });
 
   it("channel filter excludes rows from the other channel", async () => {

--- a/frontend/src/hooks/usePendingQueue.ts
+++ b/frontend/src/hooks/usePendingQueue.ts
@@ -89,9 +89,16 @@ export function usePendingQueue() {
     if (ids.length === 0) return;
     try {
       const { results } = await api.bulkPendingReplies({ ids, decision });
-      const okIds = new Set(results.filter((r) => r.ok).map((r) => r.id));
+      // Defensive intersection: ignore any server-returned id that
+      // was not in our request. The hook is the integrity boundary
+      // for local row removal — a buggy or hostile backend should
+      // never be able to flip rows we did not ask about.
+      const requestIds = new Set(ids);
+      const okIds = new Set(
+        results.filter((r) => r.ok && requestIds.has(r.id)).map((r) => r.id),
+      );
       const ok = okIds.size;
-      const failed = results.length - ok;
+      const failed = results.filter((r) => requestIds.has(r.id) && !r.ok).length;
       setRows((prev) => prev.filter((r) => !okIds.has(r.id)));
       setSelectedIds(new Set());
       setBulkSummary({ ok, failed });

--- a/frontend/src/hooks/usePendingQueue.ts
+++ b/frontend/src/hooks/usePendingQueue.ts
@@ -1,5 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
-import { api, type PendingReplyQueueRow, type PendingReplyKind } from "@/lib/api";
+import {
+  api,
+  type PendingReplyBulkDecision,
+  type PendingReplyKind,
+  type PendingReplyQueueRow,
+} from "@/lib/api";
 
 type ChannelFilter = "all" | "telegram" | "email";
 type KindFilter = "all" | PendingReplyKind;
@@ -12,6 +17,8 @@ export function usePendingQueue() {
   const [channelFilter, setChannelFilter] = useState<ChannelFilter>("all");
   const [kindFilter, setKindFilter] = useState<KindFilter>("all");
   const [lastUpdated, setLastUpdated] = useState<Date>(new Date());
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkSummary, setBulkSummary] = useState<{ ok: number; failed: number } | null>(null);
 
   const fetchData = useCallback(async (isInitial: boolean) => {
     try {
@@ -61,6 +68,39 @@ export function usePendingQueue() {
     return true;
   });
 
+  const toggleSelected = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const clearSelected = () => setSelectedIds(new Set());
+
+  // Bulk apply the decision to every currently-selected row. Removes
+  // rows that succeed from local state; rows that fail stay visible
+  // so the operator can retry or read the error. Top-level error
+  // (rare — shape problems are guarded client-side) triggers a
+  // refetch so we converge with the server.
+  const bulkDecide = async (decision: PendingReplyBulkDecision) => {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
+    try {
+      const { results } = await api.bulkPendingReplies({ ids, decision });
+      const okIds = new Set(results.filter((r) => r.ok).map((r) => r.id));
+      const ok = okIds.size;
+      const failed = results.length - ok;
+      setRows((prev) => prev.filter((r) => !okIds.has(r.id)));
+      setSelectedIds(new Set());
+      setBulkSummary({ ok, failed });
+    } catch {
+      await fetchData(false);
+      setSelectedIds(new Set());
+    }
+  };
+
   return {
     rows,
     filtered,
@@ -72,5 +112,13 @@ export function usePendingQueue() {
     setKindFilter,
     handleApprove,
     handleReject,
+    // Selection + bulk
+    selectedIds,
+    toggleSelected,
+    clearSelected,
+    bulkApprove: () => bulkDecide("approve"),
+    bulkReject: () => bulkDecide("reject"),
+    bulkSummary,
+    dismissBulkSummary: () => setBulkSummary(null),
   };
 }

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -376,6 +376,30 @@ describe("api module", () => {
       expect(opts.method).toBe("POST");
     });
 
+    it("bulkPendingReplies → POST /api/pending-replies/bulk with ids and decision", async () => {
+      const wireResponse = {
+        results: [
+          { id: "pr-1", ok: true },
+          { id: "pr-2", ok: false, error: "not found" },
+        ],
+      };
+      fetchMock.mockResolvedValueOnce(mockResponse(wireResponse));
+
+      const result = await api.bulkPendingReplies({
+        ids: ["pr-1", "pr-2"],
+        decision: "approve",
+      });
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("http://localhost:8080/api/pending-replies/bulk");
+      expect(opts.method).toBe("POST");
+      expect(JSON.parse(opts.body)).toEqual({
+        ids: ["pr-1", "pr-2"],
+        decision: "approve",
+      });
+      expect(result).toEqual(wireResponse);
+    });
+
     it("listPendingReplies → GET /api/pending-replies?status=pending with joined lead snippet", async () => {
       const sample = [
         {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -194,6 +194,13 @@ export const api = {
   // ?status=approved tab without silently widening the contract.
   listPendingReplies: () =>
     apiFetch<PendingReplyQueueRow[]>("/api/pending-replies?status=pending"),
+  // bulkPendingReplies — stub for the RED step of #49. Real impl
+  // lands in the matching GREEN commit so the contract test fails
+  // at runtime while the TS build stays green for bisect.
+  bulkPendingReplies: (
+    _body: { ids: string[]; decision: PendingReplyBulkDecision },
+  ): Promise<{ results: PendingReplyBulkResult[] }> =>
+    Promise.reject(new Error("bulkPendingReplies not implemented")),
   approvePendingReply: (id: string) =>
     apiFetch<void>(`/api/pending-replies/${id}/approve`, { method: "POST" }),
   rejectPendingReply: (id: string) =>
@@ -488,6 +495,20 @@ export interface PendingReplyLeadSnippet {
 // an N+1 lookup.
 export interface PendingReplyQueueRow extends PendingReply {
   lead: PendingReplyLeadSnippet;
+}
+
+// PendingReplyBulkDecision matches the BulkDecision enum on the
+// backend — the two terminal actions an operator can apply en-masse
+// to a slice of pending replies.
+export type PendingReplyBulkDecision = "approve" | "reject";
+
+// PendingReplyBulkResult is the per-row outcome surfaced by
+// POST /api/pending-replies/bulk. `error` is omitempty server-side
+// for success rows, so it's optional on the wire too.
+export interface PendingReplyBulkResult {
+  id: string;
+  ok: boolean;
+  error?: string;
 }
 
 export interface Reminder {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -194,13 +194,16 @@ export const api = {
   // ?status=approved tab without silently widening the contract.
   listPendingReplies: () =>
     apiFetch<PendingReplyQueueRow[]>("/api/pending-replies?status=pending"),
-  // bulkPendingReplies — stub for the RED step of #49. Real impl
-  // lands in the matching GREEN commit so the contract test fails
-  // at runtime while the TS build stays green for bisect.
-  bulkPendingReplies: (
-    _body: { ids: string[]; decision: PendingReplyBulkDecision },
-  ): Promise<{ results: PendingReplyBulkResult[] }> =>
-    Promise.reject(new Error("bulkPendingReplies not implemented")),
+  // bulkPendingReplies — power-operator endpoint: apply the same
+  // decision to many drafts in one round-trip. Per-row outcomes come
+  // back under `results` so the UI can surface partial failures
+  // (NotFound / AlreadyDecided / dispatcher 5xx) without aborting the
+  // whole batch.
+  bulkPendingReplies: (body: { ids: string[]; decision: PendingReplyBulkDecision }) =>
+    apiFetch<{ results: PendingReplyBulkResult[] }>("/api/pending-replies/bulk", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
   approvePendingReply: (id: string) =>
     apiFetch<void>(`/api/pending-replies/${id}/approve`, { method: "POST" }),
   rejectPendingReply: (id: string) =>

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -12,3 +12,20 @@ export function getTimeAgo(dateStr: string): string {
 export function getInitials(name: string): string {
   return name.split(" ").map((w) => w[0]).join("").slice(0, 2).toUpperCase();
 }
+
+// pluralRu picks the right Russian noun form for the given count. Uses
+// Intl.PluralRules so we don't hand-roll the mod-100/mod-10 logic per
+// caller. Categories: "one" (1, 21, 31, …), "few" (2-4, 22-24, …),
+// "many" (everything else: 0, 5-20, 25-30, …).
+//
+//   pluralRu(1, "ошибка", "ошибки", "ошибок") -> "ошибка"
+//   pluralRu(2, "ошибка", "ошибки", "ошибок") -> "ошибки"
+//   pluralRu(5, "ошибка", "ошибки", "ошибок") -> "ошибок"
+const ruPlural = new Intl.PluralRules("ru-RU");
+
+export function pluralRu(n: number, one: string, few: string, many: string): string {
+  const category = ruPlural.select(n);
+  if (category === "one") return one;
+  if (category === "few") return few;
+  return many;
+}


### PR DESCRIPTION
## Summary
- Backend: `POST /api/pending-replies/bulk` applies the same decision (`approve` | `reject`) to many drafts in one round-trip, delegating per-row to the existing single-row `Approve`/`Reject` so the optimistic-lock + dispatcher contract is preserved without duplication. Partial failures surface per-row; one Telegram outage doesn't poison the batch.
- Frontend: checkboxes per row + selection toolbar with "Одобрить выбранные" / "Отклонить выбранные" on `/inbox/pending`. Failed rows stay visible after a bulk so the operator can read the error; a dismissible green summary banner shows `{ok, failed}` counts (with correct Russian pluralisation via `Intl.PluralRules`).
- 9-commit TDD cascade: three RED→GREEN pairs (usecase / handler / frontend-api) + bundled UI feat + two review-fix commits.

## Trade-offs
- **Rate limit**: bulk consumes one slot per call regardless of batch size — deliberate power-operator affordance, documented in the route registration comment. Switch to `len(ids)` accounting in the middleware key fn if abuse becomes a problem.
- **Payload cap**: 256 KiB on `/bulk` only — it's the only inbox endpoint with a variable-size body. Other inbox endpoints take fixed-shape bodies and don't need a per-endpoint cap; a project-wide JSON-body limit is a separate concern.
- **Filters stay client-side** (inherited from #84). Server-side filtering is a clean extension when volume warrants.

## Internal review pass
After two review-fix commits, all axes ≥ 8:
TDD 9 · DDD 8 · CA 8 · Concurrency 8 (ctx-cancel propagation, concurrent-collision test) · Security 8 (per-endpoint payload cap) · Wire 9 · Test Quality 8 · Code Quality 8 · Floq Conventions 9.

Important issues fixed before opening:
- BulkDecide loop honours `ctx.Err()` and pads remaining ids with the context error (no wasted dispatcher round-trips on a dead context)
- Concurrent-operator collision test (sequential simulation pins the optimistic lock through the bulk path, not just symmetry-with-single-row)
- Hook intersects server-returned ids with the request set (integrity boundary against a buggy or hostile backend)
- 256 KiB payload cap

## Test plan
- [ ] `cd backend && go test ./...`
- [ ] `cd backend && go test -tags=integration -run "TestPendingReplyUseCase_BulkDecide|TestHandler_BulkDecide" ./internal/inbox/`
- [ ] `cd frontend && npm test -- --run`
- [ ] Manually: log in, navigate to `/inbox/pending`, tick several rows, click "Одобрить выбранные", confirm successful rows disappear optimistically and any failures stay visible with the green summary banner showing the correct counts

## Notes
- Pre-existing integration test `TestPendingReplyRepository_Update_PersistsStatusAndTimestamps` still fails on main (FK violation on `decided_by` after migration 032). Not introduced here; follow-up issue worth opening.

Closes #49.