### PR TITLE
docs(roadmap): refresh to reflect actual state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,157 +1,115 @@
 # Floq — Roadmap
 
-> Порядок реализации по приоритетам PM.
-> Обновлено: 2026-04-02
+> AI-помощник для полного цикла B2B-продаж: inbound (Telegram/Email) + outbound (cold outreach) + AI-квалификация и драфты.
+> Обновлено: 2026-05-20
 
 ---
 
-## Статус: что готово
+## Текущее состояние
 
-### Backend (Go)
-| Модуль | Файлы | Статус |
+### Backend (Go 1.26, chi, pgx/v5)
+
+| Bounded context | Файлы | Состояние |
 |---|---|---|
-| Конфиг + main.go | `cmd/server/main.go`, `internal/config/` | Скелет, модули не подключены |
-| Auth (JWT) | `internal/auth/` | Код готов |
-| Leads CRUD | `internal/leads/` | Код готов |
-| Inbox (TG + Email) | `internal/inbox/` | Код готов (email IMAP — стаб) |
-| AI Provider | `internal/ai/` | Код готов (Claude, OpenAI, Ollama) |
-| Reminders cron | `internal/reminders/` | Код готов |
-| Notify (TG) | `internal/notify/` | Код готов |
-| Prospects CRUD | `internal/prospects/` | Код готов |
-| Sequences | `internal/sequences/` | Код готов |
-| Миграции | `migrations/001-009` | Готовы |
+| **auth** | `internal/auth/` | JWT, login flow, ratelimit на public-роуты |
+| **leads** | `internal/leads/` | CRUD, AI-квалификация, drafts, identity-aggregation |
+| **prospects** | `internal/prospects/` | CRUD, CSV import/export, dedup |
+| **sequences** | `internal/sequences/` | Multi-step outreach, channel-aware steps, tracking pixel |
+| **sources** | `internal/sources/` | Категории + источники + stats |
+| **inbox** | `internal/inbox/` | Telegram bot + IMAP poller, attachments analyzer, HITL queue (pending replies) |
+| **outbound** | `internal/outbound/` | Resend (primary), SMTP (fallback), MTProto (TG личный аккаунт) |
+| **settings** | `internal/settings/` | Multi-tenant: per-user AI/SMTP/IMAP/Resend config + testers |
+| **chat** | `internal/chat/` | AI-ассистент для оператора (изолирован от ai через адаптер) |
+| **reminders** | `internal/reminders/` | Cron для stale leads |
+| **verify** | `internal/verify/` | Email syntax/MX/SMTP-probe, TG-username проверка, disposable-домены |
+| **parser** | `internal/parser/` | 2GIS, website scraping |
+| **tgclient** | `internal/tgclient/` | MTProto (gotd/td) для отправки с личного TG |
+| **audit** | `internal/audit/` | AsyncRecorder cost-tracking за каждый AI-call, decorator над ai.Provider |
+| **ratelimit** | `internal/ratelimit/` | Redis-backed sliding window + in-memory fallback |
+| **httputil** | `internal/httputil/` | JSON-response helpers + defence-in-depth body-size middleware |
 
-### Frontend (Next.js)
-| Страница | URL | Статус |
+### Frontend (Next.js 16, React 19)
+
+| Страница | URL | Состояние |
 |---|---|---|
-| Login | `/login` | Готова (мок) |
-| Inbox | `/inbox` | Готова (мок) |
-| Lead Detail | `/inbox/[leadId]` | Готова (мок) |
-| Alerts | `/alerts` | Готова (мок) |
-| Проспекты | `/prospects` | Готова (мок) |
-| Секвенции | `/sequences` | Готова (мок) |
-| Очередь отправки | `/outbound` | Готова (мок) |
+| Login | `/login` | Реальный API |
+| Inbox | `/inbox` | Реальный API, фильтры, статусы |
+| Lead Detail | `/inbox/[leadId]` | Реальный API + drafts + identity-aggregation |
+| Operator Queue | `/inbox/pending` | HITL queue с bulk decide, optimistic-remove, 10s polling |
+| Prospects | `/prospects` | CRUD + CSV + verify integration |
+| Sequences | `/sequences` | Multi-step builder, channel-per-step |
+| Outbound | `/outbound` | Очередь отправки + tracking |
+| Parser | `/parser` | 2GIS + website scraping |
+| Settings | `/settings` | Sub-hooks per concern (AI/SMTP/IMAP/Resend/Telegram bot/account) |
 
-### Infra
-| Компонент | Статус |
-|---|---|
-| docker-compose (PG + Redis) | Готов |
-| .env.example | Готов |
+### HITL (Human-In-The-Loop) кластер
 
----
+Закрыт на 100% активной поверхности:
 
-## Сессия 1: Верификатор email + TG (ПРИОРИТЕТ PM)
+- **Inbound** — каждый AI-draft проходит approve-before-send через `pending_replies` table
+- **Channel routing** — `channelReplyDispatcher` по `pr.Channel`, telegram + email parity
+- **Operator queue page** `/inbox/pending` с bulk approve/reject
+- **Email auto-draft** — booking-link suggestion на `DetectCallAgreement` match (email + telegram parity)
+- **Защита от мисфайра** — empty-bookingLink config → suppress (не лендим пустой URL в queue)
 
-> "50-60% хорошего outreach — это сбор релевантной базы"
-> "Дв шлёт 300 писем/день по мусорной базе → выхлоп 0"
-> "Сервисы для почт платные — нам бы свой"
+### Инфраструктура
 
-### Backend
-- [ ] `internal/verify/email.go` — верификация email:
-  - Синтаксис (RFC regex)
-  - MX lookup (`net.LookupMX`)
-  - SMTP probe (RCPT TO без отправки)
-  - Одноразовые домены (список ~3000)
-  - Catch-all детекция (RCPT TO на рандомный адрес)
-  - Free provider детекция (gmail, mail.ru, yandex)
-  - Скоринг 0-100 → статус valid/risky/invalid
-- [ ] `internal/verify/telegram.go` — проверка TG username
-- [ ] `internal/verify/disposable.go` — список одноразовых доменов
-- [ ] `internal/verify/handler.go` — API endpoints:
-  - POST /api/verify/email (один адрес)
-  - POST /api/verify/batch (массовая проверка проспектов)
-  - GET /api/prospects/:id/verify (статус проверки)
-- [ ] Миграция 010: добавить verify_status, verify_details, telegram_username в prospects
+- docker-compose: PostgreSQL 18, Redis 8, Ollama (опционально)
+- OrbStack на dev-машине
+- Миграции: golang-migrate, 001-032 (audit_log, pending_replies, decided_by FK, и т.д.)
+- Защита от DoS на body size: 10 MiB outer ceiling + 1 MiB JSON-specific cap (defence in depth)
+- CLA bot, CI gates: Backend Go, Frontend Next.js, Redteam corpus, Tooling
+- Release automation: `bin/release.sh X.Y.Z` синкает 4 version sync-points + tag + GH release
 
-### Frontend
-- [ ] Обновить `/prospects` — колонка "Проверка" с иконками (галочка/вопрос/крестик)
-- [ ] Кнопка "Проверить базу" — запуск массовой верификации
-- [ ] Проспект нельзя добавить в секвенцию если не проверен
+### Тесты
+
+- Backend unit: ~350 тестов, ~66% coverage
+- Backend integration (`go:build integration`): 55 тестов, ~79% с ними
+- Frontend vitest: 115 тестов, ~43% coverage
+- Domain packages: 100% coverage
 
 ---
 
-## Сессия 2: Парсинг контактов (ПРИОРИТЕТ PM)
+## На горизонте (приоритет TBD)
 
-> "парсинг контактов надо сразу внедрять"
-> "надо генерить идеи откуда брать контакты"
+### Outbound HITL
+Inbound имеет full approve-before-send. Outbound (sequences) пока шлёт автоматически. Возможный mirror: each scheduled outbound message → `pending_replies` queue → operator approve. Trade-off: добавляет latency + manual surface vs. lower risk на cold outreach.
 
-### Backend
-- [ ] `internal/parser/twogis.go` — парсинг 2ГИС:
-  - Вход: ниша + город
-  - Выход: компания, телефон, адрес, категория, сайт
-- [ ] `internal/parser/website.go` — поиск email на сайтах:
-  - Вход: URL сайта
-  - Выход: найденные email-адреса (со страницы контактов)
-- [ ] `internal/parser/handler.go` — API:
-  - POST /api/parser/twogis {query, city} → список компаний
-  - POST /api/parser/website {url} → найденные email
-  - POST /api/parser/import → сохранить результаты как проспектов
-- [ ] Контекст: при парсинге сохраняем industry, company_size, context в проспекта
+### Analytics dashboard
+Outbound tracking (sequences pixel) уже собирает open events. Reply rate частично через identity-aggregation. **Нет**: UI-агрегации (open rate, reply rate, conversion rate per sequence, per user, per campaign). Audit-log с cost собирается, но UI отдельной cost-dashboard нет.
 
-### Frontend
-- [ ] Новая страница `/parser` или модалка в `/prospects`:
-  - Форма: ниша + город → "Найти компании"
-  - Результаты таблицей → "Добавить в проспекты"
-  - Поиск email по URL
+### Multi-workspace
+Текущая модель: один владелец (`cfg.OwnerUserID`), single-tenant в продакшене с multi-tenant adapters внутри. Реальная multi-team разработка требует переосмысления — workspace как aggregate, RBAC, billing-per-workspace.
 
----
+### Webhook integrations
+Outgoing webhooks на ключевые события: `lead.created`, `pending_reply.approved`, `sequence.completed`. Для интеграции с CRM/Zapier/etc. без копирования данных.
 
-## Сессия 3: Мультиканальные секвенции
+### Auto-enrichment
+По domain'у компании — обогащение из публичных источников (HH.ru, Rusprofile, открытые реестры). Без paid API сначала; платные интеграции (Clearbit, Apollo) — отдельный gate.
 
-> "слать письмо, потом слать в тг фоллоу ап или давать на прозвон"
-> "письмо должно быть исходя из контекста"
+### Security follow-ups
+- Per-route file-upload cap'ы (сейчас 10 MiB outer на importCSV; possibly tighter per-route)
+- Audit-log retention/rotation (сейчас бесконечный grow)
+- A/B тестирование промптов через `internal/ai` + audit-log group-by
 
-### Backend
-- [ ] Обновить sequence_steps: добавить поле `channel` (email/telegram/phone_call)
-- [ ] Миграция: ALTER TABLE sequence_steps ADD channel
-- [ ] Обновить launch: для каждого шага разное поведение:
-  - email → создать outbound_message (автоотправка)
-  - telegram → создать outbound_message с пометкой "скопировать"
-  - phone_call → создать задачу для телемаркетолога (имя, телефон, контекст)
-- [ ] Обновить AI промпты: передавать context проспекта для персонализации
-- [ ] `internal/tasks/` — модуль задач на прозвон для телемаркетологов
-
-### Frontend
-- [ ] Обновить `/sequences` — выбор канала для каждого шага (email/TG/звонок)
-- [ ] Обновить `/outbound` — разные иконки и действия по каналу:
-  - Email: "Подтвердить" (автоотправка)
-  - Telegram: "Скопировать" (в буфер)
-  - Звонок: "Карточка прозвона" (имя, телефон, что писали)
-- [ ] Новая страница `/calls` — очередь прозвонов для телемаркетологов
+### Observability foundations
+- `/metrics` Prometheus endpoint
+- Slow-query logging
+- Уже есть structured slog, но без агрегации/алертинга
 
 ---
 
-## Сессия 4: Связать backend + фронт
+## Принципы
 
-### main.go
-- [ ] Подключить к роутеру: все модули (prospects, sequences, outbound, verify, parser)
-- [ ] Инициализация DB pool, AI provider, crons
-- [ ] Outbound sender cron (email через Resend)
-- [ ] Bounce tracking
-
-### Frontend → Backend
-- [ ] Убрать моки, подключить реальный API
-- [ ] Реальный логин + seed data
-- [ ] E2E: парсинг → верификация → секвенция → отправка
+- **TDD + DDD + Clean Architecture** — механические гейты через `CLAUDE.md`
+- **Bounded contexts** — каждый `internal/X` изолирован; cross-context только через адаптеры в `cmd/server/`
+- **Domain-инварианты** только через фабрики (`NewLead`, `NewProspect`, `NewSource`...)
+- **Без feat-коммитов с тестами одновременно** (TDD red→green pairs)
+- **Версионирование** — semver, 4 sync-точки (VERSION, README badge, package.json, package-lock.json)
+- **Без upмаунта в main** — только через PR + CI gate
 
 ---
 
-## Сессия 5: Полировка + демо
+## Архивированное (доделано, оставлено для истории)
 
-- [ ] Дедупликация: не писать тому, кто уже в inbox
-- [ ] Error handling + loading states
-- [ ] Seed data для демо PM
-- [ ] Проспект ответил боту → auto-convert в лид
-
----
-
-## Будущее (v2)
-
-- [ ] HH.ru парсинг (компании с вакансиями = есть бюджет)
-- [ ] Rusprofile (ИНН, выручка, размер)
-- [ ] LinkedIn Sales Navigator экспорт
-- [ ] Аналитика: open rate, reply rate, conversion rate
-- [ ] A/B тестирование промптов в секвенциях
-- [ ] Multi-workspace (команды)
-- [ ] Webhook для интеграций
-- [ ] Автоматический enrichment: по домену компании дополнять данные
+Раздел "Сессия 1-5" предыдущей версии roadmap'а (verify, parser, мультиканальные секвенции, backend+frontend wiring, полировка) — полностью реализовано к маю 2026. Детали — в архитектурных хрониках `chronicles.md` (user-local).


### PR DESCRIPTION
## Summary
ROADMAP.md was last updated 2026-04-02 — describes modules as "скелет, не подключены" when they've been wired and shipping for over a month. This refresh mirrors the current chronicles.

## What changed
- **Backend table** — replaced 10 stale rows with 16 actual bounded contexts (added: verify, parser, tgclient, audit, ratelimit, httputil, chat surface as real, settings as multi-tenant).
- **Frontend table** — replaced "(мок)" labels with actual state (real API per page), added `/inbox/pending` operator queue.
- **HITL кластер** section added — documents the closed surface (inbound + bulk decide + channel routing + email auto-draft + empty-bookingLink guard).
- **Сессия 1-5** plan removed — all of it shipped by mid-May (verify, parser, multi-channel sequences, backend+frontend wiring, polish).
- **На горизонте** replaced "Будущее (v2)" — surviving items + new surface that didn't exist when v1 was written (outbound HITL, analytics dashboard, multi-workspace, webhooks, auto-enrichment, security follow-ups, observability).
- **Принципы** section codifies TDD+DDD+CA gates already documented in CLAUDE.md.

## Why now
First-time contributor (or returning contributor after a long break) reads ROADMAP first. Pointing them at "Сессия 1: verify email/TG (TODO)" when verify has been shipping for weeks wastes their time and erodes trust in the doc.

## Test plan
- [x] Doc-only change — no code, no behaviour.
- [x] Manual visual review — table formatting, links, line breaks.