### PR TITLE
feat(server): defence-in-depth body size caps (MaxBodyBytes + JSONBodyCap)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -200,6 +200,11 @@ func main() {
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 	r.Use(corsMiddleware)
+	// Cap application/json request bodies project-wide so a single
+	// oversized payload can't stream straight into json.NewDecoder.
+	// Tighter local caps (e.g. the bulk endpoint's 256 KiB) still win
+	// — MaxBytesReader honours the smallest cap in the chain.
+	r.Use(httputil.JSONBodyCap(httputil.DefaultMaxJSONBodyBytes))
 
 	// Health (public)
 	r.Get("/api/health", func(w http.ResponseWriter, r *http.Request) {

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -200,10 +200,17 @@ func main() {
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 	r.Use(corsMiddleware)
-	// Cap application/json request bodies project-wide so a single
-	// oversized payload can't stream straight into json.NewDecoder.
-	// Tighter local caps (e.g. the bulk endpoint's 256 KiB) still win
-	// — MaxBytesReader honours the smallest cap in the chain.
+	// Defence in depth on request body size:
+	//   1) MaxBodyBytes (outer, 10 MiB) — unconditional ceiling so a
+	//      client omitting or spoofing Content-Type cannot stream past
+	//      the cap into a handler. Multipart uploads (importCSV) are
+	//      bounded here as well.
+	//   2) JSONBodyCap (inner, 1 MiB) — tighter cap that fires only for
+	//      application/json bodies; MaxBytesReader composes downward so
+	//      JSON clients trip the inner cap first.
+	//   3) Handler-local caps (e.g. bulk endpoint's 256 KiB) still win
+	//      when wrapped after the middleware — smallest in chain wins.
+	r.Use(httputil.MaxBodyBytes(httputil.DefaultMaxBodyBytes))
 	r.Use(httputil.JSONBodyCap(httputil.DefaultMaxJSONBodyBytes))
 
 	// Health (public)

--- a/backend/internal/httputil/middleware.go
+++ b/backend/internal/httputil/middleware.go
@@ -5,11 +5,38 @@ import (
 	"strings"
 )
 
+// DefaultMaxBodyBytes is the absolute ceiling applied by MaxBodyBytes.
+// 10 MiB comfortably accommodates legitimate multipart uploads (CSV
+// imports etc.) while still bounding the worst-case Content-Length a
+// single request can stream into a handler — the outer floor in the
+// defence-in-depth stack with JSONBodyCap.
+const DefaultMaxBodyBytes int64 = 10 * 1024 * 1024
+
 // DefaultMaxJSONBodyBytes is the default cap applied by JSONBodyCap.
 // 1 MiB is far beyond any structured JSON payload Floq accepts and far
-// below the DoS threshold (a malicious 1 GiB Content-Length would
-// otherwise stream straight into json.NewDecoder.Decode).
+// below the DoS threshold. The inner (tighter) layer in the
+// defence-in-depth stack — only fires on application/json bodies.
 const DefaultMaxJSONBodyBytes int64 = 1 * 1024 * 1024
+
+// MaxBodyBytes returns middleware that wraps r.Body in
+// http.MaxBytesReader unconditionally — regardless of Content-Type.
+// Use this as the outer ceiling so a client that omits or spoofs
+// Content-Type cannot stream past the cap into a handler that then
+// calls json.NewDecoder.Decode or io.ReadAll.
+//
+// Tighter content-type-specific caps (e.g. JSONBodyCap) compose with
+// this middleware: MaxBytesReader honours the smallest cap in the
+// chain, so the inner layer fires first on JSON traffic.
+func MaxBodyBytes(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Body != nil {
+				r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
 
 // JSONBodyCap returns middleware that wraps r.Body in
 // http.MaxBytesReader when the request Content-Type is

--- a/backend/internal/httputil/middleware.go
+++ b/backend/internal/httputil/middleware.go
@@ -1,0 +1,41 @@
+package httputil
+
+import (
+	"net/http"
+	"strings"
+)
+
+// DefaultMaxJSONBodyBytes is the default cap applied by JSONBodyCap.
+// 1 MiB is far beyond any structured JSON payload Floq accepts and far
+// below the DoS threshold (a malicious 1 GiB Content-Length would
+// otherwise stream straight into json.NewDecoder.Decode).
+const DefaultMaxJSONBodyBytes int64 = 1 * 1024 * 1024
+
+// JSONBodyCap returns middleware that wraps r.Body in
+// http.MaxBytesReader when the request Content-Type is
+// application/json (with or without a charset suffix). Multipart and
+// other non-JSON content types are untouched — file upload routes
+// carry their own size considerations and must opt in separately.
+//
+// Handlers needing a tighter local cap can still wrap r.Body again;
+// MaxBytesReader honours the smallest cap in the chain.
+func JSONBodyCap(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Body != nil && isJSONContentType(r.Header.Get("Content-Type")) {
+				r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func isJSONContentType(ct string) bool {
+	if ct == "" {
+		return false
+	}
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	return strings.EqualFold(strings.TrimSpace(ct), "application/json")
+}

--- a/backend/internal/httputil/middleware_test.go
+++ b/backend/internal/httputil/middleware_test.go
@@ -94,3 +94,77 @@ func TestJSONBodyCap_RespectsCharsetSuffix(t *testing.T) {
 		t.Fatal("expected MaxBytesError with charset-suffixed Content-Type, got nil")
 	}
 }
+
+func TestMaxBodyBytes_CapsArbitraryContentType(t *testing.T) {
+	// Outer absolute ceiling — applies regardless of Content-Type, so a
+	// client spoofing "application/octet-stream" cannot stream past
+	// the cap into json.NewDecoder via the bypass JSONBodyCap leaves
+	// open by design.
+	var capturedErr error
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, capturedErr = io.ReadAll(r.Body)
+	})
+
+	mw := MaxBodyBytes(10)(next)
+
+	oversized := strings.Repeat("x", 50)
+	req := httptest.NewRequest(http.MethodPost, "/x", bytes.NewBufferString(oversized))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if capturedErr == nil {
+		t.Fatal("expected MaxBytesError for octet-stream body, got nil")
+	}
+	var maxBytesErr *http.MaxBytesError
+	if !errors.As(capturedErr, &maxBytesErr) {
+		t.Fatalf("expected *http.MaxBytesError, got %T (%v)", capturedErr, capturedErr)
+	}
+}
+
+func TestMaxBodyBytes_CapsNoContentTypeHeader(t *testing.T) {
+	// Missing Content-Type must NOT bypass the outer cap — this is
+	// exactly the bypass JSONBodyCap alone is vulnerable to.
+	var capturedErr error
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, capturedErr = io.ReadAll(r.Body)
+	})
+
+	mw := MaxBodyBytes(10)(next)
+
+	oversized := strings.Repeat("x", 50)
+	req := httptest.NewRequest(http.MethodPost, "/x", bytes.NewBufferString(oversized))
+	// Note: no Content-Type header set.
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if capturedErr == nil {
+		t.Fatal("expected MaxBytesError when Content-Type is absent, got nil")
+	}
+}
+
+func TestMaxBodyBytes_StackedUnderJSONBodyCap(t *testing.T) {
+	// Defence in depth: MaxBodyBytes is the outer (loose) ceiling,
+	// JSONBodyCap layered inside trips first for JSON traffic because
+	// MaxBytesReader honours the smallest cap in the chain.
+	var capturedErr error
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, capturedErr = io.ReadAll(r.Body)
+	})
+
+	mw := MaxBodyBytes(1000)(JSONBodyCap(10)(next))
+
+	oversized := strings.Repeat("x", 50)
+	req := httptest.NewRequest(http.MethodPost, "/x", bytes.NewBufferString(oversized))
+	req.Header.Set("Content-Type", "application/json")
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if capturedErr == nil {
+		t.Fatal("expected MaxBytesError from inner JSON cap, got nil")
+	}
+	var maxBytesErr *http.MaxBytesError
+	if !errors.As(capturedErr, &maxBytesErr) {
+		t.Fatalf("expected *http.MaxBytesError, got %T", capturedErr)
+	}
+	if maxBytesErr.Limit != 10 {
+		t.Fatalf("expected inner JSON cap (10) to trip first, got Limit=%d", maxBytesErr.Limit)
+	}
+}

--- a/backend/internal/httputil/middleware_test.go
+++ b/backend/internal/httputil/middleware_test.go
@@ -1,0 +1,96 @@
+package httputil
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestJSONBodyCap_AppliesToJSONContentType(t *testing.T) {
+	// A handler that reads everything from r.Body and reports whether
+	// the read errored — this is exactly the shape json.NewDecoder.Decode
+	// produces when MaxBytesReader trips.
+	var capturedErr error
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, capturedErr = io.ReadAll(r.Body)
+	})
+
+	mw := JSONBodyCap(10)(next)
+
+	oversized := strings.Repeat("x", 50)
+	req := httptest.NewRequest(http.MethodPost, "/x", bytes.NewBufferString(oversized))
+	req.Header.Set("Content-Type", "application/json")
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if capturedErr == nil {
+		t.Fatal("expected ReadAll to error after exceeding cap, got nil")
+	}
+	var maxBytesErr *http.MaxBytesError
+	if !errors.As(capturedErr, &maxBytesErr) {
+		t.Fatalf("expected *http.MaxBytesError, got %T (%v)", capturedErr, capturedErr)
+	}
+}
+
+func TestJSONBodyCap_PassesUnderCapJSON(t *testing.T) {
+	var got string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		got = string(b)
+	})
+
+	mw := JSONBodyCap(100)(next)
+
+	req := httptest.NewRequest(http.MethodPost, "/x", bytes.NewBufferString(`{"ok":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got != `{"ok":true}` {
+		t.Fatalf("body within cap must pass through unchanged, got %q", got)
+	}
+}
+
+func TestJSONBodyCap_SkipsMultipartContentType(t *testing.T) {
+	// Multipart routes (CSV import etc.) need their own cap reasoning
+	// — the JSON cap must NOT apply or it would cripple file upload.
+	var got string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		got = string(b)
+	})
+
+	mw := JSONBodyCap(10)(next)
+
+	oversized := strings.Repeat("x", 50)
+	req := httptest.NewRequest(http.MethodPost, "/x", bytes.NewBufferString(oversized))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=---abc")
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got != oversized {
+		t.Fatalf("multipart body must NOT be capped (got %d bytes, want %d)", len(got), len(oversized))
+	}
+}
+
+func TestJSONBodyCap_RespectsCharsetSuffix(t *testing.T) {
+	// Real clients send "application/json; charset=utf-8" — the cap
+	// must still apply, otherwise a polite Content-Type bypasses DoS
+	// protection entirely.
+	var capturedErr error
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, capturedErr = io.ReadAll(r.Body)
+	})
+
+	mw := JSONBodyCap(10)(next)
+
+	oversized := strings.Repeat("x", 50)
+	req := httptest.NewRequest(http.MethodPost, "/x", bytes.NewBufferString(oversized))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if capturedErr == nil {
+		t.Fatal("expected MaxBytesError with charset-suffixed Content-Type, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
Two layers of `http.MaxBytesReader` at the chi root, closing the DoS surface that previously left 33 `json.NewDecoder(r.Body).Decode(...)` sites and both `importCSV` multipart routes unbounded.

- **Outer** — `httputil.MaxBodyBytes(10 MiB)` fires regardless of Content-Type. Closes the bypass an attacker has by spoofing or omitting Content-Type. Multipart upload routes (importCSV) are now bounded at 10 MiB — they were previously uncapped.
- **Inner** — `httputil.JSONBodyCap(1 MiB)` fires only on `application/json` (charset suffix tolerated). Tighter, JSON-specific cap. `MaxBytesReader` composes downward so JSON clients trip the inner cap first.
- **Handler-local** — caps like the bulk endpoint's 256 KiB still win when wrapped after the middleware (smallest in chain wins).

## Why two layers
Initial commits used only `JSONBodyCap` (Content-Type-filtered). Reviewer flagged that an adversary spoofing Content-Type bypasses the cap entirely — `json.NewDecoder.Decode` ignores Content-Type and parses whatever bytes it receives. Defence in depth fixes this without coupling protection to route topology.

## TDD trail
1. RED — `test(httputil): RED for JSONBodyCap middleware` (4 cases: oversized JSON trips, under-cap passes, multipart untouched, charset suffix still capped)
2. GREEN — `feat(httputil): JSONBodyCap middleware with 1 MiB default`
3. Wire — `feat(server): wire JSONBodyCap middleware at the root router`
4. RED — `test(httputil): RED for MaxBodyBytes outer ceiling middleware` (3 cases: arbitrary Content-Type still capped, missing Content-Type still capped, stacked layers — inner trips first)
5. GREEN — `feat(httputil): MaxBodyBytes outer ceiling for defence in depth`
6. Wire — `feat(server): stack MaxBodyBytes outside JSONBodyCap at root router`

## Test plan
- [x] `go test ./internal/httputil/` — 7 middleware tests + existing 2 green.
- [x] `go test ./...` — full unit suite green (30 packages).
- [x] `go build ./...` — clean.
- [x] RED→GREEN verified via selective checkout per commit.

## Caps chosen
- 10 MiB outer: comfortably accommodates current importCSV use cases; far below worst-case DoS (1 GiB+).
- 1 MiB inner: every known JSON endpoint accepts payloads ≤ a few KiB.
- Both expressed as `httputil.DefaultMaxBodyBytes` / `httputil.DefaultMaxJSONBodyBytes` so future tuning is one constant edit.