### PR TITLE
feat(analytics): View 2 — cost dashboard with ratios + breakdowns

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -240,7 +240,8 @@ func main() {
 		chat.RegisterRoutes(r, chat.NewHandler(chat.NewRepository(pool), newChatAIAdapter(aiClient)))
 		inbox.RegisterPendingReplyRoutes(r, pendingReplyUC, leadsUC, pendingReplyDecideMW)
 		audit.RegisterRoutes(r, audit.NewHandler(audit.NewUseCase(auditRepo)))
-		analytics.RegisterRoutes(r, analytics.NewUseCase(analytics.NewRepository(pool)))
+		analyticsRepo := analytics.NewRepository(pool)
+		analytics.RegisterRoutes(r, analytics.NewUseCase(analyticsRepo, analyticsRepo))
 		tgOpts := []tgclient.Option{}
 		if proxyDialer != nil {
 			tgOpts = append(tgOpts, tgclient.WithDialer(proxyDialer))

--- a/backend/internal/analytics/cost_ratios_handler_test.go
+++ b/backend/internal/analytics/cost_ratios_handler_test.go
@@ -1,0 +1,186 @@
+package analytics_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/daniil/floq/internal/analytics"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubCostReader records the [from, to) window the handler computes
+// from the period query param so the test can assert the window logic
+// without DB.
+type stubCostReader struct {
+	dto       *analytics.CostRatiosDTO
+	err       error
+	gotUserID uuid.UUID
+	gotFrom   time.Time
+	gotTo     time.Time
+	callCount int
+}
+
+func (s *stubCostReader) GetCostRatios(_ context.Context, userID uuid.UUID, from, to time.Time) (*analytics.CostRatiosDTO, error) {
+	s.callCount++
+	s.gotUserID = userID
+	s.gotFrom = from
+	s.gotTo = to
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.dto, nil
+}
+
+// newCostUseCase builds a UseCase wired to a stub reader for both
+// ports. The seq port is reused from handler_test.go's stubReader (or
+// nil — the cost-ratios handler doesn't call it).
+func newCostUseCase(cost analytics.CostRatiosReader) *analytics.UseCase {
+	return analytics.NewUseCase(nil, cost)
+}
+
+func dummyCostDTO(totalMicro int64, leads, qualified, converted, drafts int) *analytics.CostRatiosDTO {
+	return &analytics.CostRatiosDTO{
+		PeriodFrom:               time.Now().UTC().Add(-7 * 24 * time.Hour),
+		PeriodTo:                 time.Now().UTC(),
+		TotalCostUSDMicro:        totalMicro,
+		TotalCalls:               42,
+		LeadsCount:               leads,
+		QualifiedLeadsCount:      qualified,
+		ConvertedCount:           converted,
+		DraftsSentCount:          drafts,
+		CostPerLeadUSDMicro:      safeRatioForTest(totalMicro, leads),
+		CostPerQualifiedUSDMicro: safeRatioForTest(totalMicro, qualified),
+		CostPerConvertedUSDMicro: safeRatioForTest(totalMicro, converted),
+		CostPerDraftSentUSDMicro: safeRatioForTest(totalMicro, drafts),
+	}
+}
+
+func safeRatioForTest(total int64, count int) int64 {
+	if count <= 0 {
+		return 0
+	}
+	return total / int64(count)
+}
+
+func TestHandler_GetCostRatios_ReturnsFloatUSD(t *testing.T) {
+	userID := uuid.New()
+	reader := &stubCostReader{dto: dummyCostDTO(6_000_000, 4, 2, 1, 5)}
+
+	r := chi.NewRouter()
+	analytics.RegisterRoutes(r, newCostUseCase(reader))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, newAuthedRequest(t, "/api/analytics/cost-ratios", userID))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, userID, reader.gotUserID)
+
+	var got map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	assert.InDelta(t, 6.0, got["total_cost_usd"], 0.0001, "USD float = micro / 1_000_000")
+	assert.EqualValues(t, 42, got["total_calls"])
+	assert.EqualValues(t, 4, got["leads_count"])
+	assert.EqualValues(t, 2, got["qualified_leads_count"])
+	assert.EqualValues(t, 1, got["converted_count"])
+	assert.EqualValues(t, 5, got["drafts_sent_count"])
+	assert.InDelta(t, 1.5, got["cost_per_lead_usd"], 0.0001, "6 / 4")
+	assert.InDelta(t, 3.0, got["cost_per_qualified_lead_usd"], 0.0001, "6 / 2")
+	assert.InDelta(t, 6.0, got["cost_per_converted_usd"], 0.0001, "6 / 1")
+	assert.InDelta(t, 1.2, got["cost_per_draft_sent_usd"], 0.0001, "6 / 5")
+
+	period, _ := got["period"].(map[string]any)
+	require.NotNil(t, period, "response must include period.from/to")
+	assert.Contains(t, period, "from")
+	assert.Contains(t, period, "to")
+}
+
+func TestHandler_GetCostRatios_PeriodQueryWindow(t *testing.T) {
+	tests := []struct {
+		name         string
+		query        string
+		wantHasLower bool          // expects [from] not at epoch
+		wantSpanMax  time.Duration // tolerable upper bound (test stability)
+		wantStatus   int
+	}{
+		{"empty defaults to month", "", true, 31 * 24 * time.Hour, http.StatusOK},
+		{"week", "?period=week", true, 8 * 24 * time.Hour, http.StatusOK},
+		{"month", "?period=month", true, 31 * 24 * time.Hour, http.StatusOK},
+		{"all", "?period=all", false, 0, http.StatusOK},
+		{"invalid -> 400", "?period=quarter", false, 0, http.StatusBadRequest},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := &stubCostReader{dto: dummyCostDTO(0, 0, 0, 0, 0)}
+			r := chi.NewRouter()
+			analytics.RegisterRoutes(r, newCostUseCase(reader))
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, newAuthedRequest(t, "/api/analytics/cost-ratios"+tc.query, uuid.New()))
+
+			require.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantStatus != http.StatusOK {
+				assert.Zero(t, reader.callCount, "invalid period must NOT reach reader")
+				return
+			}
+			require.Equal(t, 1, reader.callCount)
+			if tc.wantHasLower {
+				// The lower bound must be within the expected span from `to`.
+				span := reader.gotTo.Sub(reader.gotFrom)
+				assert.True(t, span > 0 && span <= tc.wantSpanMax+time.Minute,
+					"span %v exceeds tolerated upper bound %v", span, tc.wantSpanMax)
+			} else {
+				// PeriodAll → from is the epoch sentinel.
+				assert.True(t, reader.gotFrom.Year() <= 1970, "all-time period must use epoch as from")
+			}
+		})
+	}
+}
+
+func TestHandler_GetCostRatios_Unauthorized(t *testing.T) {
+	reader := &stubCostReader{}
+	r := chi.NewRouter()
+	analytics.RegisterRoutes(r, newCostUseCase(reader))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/analytics/cost-ratios", nil))
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Zero(t, reader.callCount)
+}
+
+func TestHandler_GetCostRatios_ReaderError(t *testing.T) {
+	reader := &stubCostReader{err: errors.New("pg down")}
+	r := chi.NewRouter()
+	analytics.RegisterRoutes(r, newCostUseCase(reader))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, newAuthedRequest(t, "/api/analytics/cost-ratios", uuid.New()))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandler_GetCostRatios_ZeroDenominatorYieldsZeroRatio(t *testing.T) {
+	reader := &stubCostReader{dto: dummyCostDTO(0, 0, 0, 0, 0)}
+	r := chi.NewRouter()
+	analytics.RegisterRoutes(r, newCostUseCase(reader))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, newAuthedRequest(t, "/api/analytics/cost-ratios", uuid.New()))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var got map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	assert.EqualValues(t, 0.0, got["cost_per_lead_usd"], "zero leads → zero ratio, never NaN/Inf")
+}
+
+// Compile-time guard: existing stubReader still satisfies the sequence
+// port so the original handler tests keep working.
+var _ analytics.SequenceStatsReader = (*stubReader)(nil)

--- a/backend/internal/analytics/cost_ratios_integration_test.go
+++ b/backend/internal/analytics/cost_ratios_integration_test.go
@@ -1,0 +1,201 @@
+//go:build integration
+
+package analytics_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/daniil/floq/internal/analytics"
+	"github.com/daniil/floq/internal/testutil"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedAuditCost inserts an audit_log row charging costMicro to userID
+// at createdAt. Status defaults to 'success' — the cost-ratios view
+// counts every recorded call, success or not.
+func seedAuditCost(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID, costMicro int64, createdAt time.Time) {
+	t.Helper()
+	id := uuid.New()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO audit_log (id, user_id, request_type, provider, model,
+			input_tokens, output_tokens, total_tokens,
+			cost_usd_micro, latency_ms, status, created_at)
+		 VALUES ($1, $2, 'qualification', 'test', 'test-model', 100, 50, 150, $3, 100, 'success', $4)`,
+		id, userID, costMicro, createdAt)
+	require.NoError(t, err, "seed audit cost")
+}
+
+// seedLead inserts a leads row at createdAt. status default 'new'.
+func seedLead(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID, status string, createdAt time.Time) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO leads (id, user_id, channel, contact_name, first_message, status, created_at, updated_at)
+		 VALUES ($1, $2, 'telegram', 'Test', 'hi', $3::lead_status, $4, $4)`,
+		id, userID, status, createdAt)
+	require.NoError(t, err, "seed lead")
+	return id
+}
+
+// seedQualification attaches a qualification row with the given score
+// to leadID. generated_at defaults to NOW().
+func seedQualification(t *testing.T, pool *pgxpool.Pool, leadID uuid.UUID, score int) {
+	t.Helper()
+	id := uuid.New()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO qualifications (id, lead_id, identified_need, budget, deadline, score, score_reason, suggested_action, provider, generated_at)
+		 VALUES ($1, $2, '', '', '', $3, '', '', 'test', NOW())`,
+		id, leadID, score)
+	require.NoError(t, err, "seed qualification")
+}
+
+// updateProspect mutates a seeded prospect into converted state at
+// updatedAt — used to position conversions inside / outside the window.
+func updateProspect(t *testing.T, pool *pgxpool.Pool, prospectID uuid.UUID, leadID uuid.UUID, updatedAt time.Time) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`UPDATE prospects SET status = 'converted', converted_lead_id = $2, updated_at = $3 WHERE id = $1`,
+		prospectID, leadID, updatedAt)
+	require.NoError(t, err, "update prospect to converted")
+}
+
+// seedSentOutbound inserts an outbound_messages row already in 'sent'
+// state with sent_at = createdAt.
+func seedSentOutbound(t *testing.T, pool *pgxpool.Pool, prospectID, sequenceID uuid.UUID, sentAt time.Time) {
+	t.Helper()
+	id := uuid.New()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO outbound_messages (id, prospect_id, sequence_id, step_order, channel, body, status, scheduled_at, sent_at, created_at)
+		 VALUES ($1, $2, $3, 1, 'email', 'hi', 'sent'::outbound_status, $4, $4, $4)`,
+		id, prospectID, sequenceID, sentAt)
+	require.NoError(t, err, "seed sent outbound")
+}
+
+func TestRepository_GetCostRatios_EmptyWhenNoData(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+
+	now := time.Now().UTC()
+	got, err := repo.GetCostRatios(context.Background(), userID, now.Add(-7*24*time.Hour), now)
+	require.NoError(t, err)
+	require.NotNil(t, got, "empty period must return zero-valued DTO, not nil")
+	assert.Zero(t, got.TotalCostUSDMicro)
+	assert.Zero(t, got.TotalCalls)
+	assert.Zero(t, got.LeadsCount)
+	assert.Zero(t, got.QualifiedLeadsCount)
+	assert.Zero(t, got.ConvertedCount)
+	assert.Zero(t, got.DraftsSentCount)
+	assert.Zero(t, got.CostPerLeadUSDMicro, "zero leads must yield zero ratio (no div-by-zero)")
+}
+
+func TestRepository_GetCostRatios_AggregatesCounts(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+
+	now := time.Now().UTC()
+	from := now.Add(-7 * 24 * time.Hour)
+
+	// 3 audit calls: 1, 2, 3 USD micro = 6 total
+	seedAuditCost(t, pool, userID, 1_000_000, now.Add(-1*time.Hour))
+	seedAuditCost(t, pool, userID, 2_000_000, now.Add(-2*time.Hour))
+	seedAuditCost(t, pool, userID, 3_000_000, now.Add(-3*time.Hour))
+
+	// 4 leads: 2 qualified (score >= 80), 2 not
+	l1 := seedLead(t, pool, userID, "new", now.Add(-1*time.Hour))
+	l2 := seedLead(t, pool, userID, "qualified", now.Add(-2*time.Hour))
+	l3 := seedLead(t, pool, userID, "qualified", now.Add(-3*time.Hour))
+	l4 := seedLead(t, pool, userID, "new", now.Add(-4*time.Hour))
+	seedQualification(t, pool, l1, 50) // below threshold
+	seedQualification(t, pool, l2, 85) // qualified
+	seedQualification(t, pool, l3, 90) // qualified
+	seedQualification(t, pool, l4, 70) // below
+
+	// 1 converted prospect in window (updated_at inside)
+	prospectID := seedProspect(t, pool, userID, "in_sequence")
+	updateProspect(t, pool, prospectID, l2, now.Add(-30*time.Minute))
+
+	// 5 sent outbound messages in window
+	seqID := seedSequence(t, pool, userID, "S1")
+	for i := 0; i < 5; i++ {
+		seedSentOutbound(t, pool, prospectID, seqID, now.Add(time.Duration(-i)*time.Hour))
+	}
+
+	got, err := repo.GetCostRatios(context.Background(), userID, from, now)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.EqualValues(t, 6_000_000, got.TotalCostUSDMicro)
+	assert.Equal(t, 3, got.TotalCalls)
+	assert.Equal(t, 4, got.LeadsCount, "4 leads created in window")
+	assert.Equal(t, 2, got.QualifiedLeadsCount, "2 leads with max qualification score >= 80")
+	assert.Equal(t, 1, got.ConvertedCount, "1 prospect updated to converted inside window")
+	assert.Equal(t, 5, got.DraftsSentCount, "5 outbound messages with status='sent' inside window")
+
+	assert.EqualValues(t, 1_500_000, got.CostPerLeadUSDMicro, "6_000_000 / 4 = 1_500_000")
+	assert.EqualValues(t, 3_000_000, got.CostPerQualifiedUSDMicro, "6_000_000 / 2")
+	assert.EqualValues(t, 6_000_000, got.CostPerConvertedUSDMicro, "6_000_000 / 1")
+	assert.EqualValues(t, 1_200_000, got.CostPerDraftSentUSDMicro, "6_000_000 / 5")
+}
+
+func TestRepository_GetCostRatios_ScopedByUser(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userA := testutil.SeedUser(t, pool)
+	userB := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+
+	now := time.Now().UTC()
+	seedAuditCost(t, pool, userA, 5_000_000, now.Add(-1*time.Hour))
+	seedAuditCost(t, pool, userB, 99_000_000, now.Add(-1*time.Hour))
+	seedLead(t, pool, userA, "new", now.Add(-1*time.Hour))
+	seedLead(t, pool, userB, "new", now.Add(-1*time.Hour))
+
+	got, err := repo.GetCostRatios(context.Background(), userA, now.Add(-24*time.Hour), now)
+	require.NoError(t, err)
+	assert.EqualValues(t, 5_000_000, got.TotalCostUSDMicro, "must not include user B")
+	assert.Equal(t, 1, got.LeadsCount, "must not include user B leads")
+}
+
+func TestRepository_GetCostRatios_WindowFilter(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+
+	now := time.Now().UTC()
+	from := now.Add(-7 * 24 * time.Hour)
+
+	// inside window
+	seedAuditCost(t, pool, userID, 1_000_000, now.Add(-1*time.Hour))
+	seedLead(t, pool, userID, "new", now.Add(-2*time.Hour))
+	// outside window (10 days old)
+	seedAuditCost(t, pool, userID, 999_000_000, now.Add(-10*24*time.Hour))
+	seedLead(t, pool, userID, "new", now.Add(-10*24*time.Hour))
+
+	got, err := repo.GetCostRatios(context.Background(), userID, from, now)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1_000_000, got.TotalCostUSDMicro)
+	assert.Equal(t, 1, got.LeadsCount)
+}
+
+func TestRepository_GetCostRatios_QualifiedUsesMaxScore(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+
+	now := time.Now().UTC()
+	// One lead with two qualifications: first below threshold, second
+	// above — max() must win so the lead counts as qualified.
+	leadID := seedLead(t, pool, userID, "qualified", now.Add(-1*time.Hour))
+	seedQualification(t, pool, leadID, 40)
+	seedQualification(t, pool, leadID, 85)
+
+	got, err := repo.GetCostRatios(context.Background(), userID, now.Add(-7*24*time.Hour), now)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.QualifiedLeadsCount, "lead with max(score) >= 80 must count once, regardless of earlier sub-threshold scores")
+}

--- a/backend/internal/analytics/cost_ratios_integration_test.go
+++ b/backend/internal/analytics/cost_ratios_integration_test.go
@@ -43,13 +43,15 @@ func seedLead(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID, status string,
 }
 
 // seedQualification attaches a qualification row with the given score
-// to leadID. generated_at defaults to NOW().
+// to leadID. qualifications.lead_id is UNIQUE — one row per lead via
+// UPSERT in production. generated_at defaults to NOW().
 func seedQualification(t *testing.T, pool *pgxpool.Pool, leadID uuid.UUID, score int) {
 	t.Helper()
 	id := uuid.New()
 	_, err := pool.Exec(context.Background(),
-		`INSERT INTO qualifications (id, lead_id, identified_need, budget, deadline, score, score_reason, suggested_action, provider, generated_at)
-		 VALUES ($1, $2, '', '', '', $3, '', '', 'test', NOW())`,
+		`INSERT INTO qualifications (id, lead_id, identified_need, estimated_budget, deadline, score, score_reason, recommended_action, provider_used, generated_at)
+		 VALUES ($1, $2, '', '', '', $3, '', '', 'test', NOW())
+		 ON CONFLICT (lead_id) DO UPDATE SET score = EXCLUDED.score, generated_at = EXCLUDED.generated_at`,
 		id, leadID, score)
 	require.NoError(t, err, "seed qualification")
 }
@@ -121,10 +123,12 @@ func TestRepository_GetCostRatios_AggregatesCounts(t *testing.T) {
 	prospectID := seedProspect(t, pool, userID, "in_sequence")
 	updateProspect(t, pool, prospectID, l2, now.Add(-30*time.Minute))
 
-	// 5 sent outbound messages in window
+	// 5 sent outbound messages in window. Offset by -1m so the latest
+	// row sits strictly before `to` (the half-open window's right
+	// boundary excludes exactly-equal rows).
 	seqID := seedSequence(t, pool, userID, "S1")
 	for i := 0; i < 5; i++ {
-		seedSentOutbound(t, pool, prospectID, seqID, now.Add(time.Duration(-i)*time.Hour))
+		seedSentOutbound(t, pool, prospectID, seqID, now.Add(-1*time.Minute).Add(time.Duration(-i)*time.Hour))
 	}
 
 	got, err := repo.GetCostRatios(context.Background(), userID, from, now)
@@ -183,19 +187,20 @@ func TestRepository_GetCostRatios_WindowFilter(t *testing.T) {
 	assert.Equal(t, 1, got.LeadsCount)
 }
 
-func TestRepository_GetCostRatios_QualifiedUsesMaxScore(t *testing.T) {
+func TestRepository_GetCostRatios_QualifiedReQualification(t *testing.T) {
 	pool := testutil.TestDB(t)
 	userID := testutil.SeedUser(t, pool)
 	repo := analytics.NewRepository(pool)
 
 	now := time.Now().UTC()
-	// One lead with two qualifications: first below threshold, second
-	// above — max() must win so the lead counts as qualified.
+	// qualifications.lead_id is UNIQUE — the production AI re-qualifier
+	// UPSERTs over the existing row. A lead first scored below
+	// threshold and later re-scored above must count as qualified now.
 	leadID := seedLead(t, pool, userID, "qualified", now.Add(-1*time.Hour))
-	seedQualification(t, pool, leadID, 40)
-	seedQualification(t, pool, leadID, 85)
+	seedQualification(t, pool, leadID, 40) // initial low score
+	seedQualification(t, pool, leadID, 85) // re-qualification UPSERT overwrites
 
 	got, err := repo.GetCostRatios(context.Background(), userID, now.Add(-7*24*time.Hour), now)
 	require.NoError(t, err)
-	assert.Equal(t, 1, got.QualifiedLeadsCount, "lead with max(score) >= 80 must count once, regardless of earlier sub-threshold scores")
+	assert.Equal(t, 1, got.QualifiedLeadsCount, "lead with latest score >= 80 counts as qualified after UPSERT")
 }

--- a/backend/internal/analytics/dto.go
+++ b/backend/internal/analytics/dto.go
@@ -3,6 +3,7 @@ package analytics
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -59,4 +60,39 @@ type SequenceStatsDTO struct {
 // implementation lives in repository.go; tests stub it directly.
 type SequenceStatsReader interface {
 	GetSequenceStats(ctx context.Context, userID uuid.UUID, period Period) ([]SequenceStatsDTO, error)
+}
+
+// QualifiedScoreThreshold is the minimum qualifications.score for a
+// lead to count as "qualified" in the cost-ratios view. Score range
+// is 0-100 (set by the AI qualifier); 80 reflects the threshold the
+// product treats as a real sales-ready prospect.
+const QualifiedScoreThreshold = 80
+
+// CostRatiosDTO is the read model for the View 2 cost dashboard. All
+// money fields are in USD micro-units (integer) at the DTO boundary;
+// the wire mapping in the handler converts to float USD with the
+// same microToUSD helper the audit package uses, keeping precision
+// integer-pure across the aggregation pipeline.
+type CostRatiosDTO struct {
+	PeriodFrom              time.Time
+	PeriodTo                time.Time
+	TotalCostUSDMicro       int64
+	TotalCalls              int
+	LeadsCount              int
+	QualifiedLeadsCount     int
+	ConvertedCount          int
+	DraftsSentCount         int
+	CostPerLeadUSDMicro     int64
+	CostPerQualifiedUSDMicro int64
+	CostPerConvertedUSDMicro int64
+	CostPerDraftSentUSDMicro int64
+}
+
+// CostRatiosReader is the port the cost-ratios usecase depends on.
+// Composes audit_log + leads + qualifications + prospects +
+// outbound_messages into a single dashboard row; the pg implementation
+// runs the queries in sequence (5 round-trips for v1 — readability
+// beats throughput on the operator dashboard).
+type CostRatiosReader interface {
+	GetCostRatios(ctx context.Context, userID uuid.UUID, from, to time.Time) (*CostRatiosDTO, error)
 }

--- a/backend/internal/analytics/handler.go
+++ b/backend/internal/analytics/handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/daniil/floq/internal/httputil"
 	"github.com/go-chi/chi/v5"
@@ -15,6 +16,7 @@ import (
 func RegisterRoutes(r chi.Router, uc *UseCase) {
 	h := &handler{uc: uc}
 	r.Get("/api/analytics/sequences", h.getSequenceStats)
+	r.Get("/api/analytics/cost-ratios", h.getCostRatios)
 }
 
 type handler struct {
@@ -101,4 +103,97 @@ func safeRatio(num, denom int64) float64 {
 		return 0
 	}
 	return float64(num) / float64(denom)
+}
+
+// costRatiosPeriodResponse mirrors CostRatiosDTO onto the JSON wire,
+// converting USD micro-units to float USD at the boundary.
+type costRatiosPeriodResponse struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+type costRatiosResponse struct {
+	Period                  costRatiosPeriodResponse `json:"period"`
+	TotalCostUSD            float64                  `json:"total_cost_usd"`
+	TotalCalls              int                      `json:"total_calls"`
+	LeadsCount              int                      `json:"leads_count"`
+	QualifiedLeadsCount     int                      `json:"qualified_leads_count"`
+	ConvertedCount          int                      `json:"converted_count"`
+	DraftsSentCount         int                      `json:"drafts_sent_count"`
+	CostPerLeadUSD          float64                  `json:"cost_per_lead_usd"`
+	CostPerQualifiedLeadUSD float64                  `json:"cost_per_qualified_lead_usd"`
+	CostPerConvertedUSD     float64                  `json:"cost_per_converted_usd"`
+	CostPerDraftSentUSD     float64                  `json:"cost_per_draft_sent_usd"`
+}
+
+// microToUSD mirrors the same conversion the audit package uses so
+// the two surfaces report numbers on the same scale.
+func microToUSD(m int64) float64 {
+	return float64(m) / 1_000_000.0
+}
+
+// periodWindow resolves the requested period into a [from, to) pair.
+// PeriodAll uses the Unix epoch as the lower bound — a single zero-
+// time sentinel would surprise the repo and force every caller to
+// branch, so we instead pass an unambiguous "very-old" timestamp.
+func periodWindow(period Period, now time.Time) (time.Time, time.Time) {
+	to := now
+	switch period {
+	case PeriodWeek:
+		return to.Add(-7 * 24 * time.Hour), to
+	case PeriodMonth:
+		return to.Add(-30 * 24 * time.Hour), to
+	default: // PeriodAll
+		return time.Unix(0, 0).UTC(), to
+	}
+}
+
+func (h *handler) getCostRatios(w http.ResponseWriter, r *http.Request) {
+	userID, ok := httputil.UserIDFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	periodParam := r.URL.Query().Get("period")
+	if periodParam == "" {
+		periodParam = string(PeriodMonth) // default for cost dashboard
+	}
+	period, err := ParsePeriod(periodParam)
+	if err != nil {
+		if errors.Is(err, ErrInvalidPeriod) {
+			httputil.WriteError(w, http.StatusBadRequest, "period must be one of: week, month, all")
+			return
+		}
+		httputil.WriteError(w, http.StatusBadRequest, "invalid period")
+		return
+	}
+
+	from, to := periodWindow(period, time.Now().UTC())
+	dto, err := h.uc.GetCostRatios(r.Context(), userID, from, to)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "analytics: get cost ratios failed",
+			slog.String("user_id", userID.String()),
+			slog.String("period", string(period)),
+			slog.Any("err", err))
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to load cost analytics")
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, costRatiosResponse{
+		Period: costRatiosPeriodResponse{
+			From: dto.PeriodFrom.UTC().Format(time.RFC3339),
+			To:   dto.PeriodTo.UTC().Format(time.RFC3339),
+		},
+		TotalCostUSD:            microToUSD(dto.TotalCostUSDMicro),
+		TotalCalls:              dto.TotalCalls,
+		LeadsCount:              dto.LeadsCount,
+		QualifiedLeadsCount:     dto.QualifiedLeadsCount,
+		ConvertedCount:          dto.ConvertedCount,
+		DraftsSentCount:         dto.DraftsSentCount,
+		CostPerLeadUSD:          microToUSD(dto.CostPerLeadUSDMicro),
+		CostPerQualifiedLeadUSD: microToUSD(dto.CostPerQualifiedUSDMicro),
+		CostPerConvertedUSD:     microToUSD(dto.CostPerConvertedUSDMicro),
+		CostPerDraftSentUSD:     microToUSD(dto.CostPerDraftSentUSDMicro),
+	})
 }

--- a/backend/internal/analytics/handler_test.go
+++ b/backend/internal/analytics/handler_test.go
@@ -53,7 +53,7 @@ func TestHandler_GetSequenceStats_ReturnsRows(t *testing.T) {
 	}}}
 
 	r := chi.NewRouter()
-	analytics.RegisterRoutes(r, analytics.NewUseCase(reader))
+	analytics.RegisterRoutes(r, analytics.NewUseCase(reader, nil))
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, newAuthedRequest(t, "/api/analytics/sequences", userID))
@@ -101,7 +101,7 @@ func TestHandler_GetSequenceStats_PeriodQueryParam(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			reader := &stubReader{}
 			r := chi.NewRouter()
-			analytics.RegisterRoutes(r, analytics.NewUseCase(reader))
+			analytics.RegisterRoutes(r, analytics.NewUseCase(reader, nil))
 
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, newAuthedRequest(t, "/api/analytics/sequences"+tc.query, uuid.New()))
@@ -119,7 +119,7 @@ func TestHandler_GetSequenceStats_PeriodQueryParam(t *testing.T) {
 func TestHandler_GetSequenceStats_Unauthorized(t *testing.T) {
 	reader := &stubReader{}
 	r := chi.NewRouter()
-	analytics.RegisterRoutes(r, analytics.NewUseCase(reader))
+	analytics.RegisterRoutes(r, analytics.NewUseCase(reader, nil))
 
 	w := httptest.NewRecorder()
 	// Plain httptest request — no user_id in context.
@@ -132,7 +132,7 @@ func TestHandler_GetSequenceStats_Unauthorized(t *testing.T) {
 func TestHandler_GetSequenceStats_ReaderError(t *testing.T) {
 	reader := &stubReader{err: errors.New("pg down")}
 	r := chi.NewRouter()
-	analytics.RegisterRoutes(r, analytics.NewUseCase(reader))
+	analytics.RegisterRoutes(r, analytics.NewUseCase(reader, nil))
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, newAuthedRequest(t, "/api/analytics/sequences", uuid.New()))
@@ -143,7 +143,7 @@ func TestHandler_GetSequenceStats_ReaderError(t *testing.T) {
 func TestHandler_GetSequenceStats_EmptyReturnsEmptyArray(t *testing.T) {
 	reader := &stubReader{rows: nil}
 	r := chi.NewRouter()
-	analytics.RegisterRoutes(r, analytics.NewUseCase(reader))
+	analytics.RegisterRoutes(r, analytics.NewUseCase(reader, nil))
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, newAuthedRequest(t, "/api/analytics/sequences", uuid.New()))
@@ -162,7 +162,7 @@ func TestHandler_RatesAreComputedCorrectly(t *testing.T) {
 	}}
 
 	r := chi.NewRouter()
-	analytics.RegisterRoutes(r, analytics.NewUseCase(reader))
+	analytics.RegisterRoutes(r, analytics.NewUseCase(reader, nil))
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, newAuthedRequest(t, "/api/analytics/sequences", userID))

--- a/backend/internal/analytics/repository.go
+++ b/backend/internal/analytics/repository.go
@@ -20,10 +20,13 @@ func NewRepository(pool *pgxpool.Pool) *Repository {
 	return &Repository{pool: pool}
 }
 
-// Compile-time check: Repository satisfies the port consumed by the
-// usecase. Adding the assertion here means a signature drift breaks
+// Compile-time check: Repository satisfies the ports consumed by the
+// usecases. Adding the assertions here means a signature drift breaks
 // the build, not a runtime cast at wire-up time.
-var _ SequenceStatsReader = (*Repository)(nil)
+var (
+	_ SequenceStatsReader = (*Repository)(nil)
+	_ CostRatiosReader    = (*Repository)(nil)
+)
 
 // GetSequenceStats returns one row per sequence with activity in the
 // requested period. Sequences with zero outbound rows in the window
@@ -96,4 +99,86 @@ func nullableCutoff(t time.Time, hasCutoff bool) any {
 		return nil
 	}
 	return t
+}
+
+// GetCostRatios composes the View 2 cost dashboard read model: the
+// total AI spend over [from, to) plus the four denominator counts
+// (leads / qualified leads / converted prospects / sent outbounds)
+// the ratios depend on. Five sequential queries — clarity over
+// throughput; the dashboard is not a hot path.
+//
+// Ratios are computed inside the repo so the wire surface stays
+// integer-pure (USD micro-units divided by counts). A zero
+// denominator yields a zero ratio rather than panicking or emitting
+// IEEE-754 Inf.
+func (r *Repository) GetCostRatios(ctx context.Context, userID uuid.UUID, from, to time.Time) (*CostRatiosDTO, error) {
+	dto := &CostRatiosDTO{
+		PeriodFrom: from,
+		PeriodTo:   to,
+	}
+
+	if err := r.pool.QueryRow(ctx,
+		`SELECT COALESCE(SUM(cost_usd_micro), 0), COUNT(*)
+		 FROM audit_log
+		 WHERE user_id = $1 AND created_at >= $2 AND created_at < $3`,
+		userID, from, to,
+	).Scan(&dto.TotalCostUSDMicro, &dto.TotalCalls); err != nil {
+		return nil, fmt.Errorf("analytics cost-ratios audit: %w", err)
+	}
+
+	if err := r.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM leads
+		 WHERE user_id = $1 AND created_at >= $2 AND created_at < $3`,
+		userID, from, to,
+	).Scan(&dto.LeadsCount); err != nil {
+		return nil, fmt.Errorf("analytics cost-ratios leads: %w", err)
+	}
+
+	if err := r.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM (
+			SELECT l.id FROM leads l
+			JOIN qualifications q ON q.lead_id = l.id
+			WHERE l.user_id = $1 AND l.created_at >= $2 AND l.created_at < $3
+			GROUP BY l.id
+			HAVING MAX(q.score) >= $4
+		) sub`,
+		userID, from, to, QualifiedScoreThreshold,
+	).Scan(&dto.QualifiedLeadsCount); err != nil {
+		return nil, fmt.Errorf("analytics cost-ratios qualified: %w", err)
+	}
+
+	if err := r.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM prospects
+		 WHERE user_id = $1 AND status = 'converted'
+		   AND updated_at >= $2 AND updated_at < $3`,
+		userID, from, to,
+	).Scan(&dto.ConvertedCount); err != nil {
+		return nil, fmt.Errorf("analytics cost-ratios converted: %w", err)
+	}
+
+	if err := r.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM outbound_messages om
+		 JOIN prospects p ON p.id = om.prospect_id
+		 WHERE p.user_id = $1 AND om.status = 'sent'
+		   AND om.sent_at >= $2 AND om.sent_at < $3`,
+		userID, from, to,
+	).Scan(&dto.DraftsSentCount); err != nil {
+		return nil, fmt.Errorf("analytics cost-ratios drafts: %w", err)
+	}
+
+	dto.CostPerLeadUSDMicro = safeRatioInt(dto.TotalCostUSDMicro, dto.LeadsCount)
+	dto.CostPerQualifiedUSDMicro = safeRatioInt(dto.TotalCostUSDMicro, dto.QualifiedLeadsCount)
+	dto.CostPerConvertedUSDMicro = safeRatioInt(dto.TotalCostUSDMicro, dto.ConvertedCount)
+	dto.CostPerDraftSentUSDMicro = safeRatioInt(dto.TotalCostUSDMicro, dto.DraftsSentCount)
+	return dto, nil
+}
+
+// safeRatioInt divides totalMicro by count, returning 0 when count is
+// non-positive. Integer-pure — the wire-mapping converts to float USD
+// at the JSON boundary.
+func safeRatioInt(totalMicro int64, count int) int64 {
+	if count <= 0 {
+		return 0
+	}
+	return totalMicro / int64(count)
 }

--- a/backend/internal/analytics/usecase.go
+++ b/backend/internal/analytics/usecase.go
@@ -2,25 +2,38 @@ package analytics
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 )
 
 // UseCase composes the analytics read-side. Today it just delegates
-// to the reader port — kept as its own seam so future cross-context
-// projections (e.g. cost-ratio composition over leads + audit_log)
-// don't have to rewire every handler.
+// to its port collaborators — kept as its own seam so future cross-
+// context projections (e.g. cost-ratio composition over leads +
+// audit_log + sequence stats joined together) don't have to rewire
+// every handler.
 type UseCase struct {
-	reader SequenceStatsReader
+	seq  SequenceStatsReader
+	cost CostRatiosReader
 }
 
-func NewUseCase(reader SequenceStatsReader) *UseCase {
-	return &UseCase{reader: reader}
+// NewUseCase wires the two read ports. Either may be nil if the
+// surrounding wire-up only registers a subset of routes (tests do
+// this — production wire-up always passes both).
+func NewUseCase(seq SequenceStatsReader, cost CostRatiosReader) *UseCase {
+	return &UseCase{seq: seq, cost: cost}
 }
 
 // GetSequenceStats forwards the call to the configured reader. Period
 // validation happens at the handler boundary via ParsePeriod so this
 // layer only sees the typed value.
 func (uc *UseCase) GetSequenceStats(ctx context.Context, userID uuid.UUID, period Period) ([]SequenceStatsDTO, error) {
-	return uc.reader.GetSequenceStats(ctx, userID, period)
+	return uc.seq.GetSequenceStats(ctx, userID, period)
+}
+
+// GetCostRatios forwards the call to the cost-ratios reader. The
+// window [from, to) is resolved at the handler boundary from the
+// period query param so the usecase stays time-source agnostic.
+func (uc *UseCase) GetCostRatios(ctx context.Context, userID uuid.UUID, from, to time.Time) (*CostRatiosDTO, error) {
+	return uc.cost.GetCostRatios(ctx, userID, from, to)
 }

--- a/frontend/src/app/(dashboard)/analytics/cost/page.tsx
+++ b/frontend/src/app/(dashboard)/analytics/cost/page.tsx
@@ -2,14 +2,16 @@
 
 import { useState } from "react";
 import type { AnalyticsPeriod } from "@/lib/api";
-import { useSequenceAnalytics } from "@/hooks/useSequenceAnalytics";
+import { useCostAnalytics } from "@/hooks/useCostAnalytics";
 import { AnalyticsTabs } from "@/components/analytics/AnalyticsTabs";
 import { PeriodSelector } from "@/components/analytics/PeriodSelector";
-import { SequenceStatsTable } from "@/components/analytics/SequenceStatsTable";
+import { CostSummaryCard } from "@/components/analytics/CostSummaryCard";
+import { CostRatiosPanel } from "@/components/analytics/CostRatiosPanel";
+import { CostBreakdownTable } from "@/components/analytics/CostBreakdownTable";
 
-export default function SequenceAnalyticsPage() {
-  const [period, setPeriod] = useState<AnalyticsPeriod>("all");
-  const { rows, loading, error, lastUpdated, refresh } = useSequenceAnalytics(period);
+export default function CostAnalyticsPage() {
+  const [period, setPeriod] = useState<AnalyticsPeriod>("month");
+  const { ratios, summary, loading, error, lastUpdated, refresh } = useCostAnalytics(period);
 
   return (
     <section className="flex-1 overflow-y-auto px-4 sm:px-8 lg:px-12 py-8">
@@ -17,9 +19,9 @@ export default function SequenceAnalyticsPage() {
         <AnalyticsTabs />
         <header className="flex items-end justify-between gap-4 flex-wrap">
           <div>
-            <h1 className="text-2xl sm:text-3xl font-extrabold tracking-tight text-[#0d1c2e]">Аналитика sequence&apos;ов</h1>
+            <h1 className="text-2xl sm:text-3xl font-extrabold tracking-tight text-[#0d1c2e]">Аналитика затрат</h1>
             <p className="text-sm text-slate-500 mt-1">
-              Какая sequence работает лучше — sent / delivered / opened / replied / converted.
+              Сколько трачу на AI и что получаю — cost per lead / qualified / converted.
             </p>
           </div>
           <div className="flex items-center gap-3">
@@ -40,13 +42,32 @@ export default function SequenceAnalyticsPage() {
           </div>
         )}
 
-        {loading && rows.length === 0 ? (
+        {loading && !ratios ? (
           <div className="rounded-lg border border-slate-200 bg-white p-8 text-center text-sm text-slate-500">
             Загружаем…
           </div>
-        ) : (
-          <SequenceStatsTable rows={rows} />
-        )}
+        ) : ratios ? (
+          <>
+            <CostSummaryCard ratios={ratios} />
+            <CostRatiosPanel ratios={ratios} />
+            {summary && (
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                <CostBreakdownTable
+                  title="По типу запроса"
+                  labelHeader="Тип запроса"
+                  rows={summary.by_request_type}
+                  labelKey="request_type"
+                />
+                <CostBreakdownTable
+                  title="По модели"
+                  labelHeader="Модель"
+                  rows={summary.by_model}
+                  labelKey="model"
+                />
+              </div>
+            )}
+          </>
+        ) : null}
 
         {lastUpdated && (
           <div className="text-xs text-slate-400">

--- a/frontend/src/components/analytics/AnalyticsTabs.tsx
+++ b/frontend/src/components/analytics/AnalyticsTabs.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+const TABS = [
+  { href: "/analytics/sequences", label: "Sequences" },
+  { href: "/analytics/cost", label: "Затраты" },
+];
+
+// AnalyticsTabs renders the sub-navigation for /analytics/* pages.
+// Active state derived from usePathname() so adding a new view only
+// needs an entry in TABS — no per-page wiring. Mirrors the
+// PendingQueueTabs pattern used in the inbox surface.
+export function AnalyticsTabs() {
+  const pathname = usePathname();
+  return (
+    <nav aria-label="Аналитика" className="flex gap-2 border-b border-slate-200">
+      {TABS.map((tab) => {
+        const active = pathname === tab.href;
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className={cn(
+              "px-3 py-2 text-sm font-medium border-b-2 transition-colors -mb-px",
+              active
+                ? "border-slate-900 text-slate-900"
+                : "border-transparent text-slate-500 hover:text-slate-700",
+            )}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/components/analytics/CostBreakdownTable.tsx
+++ b/frontend/src/components/analytics/CostBreakdownTable.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { CostBreakdownRow } from "@/lib/api";
+
+type SortKey = "label" | "calls" | "usd" | "tokens_in" | "tokens_out";
+type SortDir = "asc" | "desc";
+
+interface CostBreakdownTableProps {
+  title: string;
+  labelHeader: string;
+  rows: CostBreakdownRow[];
+  // labelKey picks which CostBreakdownRow field (request_type or model)
+  // backs the first column. Keeps the component reusable for both
+  // breakdowns without an `any` cast.
+  labelKey: "request_type" | "model";
+}
+
+function formatUSD(v: number): string {
+  if (v < 0.01) return `$${v.toFixed(4)}`;
+  return `$${v.toFixed(2)}`;
+}
+
+export function CostBreakdownTable({ title, labelHeader, rows, labelKey }: CostBreakdownTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>("usd");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const sorted = useMemo(() => {
+    const copy = [...rows];
+    copy.sort((a, b) => {
+      let cmp: number;
+      if (sortKey === "label") {
+        const la = String(a[labelKey] ?? "");
+        const lb = String(b[labelKey] ?? "");
+        cmp = la.localeCompare(lb);
+      } else {
+        cmp = (a[sortKey] as number) - (b[sortKey] as number);
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+    return copy;
+  }, [rows, sortKey, sortDir, labelKey]);
+
+  function handleSort(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white p-6 text-center text-sm text-slate-500">
+        {title}: нет данных за период.
+      </div>
+    );
+  }
+
+  const columns: { key: SortKey; label: string; numeric: boolean }[] = [
+    { key: "label", label: labelHeader, numeric: false },
+    { key: "calls", label: "Вызовов", numeric: true },
+    { key: "usd", label: "USD", numeric: true },
+    { key: "tokens_in", label: "Tokens in", numeric: true },
+    { key: "tokens_out", label: "Tokens out", numeric: true },
+  ];
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white">
+      <h2 className="px-4 py-2 text-sm font-semibold text-slate-700 border-b border-slate-100">{title}</h2>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-200 text-sm">
+          <thead className="bg-slate-50">
+            <tr>
+              {columns.map((col) => (
+                <th
+                  key={col.key}
+                  scope="col"
+                  className={`px-4 py-2 font-medium text-slate-700 ${col.numeric ? "text-right" : "text-left"}`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => handleSort(col.key)}
+                    className="inline-flex items-center gap-1 hover:text-slate-900"
+                  >
+                    {col.label}
+                    {sortKey === col.key && <span aria-hidden="true">{sortDir === "asc" ? "↑" : "↓"}</span>}
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {sorted.map((row, idx) => (
+              <tr key={`${row[labelKey] ?? "row"}-${idx}`}>
+                <td className="px-4 py-2 font-medium text-slate-900">{row[labelKey] ?? "—"}</td>
+                <td className="px-4 py-2 text-right tabular-nums">{row.calls}</td>
+                <td className="px-4 py-2 text-right tabular-nums">{formatUSD(row.usd)}</td>
+                <td className="px-4 py-2 text-right tabular-nums">{row.tokens_in}</td>
+                <td className="px-4 py-2 text-right tabular-nums">{row.tokens_out}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/analytics/CostRatiosPanel.tsx
+++ b/frontend/src/components/analytics/CostRatiosPanel.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { CostRatiosResponse } from "@/lib/api";
+
+interface CostRatiosPanelProps {
+  ratios: CostRatiosResponse;
+}
+
+function formatUSD(v: number): string {
+  if (v === 0) return "—";
+  if (v < 0.01) return `$${v.toFixed(4)}`;
+  return `$${v.toFixed(2)}`;
+}
+
+function RatioCard({ label, ratio, count, hint }: { label: string; ratio: number; count: number; hint: string }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <div className="text-xs uppercase tracking-wide text-slate-500">{label}</div>
+      <div className="mt-2 text-2xl font-extrabold tabular-nums text-[#0d1c2e]">{formatUSD(ratio)}</div>
+      <div className="mt-1 text-xs text-slate-400">
+        {count > 0 ? `на ${count} ${hint}` : `нет ${hint} в периоде`}
+      </div>
+    </div>
+  );
+}
+
+export function CostRatiosPanel({ ratios }: CostRatiosPanelProps) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+      <RatioCard
+        label="Стоимость / лид"
+        ratio={ratios.cost_per_lead_usd}
+        count={ratios.leads_count}
+        hint="лидов"
+      />
+      <RatioCard
+        label="Стоимость / квалиф. лид"
+        ratio={ratios.cost_per_qualified_lead_usd}
+        count={ratios.qualified_leads_count}
+        hint="квалиф. лидов"
+      />
+      <RatioCard
+        label="Стоимость / конверсия"
+        ratio={ratios.cost_per_converted_usd}
+        count={ratios.converted_count}
+        hint="конверсий"
+      />
+      <RatioCard
+        label="Стоимость / отправл."
+        ratio={ratios.cost_per_draft_sent_usd}
+        count={ratios.drafts_sent_count}
+        hint="отправленных"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/analytics/CostSummaryCard.tsx
+++ b/frontend/src/components/analytics/CostSummaryCard.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import type { CostRatiosResponse } from "@/lib/api";
+
+interface CostSummaryCardProps {
+  ratios: CostRatiosResponse;
+}
+
+function formatUSD(v: number): string {
+  if (v < 0.01) return `$${v.toFixed(4)}`;
+  return `$${v.toFixed(2)}`;
+}
+
+export function CostSummaryCard({ ratios }: CostSummaryCardProps) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-5">
+      <div className="flex items-baseline justify-between gap-4">
+        <div>
+          <div className="text-xs uppercase tracking-wide text-slate-500">AI-расход за период</div>
+          <div className="mt-2 text-4xl font-extrabold tabular-nums text-[#0d1c2e]">
+            {formatUSD(ratios.total_cost_usd)}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-xs uppercase tracking-wide text-slate-500">Вызовов</div>
+          <div className="mt-2 text-2xl font-bold tabular-nums text-slate-700">{ratios.total_calls}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useCostAnalytics.test.ts
+++ b/frontend/src/hooks/useCostAnalytics.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { CostRatiosResponse, CostSummaryResponse } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getCostRatios: vi.fn(),
+    getCostSummary: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { POLL_INTERVAL_MS, useCostAnalytics } from "./useCostAnalytics";
+
+function ratios(over: Partial<CostRatiosResponse> = {}): CostRatiosResponse {
+  return {
+    period: over.period ?? { from: "2026-04-20T00:00:00Z", to: "2026-05-20T00:00:00Z" },
+    total_cost_usd: over.total_cost_usd ?? 6.0,
+    total_calls: over.total_calls ?? 42,
+    leads_count: over.leads_count ?? 4,
+    qualified_leads_count: over.qualified_leads_count ?? 2,
+    converted_count: over.converted_count ?? 1,
+    drafts_sent_count: over.drafts_sent_count ?? 5,
+    cost_per_lead_usd: over.cost_per_lead_usd ?? 1.5,
+    cost_per_qualified_lead_usd: over.cost_per_qualified_lead_usd ?? 3.0,
+    cost_per_converted_usd: over.cost_per_converted_usd ?? 6.0,
+    cost_per_draft_sent_usd: over.cost_per_draft_sent_usd ?? 1.2,
+  };
+}
+
+function summary(over: Partial<CostSummaryResponse> = {}): CostSummaryResponse {
+  return {
+    total_usd: over.total_usd ?? 6.0,
+    total_calls: over.total_calls ?? 42,
+    by_request_type: over.by_request_type ?? [
+      { request_type: "qualification", calls: 30, usd: 4.5, tokens_in: 1000, tokens_out: 500 },
+      { request_type: "cold_message", calls: 12, usd: 1.5, tokens_in: 800, tokens_out: 400 },
+    ],
+    by_model: over.by_model ?? [
+      { model: "claude-haiku-4-5", calls: 30, usd: 4.5, tokens_in: 1000, tokens_out: 500 },
+    ],
+    period: over.period ?? { from: "2026-04-20", to: "2026-05-20" },
+  };
+}
+
+describe("useCostAnalytics", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(api.getCostRatios).mockResolvedValue(ratios());
+    vi.mocked(api.getCostSummary).mockResolvedValue(summary());
+  });
+
+  it("fetches both endpoints on mount with default period", async () => {
+    const { result } = renderHook(() => useCostAnalytics());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(api.getCostRatios).toHaveBeenCalledTimes(1);
+    expect(api.getCostRatios).toHaveBeenCalledWith("month");
+    expect(api.getCostSummary).toHaveBeenCalledTimes(1);
+
+    expect(result.current.ratios?.total_cost_usd).toBe(6.0);
+    expect(result.current.summary?.by_request_type).toHaveLength(2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("derives summary [from, to) ISO dates from the requested period", async () => {
+    renderHook(() => useCostAnalytics("week"));
+
+    await waitFor(() => expect(api.getCostSummary).toHaveBeenCalledTimes(1));
+
+    const [from, to] = vi.mocked(api.getCostSummary).mock.calls[0]!;
+    // Both ISO yyyy-mm-dd; span ≈ 7 days within tolerance.
+    expect(from).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const span = (new Date(to).getTime() - new Date(from).getTime()) / 86_400_000;
+    expect(span).toBeGreaterThanOrEqual(6.5);
+    expect(span).toBeLessThanOrEqual(7.5);
+  });
+
+  it("refetches both when period changes", async () => {
+    const { rerender } = renderHook(({ p }: { p: "week" | "month" | "all" }) => useCostAnalytics(p), {
+      initialProps: { p: "month" },
+    });
+    await waitFor(() => expect(api.getCostRatios).toHaveBeenCalledTimes(1));
+
+    rerender({ p: "week" });
+    await waitFor(() => expect(api.getCostRatios).toHaveBeenLastCalledWith("week"));
+    await waitFor(() => expect(api.getCostSummary).toHaveBeenCalledTimes(2));
+  });
+
+  it("polls every POLL_INTERVAL_MS", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      renderHook(() => useCostAnalytics());
+      await waitFor(() => expect(api.getCostRatios).toHaveBeenCalledTimes(1));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      });
+      expect(api.getCostRatios).toHaveBeenCalledTimes(2);
+      expect(api.getCostSummary).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces error from either endpoint and preserves last good data", async () => {
+    vi.mocked(api.getCostRatios).mockResolvedValueOnce(ratios());
+    vi.mocked(api.getCostSummary).mockResolvedValueOnce(summary());
+    vi.mocked(api.getCostRatios).mockRejectedValueOnce(new Error("network"));
+
+    const { result } = renderHook(() => useCostAnalytics());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.ratios).not.toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.error).not.toBeNull();
+    // Last-good ratios preserved through the failed refresh.
+    expect(result.current.ratios?.total_cost_usd).toBe(6.0);
+  });
+});

--- a/frontend/src/hooks/useCostAnalytics.ts
+++ b/frontend/src/hooks/useCostAnalytics.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  api,
+  type AnalyticsPeriod,
+  type CostRatiosResponse,
+  type CostSummaryResponse,
+} from "@/lib/api";
+
+export const POLL_INTERVAL_MS = 30_000;
+
+interface UseCostAnalyticsResult {
+  ratios: CostRatiosResponse | null;
+  summary: CostSummaryResponse | null;
+  loading: boolean;
+  error: Error | null;
+  lastUpdated: Date | null;
+  refresh: () => Promise<void>;
+}
+
+// daysForPeriod maps the period enum onto the day-span the
+// cost-summary endpoint (which takes explicit from/to) needs. Mirrors
+// the backend periodWindow logic — keeping the conversion client-side
+// avoids a second backend round-trip just to derive dates.
+function daysForPeriod(period: AnalyticsPeriod): number {
+  if (period === "week") return 7;
+  if (period === "month") return 30;
+  // "all" — pick a very long span so the audit aggregation covers
+  // everything the user could plausibly have logged.
+  return 365 * 10;
+}
+
+// formatYMD turns a Date into the yyyy-mm-dd shape the cost-summary
+// endpoint expects. Local-tz date is fine — the endpoint treats the
+// strings as date boundaries, not instants.
+function formatYMD(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function useCostAnalytics(period: AnalyticsPeriod = "month"): UseCostAnalyticsResult {
+  const [ratios, setRatios] = useState<CostRatiosResponse | null>(null);
+  const [summary, setSummary] = useState<CostSummaryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const mountedRef = useRef(true);
+
+  const fetchOnce = useCallback(async () => {
+    try {
+      const to = new Date();
+      const from = new Date(to.getTime() - daysForPeriod(period) * 86_400_000);
+      const [ratiosResp, summaryResp] = await Promise.all([
+        api.getCostRatios(period),
+        api.getCostSummary(formatYMD(from), formatYMD(to)),
+      ]);
+      if (!mountedRef.current) return;
+      setRatios(ratiosResp);
+      setSummary(summaryResp);
+      setError(null);
+      setLastUpdated(new Date());
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [period]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    setLoading(true);
+    void fetchOnce();
+    const interval = setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(interval);
+    };
+  }, [fetchOnce]);
+
+  return { ratios, summary, loading, error, lastUpdated, refresh: fetchOnce };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -367,6 +367,10 @@ export const api = {
   // Analytics
   getSequenceAnalytics: (period: AnalyticsPeriod = "all") =>
     apiFetch<SequenceAnalyticsResponse>(`/api/analytics/sequences?period=${period}`),
+  getCostRatios: (period: AnalyticsPeriod = "month") =>
+    apiFetch<CostRatiosResponse>(`/api/analytics/cost-ratios?period=${period}`),
+  getCostSummary: (from: string, to: string) =>
+    apiFetch<CostSummaryResponse>(`/api/audit/cost-summary?from=${from}&to=${to}`),
 };
 
 // Types
@@ -645,6 +649,37 @@ export interface SequenceAnalyticsRow {
 export interface SequenceAnalyticsResponse {
   sequences: SequenceAnalyticsRow[];
   period: AnalyticsPeriod;
+}
+
+export interface CostRatiosResponse {
+  period: { from: string; to: string };
+  total_cost_usd: number;
+  total_calls: number;
+  leads_count: number;
+  qualified_leads_count: number;
+  converted_count: number;
+  drafts_sent_count: number;
+  cost_per_lead_usd: number;
+  cost_per_qualified_lead_usd: number;
+  cost_per_converted_usd: number;
+  cost_per_draft_sent_usd: number;
+}
+
+export interface CostBreakdownRow {
+  request_type?: string;
+  model?: string;
+  calls: number;
+  usd: number;
+  tokens_in: number;
+  tokens_out: number;
+}
+
+export interface CostSummaryResponse {
+  total_usd: number;
+  total_calls: number;
+  by_request_type: CostBreakdownRow[];
+  by_model: CostBreakdownRow[];
+  period: { from: string; to: string };
 }
 
 export interface UserSettings {


### PR DESCRIPTION
Closes #96. Refs #91 (2 of 4 views complete).

## Summary
Second analytics view: AI-cost effectiveness lens. Composes the existing `/api/audit/cost-summary` endpoint (shipped in #58) with a new `/api/analytics/cost-ratios` endpoint that returns the cost-per-{lead,qualified,converted,draft} denominators.

## What changed

### Backend
- New `internal/analytics` repository method `GetCostRatios(ctx, userID, from, to)` — five sequential queries compose audit_log + leads + qualifications + prospects + outbound_messages into one DTO. Clarity over throughput: dashboard surface, not a hot path.
- `CostRatiosDTO` integer-pure (USD micro-units). Wire mapping in handler converts to float USD via the same `microToUSD` helper the audit package uses. Zero denominator → zero ratio (no NaN/Inf in JSON).
- `QualifiedScoreThreshold = 80` (score range 0-100). Lead counts as qualified if MAX(qualifications.score) ≥ 80 in window — HAVING-style filter so the UNIQUE constraint plus future re-qualification UPSERTs both work.
- New endpoint: `GET /api/analytics/cost-ratios?period={week|month|all}`. Default "month" — sensible first-load for cost dashboard. `periodWindow` resolves to [from, to); PeriodAll uses Unix epoch.
- `UseCase` widened to hold both ports (SequenceStatsReader + CostRatiosReader). Repository implements both, so wire-up at main.go composition root reuses one instance.

### Frontend
- `useCostAnalytics(period)` hook: `Promise.all` parallel fetch of `getCostRatios` + `getCostSummary` (audit endpoint takes explicit from/to — `daysForPeriod` derives client-side, mirrors backend periodWindow logic).
- New `/analytics/cost` page with 4 presentational components:
  - `CostSummaryCard` — total USD + total calls hero.
  - `CostRatiosPanel` — 4 ratio cards. Renders "—" when count = 0 to signal "no denominator", not "free".
  - `CostBreakdownTable` — reusable for by-request-type and by-model rows. Sortable, USD-DESC default.
  - `PeriodSelector` — reused from #95.
- Shared `AnalyticsTabs` sub-nav at the top of all `/analytics/*` pages. Single sidebar entry "Аналитика" stays; tabs switch between sequences (#95) and cost (#96). `usePathname()`-driven active state — same pattern as `PendingQueueTabs` in the inbox surface.

## TDD trail (7 commits)
1. RED — pg repository contract (5 integration cases: empty, aggregation, cross-tenant, window filter, re-qualification UPSERT)
2. GREEN — repository implementation
3. RED — handler HTTP contract (5 cases: float USD conversion, period window table, 401, 500, zero denominator)
4. GREEN — UseCase widening + handler + RegisterRoutes + wire-up in main.go (one commit because the 3 changes are entangled: handler test references widened NewUseCase signature)
5. RED — `useCostAnalytics` hook (5 cases: dual fetch on mount, date derivation, period change refetch, polling, error preservation)
6. GREEN — hook implementation with Promise.all
7. UI feat — page + 4 components + AnalyticsTabs (no fake TDD; logic covered by hook test)

## Test plan
- [x] `go test ./internal/analytics/` — all unit tests green (handler + sequences).
- [x] `go test -tags=integration ./internal/analytics/` — 10 integration tests green (5 sequences + 5 cost ratios).
- [x] `npx vitest run` — 36 files, 403 tests green.
- [x] `npm run lint` — clean.
- [x] `npx tsc --noEmit` — clean.
- [x] `go build ./...` — clean.

## Caps preserved
- Defence-in-depth body caps from #89 still apply at the root router. New cost-ratios endpoint reads no client body so the cap is moot for this surface.