### PR TITLE
feat(inbox): suppress telegram booking link when bookingLink empty

### DIFF
--- a/backend/internal/inbox/telegram.go
+++ b/backend/internal/inbox/telegram.go
@@ -221,10 +221,19 @@ func (t *TelegramBot) handleMessage(ctx context.Context, msg *tgbotapi.Message) 
 	// so the secure default when no proposer is wired is to suppress
 	// the branch entirely — we do NOT fall back to instant send.
 	if DetectCallAgreement(text) {
-		if t.pendingProposer == nil {
+		switch {
+		case t.pendingProposer == nil:
 			t.logger.WarnContext(ctx, "booking link suppressed: no pending reply proposer wired",
 				slog.Int64("chat_id", chatID), slog.String("lead_id", lead.ID.String()))
-		} else {
+		case t.bookingLink == "":
+			// Enqueueing with an empty URL would let an operator
+			// approve a customer-visible message ending in
+			// "…ссылка для звонка: " with nothing after it.
+			// Suppress the branch instead — operator can write the
+			// message manually if needed.
+			t.logger.WarnContext(ctx, "booking link suppressed: bookingLink not configured",
+				slog.Int64("chat_id", chatID), slog.String("lead_id", lead.ID.String()))
+		default:
 			bookingMsg := fmt.Sprintf(bookingLinkReplyTemplate, t.bookingLink)
 			if _, err := t.pendingProposer.Propose(ctx, lead.UserID, lead.ID, ChannelTelegram, PendingReplyKindBookingLink, bookingMsg); err != nil {
 				t.logger.WarnContext(ctx, "failed to enqueue booking reply for approval",

--- a/backend/internal/inbox/telegram_test.go
+++ b/backend/internal/inbox/telegram_test.go
@@ -397,6 +397,27 @@ func TestHandleMessage_CallAgreement_EnqueuesForApproval(t *testing.T) {
 	assert.Contains(t, calls[0].Body, bookingLink)
 }
 
+func TestHandleMessage_CallAgreement_EmptyBookingLinkSuppresses(t *testing.T) {
+	// Mirrors the email-side guard added in #53: a proposer wired AND
+	// DetectCallAgreement matching still must NOT enqueue when
+	// bookingLink is "". Otherwise the formatted template carries a
+	// blank URL slot ("…вот ссылка: ") and the operator can approve a
+	// customer-visible message with no link in it.
+	repo := newMockLeadRepo()
+	aiClient := &mockAIQualifier{result: &QualificationResult{Score: 9}}
+	ownerID := uuid.New()
+	proposer := &spyPendingProposer{}
+	bot := newTestBot(repo, aiClient, ownerID, "") // empty bookingLink
+	bot.SetPendingProposer(proposer)
+
+	msg := makeTgMessage(99999, "Bob", "", "Звучит интересно, давайте созвон проведём!")
+	bot.handleMessage(context.Background(), msg)
+	waitQualifyDone(t, repo)
+
+	assert.Empty(t, proposer.Calls(),
+		"proposer must NOT fire with empty bookingLink — would land a customer-visible message with a blank URL")
+}
+
 func TestHandleMessage_CallAgreement_NoProposerSuppressesBookingLink(t *testing.T) {
 	repo := newMockLeadRepo()
 	aiClient := &mockAIQualifier{result: &QualificationResult{Score: 9}}


### PR DESCRIPTION
## Summary
- Mirrors the email-side guard from #53 (#86) on the Telegram bot.
- Before: `t.pendingProposer != nil && DetectCallAgreement(text)` → `fmt.Sprintf(template, "")` enqueues a draft ending in "…ссылка для звонка: " with a blank URL slot, ready for an operator to approve and send.
- After: a third `case t.bookingLink == ""` suppresses the branch with a warning log, symmetric with the email switch.

## Why now
Pre-existing bug spotted while shipping #53 — that PR fixed only the email side because changing telegram.go was out of its scope. Filed as tech-debt in the handoff (`2026-05-20_issue-53-email-hitl.md`).

## Test plan
- [x] `go test -run TestHandleMessage_CallAgreement ./internal/inbox/` — both new + existing tests green.
- [x] `go test -count=1 ./internal/inbox/` — full inbox unit suite green.
- [x] `gofmt -l internal/inbox/telegram.go` — clean (no alignment regression).