### PR TITLE
feat(onec): inbound 1C webhook — idempotent event capture (#106)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -27,22 +27,23 @@ import (
 	"github.com/daniil/floq/internal/httputil"
 	"github.com/daniil/floq/internal/inbox"
 	"github.com/daniil/floq/internal/inbox/attachments"
+	"github.com/daniil/floq/internal/integrations/onec"
 	"github.com/daniil/floq/internal/leads"
 	"github.com/daniil/floq/internal/notify"
 	"github.com/daniil/floq/internal/outbound"
 	"github.com/daniil/floq/internal/parser"
+	"github.com/daniil/floq/internal/prospects"
 	"github.com/daniil/floq/internal/proxy"
 	"github.com/daniil/floq/internal/ratelimit"
 	"github.com/daniil/floq/internal/reminders"
-	"github.com/daniil/floq/internal/prospects"
 	"github.com/daniil/floq/internal/sequences"
 	"github.com/daniil/floq/internal/settings"
 	"github.com/daniil/floq/internal/sources"
 	"github.com/daniil/floq/internal/tgclient"
 	"github.com/daniil/floq/internal/verify"
-	"github.com/google/uuid"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/joho/godotenv"
 	"github.com/redis/go-redis/v9"
@@ -226,6 +227,10 @@ func main() {
 
 	// Auth (public)
 	auth.RegisterRoutes(r, authHandler)
+
+	// 1C inbound webhook (public — authenticated by per-user secret, not JWT)
+	onecRepo := onec.NewRepository(pool)
+	onec.RegisterRoutes(r, onec.NewHandler(onec.NewUseCase(onecRepo)), onecRepo)
 
 	// Protected routes
 	r.Group(func(r chi.Router) {
@@ -424,4 +429,3 @@ func pendingReplyKeyFn(r *http.Request) (string, bool) {
 	}
 	return "ratelimit:pending-replies:" + id.String(), true
 }
-

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -230,7 +230,7 @@ func main() {
 
 	// 1C inbound webhook (public — authenticated by per-user secret, not JWT)
 	onecRepo := onec.NewRepository(pool)
-	onec.RegisterRoutes(r, onec.NewHandler(onec.NewUseCase(onecRepo)), onecRepo)
+	onec.RegisterRoutes(r, onec.NewHandler(onec.NewUseCase(onecRepo, onec.WithLogger(slog.Default()))), onecRepo)
 
 	// Protected routes
 	r.Group(func(r chi.Router) {

--- a/backend/internal/integrations/onec/domain/entity.go
+++ b/backend/internal/integrations/onec/domain/entity.go
@@ -1,0 +1,161 @@
+// Package domain holds the bounded-context model for the 1C integration:
+// the inbound event vocabulary (EventKind), the value object that wraps a
+// raw 1C event (ExternalEvent), and the sync ledger entry (SyncRecord) used
+// for idempotent dedup. All invariants are enforced through the factories
+// here — no struct must be assembled directly outside this package.
+package domain
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+
+	"github.com/google/uuid"
+)
+
+// Domain errors. Declared as package vars so callers can use errors.Is.
+var (
+	ErrInvalidEventKind  = errors.New("onec: invalid event kind")
+	ErrEmptyExternalID   = errors.New("onec: external id is required")
+	ErrEmptyExternalType = errors.New("onec: external type is required")
+	ErrInvalidDirection  = errors.New("onec: invalid sync direction")
+	ErrNilUser           = errors.New("onec: user id is required")
+	ErrNilEvent          = errors.New("onec: external event is required")
+)
+
+// EventKind is the ubiquitous-language enum of 1C events Floq reacts to.
+// The 1C side maps its own document types onto these kinds; Floq only ever
+// deals with this closed set, never raw 1C document names.
+type EventKind string
+
+const (
+	EventKindPayment             EventKind = "payment"              // счёт оплачен
+	EventKindCounterpartyCreated EventKind = "counterparty_created" // новый контрагент
+	EventKindOrderStatus         EventKind = "order_status"         // изменился статус заказа/сделки
+	EventKindShipment            EventKind = "shipment"             // отгрузка / акт
+)
+
+// IsValid reports whether k is one of the known event kinds.
+func (k EventKind) IsValid() bool {
+	switch k {
+	case EventKindPayment, EventKindCounterpartyCreated, EventKindOrderStatus, EventKindShipment:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the wire representation of the kind.
+func (k EventKind) String() string { return string(k) }
+
+// ParseEventKind converts a wire string into an EventKind, rejecting unknown
+// values with ErrInvalidEventKind.
+func ParseEventKind(s string) (EventKind, error) {
+	k := EventKind(s)
+	if !k.IsValid() {
+		return "", ErrInvalidEventKind
+	}
+	return k, nil
+}
+
+// SyncDirection distinguishes events received from 1C (inbound) from actions
+// Floq pushes to 1C (outbound). Both share the same ledger.
+type SyncDirection string
+
+const (
+	DirectionInbound  SyncDirection = "inbound"
+	DirectionOutbound SyncDirection = "outbound"
+)
+
+// IsValid reports whether d is a known direction.
+func (d SyncDirection) IsValid() bool {
+	return d == DirectionInbound || d == DirectionOutbound
+}
+
+// SyncStatus is the lifecycle state of a ledger entry.
+type SyncStatus string
+
+const (
+	SyncStatusReceived  SyncStatus = "received"  // принято, ещё не применено
+	SyncStatusProcessed SyncStatus = "processed" // применено к домену
+	SyncStatusError     SyncStatus = "error"     // применение упало
+)
+
+// ExternalEvent is a value object wrapping a single 1C event. ExternalID +
+// ExternalType form the natural dedup key (a 1C object is uniquely a
+// (type, id) pair). Payload is the raw 1C body, kept opaque at this layer —
+// interpretation happens in the mapping layer (#107).
+type ExternalEvent struct {
+	ExternalID   string
+	ExternalType string
+	Kind         EventKind
+	Payload      []byte
+}
+
+// NewExternalEvent validates and constructs an ExternalEvent. It rejects an
+// empty external id/type and an unknown kind.
+func NewExternalEvent(externalID, externalType string, kind EventKind, payload []byte) (*ExternalEvent, error) {
+	if externalID == "" {
+		return nil, ErrEmptyExternalID
+	}
+	if externalType == "" {
+		return nil, ErrEmptyExternalType
+	}
+	if !kind.IsValid() {
+		return nil, ErrInvalidEventKind
+	}
+	return &ExternalEvent{
+		ExternalID:   externalID,
+		ExternalType: externalType,
+		Kind:         kind,
+		Payload:      payload,
+	}, nil
+}
+
+// SyncRecord is the ledger entry proving an event was seen, enabling
+// idempotent processing: the repository's UNIQUE (user_id, external_id,
+// external_type) constraint plus this record means a replayed webhook is a
+// no-op. PayloadHash lets a future reconciliation detect a changed payload
+// under the same external id.
+type SyncRecord struct {
+	ID           uuid.UUID
+	UserID       uuid.UUID
+	ExternalID   string
+	ExternalType string
+	Direction    SyncDirection
+	Kind         EventKind
+	Status       SyncStatus
+	PayloadHash  string
+}
+
+// NewSyncRecord builds a fresh ledger entry in the Received state from a
+// validated event. It enforces a non-nil user, a non-nil event and a legal
+// direction, and computes the payload hash up front.
+func NewSyncRecord(userID uuid.UUID, ev *ExternalEvent, direction SyncDirection) (*SyncRecord, error) {
+	if userID == uuid.Nil {
+		return nil, ErrNilUser
+	}
+	if ev == nil {
+		return nil, ErrNilEvent
+	}
+	if !direction.IsValid() {
+		return nil, ErrInvalidDirection
+	}
+	return &SyncRecord{
+		ID:           uuid.New(),
+		UserID:       userID,
+		ExternalID:   ev.ExternalID,
+		ExternalType: ev.ExternalType,
+		Direction:    direction,
+		Kind:         ev.Kind,
+		Status:       SyncStatusReceived,
+		PayloadHash:  hashPayload(ev.Payload),
+	}, nil
+}
+
+// hashPayload returns a hex SHA-256 of the raw payload, used to detect
+// content drift on replays.
+func hashPayload(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}

--- a/backend/internal/integrations/onec/domain/entity.go
+++ b/backend/internal/integrations/onec/domain/entity.go
@@ -72,13 +72,13 @@ func (d SyncDirection) IsValid() bool {
 	return d == DirectionInbound || d == DirectionOutbound
 }
 
-// SyncStatus is the lifecycle state of a ledger entry.
+// SyncStatus is the lifecycle state of a ledger entry. #106 only ever records
+// Received (capture). The processed/error transitions arrive with the mapping
+// layer (#107) — intentionally not declared here to avoid dead states.
 type SyncStatus string
 
 const (
-	SyncStatusReceived  SyncStatus = "received"  // принято, ещё не применено
-	SyncStatusProcessed SyncStatus = "processed" // применено к домену
-	SyncStatusError     SyncStatus = "error"     // применение упало
+	SyncStatusReceived SyncStatus = "received" // принято, ещё не применено
 )
 
 // ExternalEvent is a value object wrapping a single 1C event. ExternalID +

--- a/backend/internal/integrations/onec/domain/entity_test.go
+++ b/backend/internal/integrations/onec/domain/entity_test.go
@@ -1,0 +1,144 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestParseEventKind(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    EventKind
+		wantErr error
+	}{
+		{"payment", "payment", EventKindPayment, nil},
+		{"counterparty", "counterparty_created", EventKindCounterpartyCreated, nil},
+		{"order status", "order_status", EventKindOrderStatus, nil},
+		{"shipment", "shipment", EventKindShipment, nil},
+		{"unknown", "delivery", "", ErrInvalidEventKind},
+		{"empty", "", "", ErrInvalidEventKind},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseEventKind(tt.in)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("got = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEventKind_IsValid(t *testing.T) {
+	valid := []EventKind{EventKindPayment, EventKindCounterpartyCreated, EventKindOrderStatus, EventKindShipment}
+	for _, k := range valid {
+		if !k.IsValid() {
+			t.Errorf("%q should be valid", k)
+		}
+	}
+	if EventKind("nope").IsValid() {
+		t.Error("unknown kind should be invalid")
+	}
+}
+
+func TestNewExternalEvent(t *testing.T) {
+	tests := []struct {
+		name         string
+		externalID   string
+		externalType string
+		kind         EventKind
+		payload      []byte
+		wantErr      error
+	}{
+		{"valid", "ОП-0001", "Документ.ОплатаПокупателя", EventKindPayment, []byte(`{"sum":1000}`), nil},
+		{"empty external id", "", "Документ.ОплатаПокупателя", EventKindPayment, []byte(`{}`), ErrEmptyExternalID},
+		{"empty external type", "ОП-0001", "", EventKindPayment, []byte(`{}`), ErrEmptyExternalType},
+		{"invalid kind", "ОП-0001", "Документ", EventKind("bad"), []byte(`{}`), ErrInvalidEventKind},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev, err := NewExternalEvent(tt.externalID, tt.externalType, tt.kind, tt.payload)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil {
+				if ev == nil {
+					t.Fatal("expected non-nil event")
+				}
+				if ev.ExternalID != tt.externalID || ev.Kind != tt.kind {
+					t.Fatalf("event fields mismatch: %+v", ev)
+				}
+			}
+		})
+	}
+}
+
+func TestNewSyncRecord(t *testing.T) {
+	user := uuid.New()
+	ev, err := NewExternalEvent("ОП-0001", "Документ.ОплатаПокупателя", EventKindPayment, []byte(`{"sum":1000}`))
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	t.Run("valid inbound", func(t *testing.T) {
+		rec, err := NewSyncRecord(user, ev, DirectionInbound)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if rec.UserID != user || rec.ExternalID != ev.ExternalID || rec.ExternalType != ev.ExternalType {
+			t.Fatalf("record fields mismatch: %+v", rec)
+		}
+		if rec.Direction != DirectionInbound {
+			t.Fatalf("direction = %q", rec.Direction)
+		}
+		if rec.Status != SyncStatusReceived {
+			t.Fatalf("status = %q, want received", rec.Status)
+		}
+		if rec.PayloadHash == "" {
+			t.Fatal("expected payload hash to be computed")
+		}
+		if rec.ID == uuid.Nil {
+			t.Fatal("expected generated ID")
+		}
+	})
+
+	t.Run("nil user", func(t *testing.T) {
+		if _, err := NewSyncRecord(uuid.Nil, ev, DirectionInbound); !errors.Is(err, ErrNilUser) {
+			t.Fatalf("err = %v, want ErrNilUser", err)
+		}
+	})
+
+	t.Run("nil event", func(t *testing.T) {
+		if _, err := NewSyncRecord(user, nil, DirectionInbound); !errors.Is(err, ErrNilEvent) {
+			t.Fatalf("err = %v, want ErrNilEvent", err)
+		}
+	})
+
+	t.Run("invalid direction", func(t *testing.T) {
+		if _, err := NewSyncRecord(user, ev, SyncDirection("sideways")); !errors.Is(err, ErrInvalidDirection) {
+			t.Fatalf("err = %v, want ErrInvalidDirection", err)
+		}
+	})
+}
+
+func TestPayloadHash_StableAndDistinct(t *testing.T) {
+	user := uuid.New()
+	mk := func(payload string) *SyncRecord {
+		ev, _ := NewExternalEvent("ID-1", "Документ", EventKindPayment, []byte(payload))
+		rec, _ := NewSyncRecord(user, ev, DirectionInbound)
+		return rec
+	}
+	a, b := mk(`{"sum":1000}`), mk(`{"sum":1000}`)
+	if a.PayloadHash != b.PayloadHash {
+		t.Error("same payload must hash equally")
+	}
+	c := mk(`{"sum":2000}`)
+	if a.PayloadHash == c.PayloadHash {
+		t.Error("different payload must hash differently")
+	}
+}

--- a/backend/internal/integrations/onec/handler.go
+++ b/backend/internal/integrations/onec/handler.go
@@ -2,6 +2,7 @@ package onec
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/daniil/floq/internal/httputil"
@@ -53,6 +54,12 @@ func (h *Handler) Webhook(w http.ResponseWriter, r *http.Request) {
 
 	var req webhookRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		// A body that exceeds the JSONBodyCap is a size violation (413), not
+		// malformed JSON (400).
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+			http.Error(w, "payload too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, "invalid json body", http.StatusBadRequest)
 		return
 	}

--- a/backend/internal/integrations/onec/handler.go
+++ b/backend/internal/integrations/onec/handler.go
@@ -1,0 +1,107 @@
+package onec
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/daniil/floq/internal/httputil"
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/go-chi/chi/v5"
+)
+
+// webhookSecretHeader carries the per-user secret 1C sends with each call.
+const webhookSecretHeader = "X-Onec-Secret"
+
+// Handler exposes the 1C inbound webhook.
+type Handler struct {
+	uc *UseCase
+}
+
+// NewHandler builds a Handler over the use case.
+func NewHandler(uc *UseCase) *Handler {
+	return &Handler{uc: uc}
+}
+
+// RegisterRoutes mounts the public webhook endpoint. It is intentionally
+// outside the JWT-protected group: 1C authenticates with its per-user secret
+// via WebhookAuth, which resolves the tenant and injects the user id. The
+// global JSONBodyCap on the root router already enforces the size limit (413).
+func RegisterRoutes(r chi.Router, h *Handler, resolver SecretResolver) {
+	r.Group(func(r chi.Router) {
+		r.Use(WebhookAuth(resolver))
+		r.Post("/api/integrations/onec/webhook", h.Webhook)
+	})
+}
+
+// webhookRequest is the JSON contract 1C posts. Payload stays raw — its shape
+// depends on the 1C configuration and is interpreted by the mapping layer (#107).
+type webhookRequest struct {
+	ExternalID   string          `json:"external_id"`
+	ExternalType string          `json:"external_type"`
+	Kind         string          `json:"kind"`
+	Payload      json.RawMessage `json:"payload"`
+}
+
+// Webhook ingests one 1C event for the authenticated tenant. Replays are
+// idempotent and still return 200.
+func (h *Handler) Webhook(w http.ResponseWriter, r *http.Request) {
+	userID, ok := httputil.UserIDFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req webhookRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json body", http.StatusBadRequest)
+		return
+	}
+
+	kind, err := domain.ParseEventKind(req.Kind)
+	if err != nil {
+		http.Error(w, "invalid event kind", http.StatusBadRequest)
+		return
+	}
+
+	ev, err := domain.NewExternalEvent(req.ExternalID, req.ExternalType, kind, req.Payload)
+	if err != nil {
+		http.Error(w, "invalid event", http.StatusBadRequest)
+		return
+	}
+
+	res, err := h.uc.ProcessInboundEvent(r.Context(), userID, ev)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "deduped": res.Deduped})
+}
+
+// WebhookAuth resolves the tenant from the webhook secret header and injects
+// the user id into the request context. An empty or unknown secret → 401; a
+// resolver failure → 500.
+func WebhookAuth(resolver SecretResolver) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			secret := r.Header.Get(webhookSecretHeader)
+			if secret == "" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			userID, found, err := resolver.UserIDByWebhookSecret(r.Context(), secret)
+			if err != nil {
+				http.Error(w, "internal error", http.StatusInternalServerError)
+				return
+			}
+			if !found {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			ctx := httputil.WithUserID(r.Context(), userID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/backend/internal/integrations/onec/handler_test.go
+++ b/backend/internal/integrations/onec/handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/daniil/floq/internal/httputil"
 	"github.com/daniil/floq/internal/integrations/onec"
+	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
 
@@ -169,4 +170,41 @@ func TestWebhookAuth_ResolverError(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500", rec.Code)
 	}
+}
+
+// --- full wire-up: RegisterRoutes composes auth middleware + handler ---
+
+func TestRegisterRoutes_EndToEnd(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	resolver := &fakeResolver{user: uuid.New(), found: true}
+	r := chi.NewRouter()
+	onec.RegisterRoutes(r, onec.NewHandler(onec.NewUseCase(store)), resolver)
+
+	const path = "/api/integrations/onec/webhook"
+
+	t.Run("valid secret + body → 200, stored", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(validBody))
+		req.Header.Set("X-Onec-Secret", "good")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+		}
+		if store.calls != 1 {
+			t.Errorf("store calls = %d, want 1", store.calls)
+		}
+	})
+
+	t.Run("missing secret → 401, not stored", func(t *testing.T) {
+		store.calls = 0
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(validBody))
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+		if store.calls != 0 {
+			t.Errorf("unauthenticated request must not reach the store")
+		}
+	})
 }

--- a/backend/internal/integrations/onec/handler_test.go
+++ b/backend/internal/integrations/onec/handler_test.go
@@ -208,3 +208,25 @@ func TestRegisterRoutes_EndToEnd(t *testing.T) {
 		}
 	})
 }
+
+// Oversized JSON body under JSONBodyCap must yield 413, not 400 — the public
+// webhook is the only unauthenticated-by-JWT route and must reject large
+// bodies with the right status.
+func TestWebhook_BodyCapReturns413(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	r := chi.NewRouter()
+	r.Use(httputil.JSONBodyCap(64)) // tiny cap to force overflow
+	resolver := &fakeResolver{user: uuid.New(), found: true}
+	onec.RegisterRoutes(r, onec.NewHandler(onec.NewUseCase(store)), resolver)
+
+	big := `{"external_id":"x","external_type":"y","kind":"payment","payload":"` + strings.Repeat("A", 500) + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/integrations/onec/webhook", strings.NewReader(big))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Onec-Secret", "good")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", rec.Code)
+	}
+}

--- a/backend/internal/integrations/onec/handler_test.go
+++ b/backend/internal/integrations/onec/handler_test.go
@@ -1,0 +1,172 @@
+package onec_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/daniil/floq/internal/httputil"
+	"github.com/daniil/floq/internal/integrations/onec"
+	"github.com/google/uuid"
+)
+
+// fakeResolver is a SecretResolver for middleware tests.
+type fakeResolver struct {
+	user  uuid.UUID
+	found bool
+	err   error
+}
+
+func (f *fakeResolver) UserIDByWebhookSecret(_ context.Context, _ string) (uuid.UUID, bool, error) {
+	return f.user, f.found, f.err
+}
+
+const validBody = `{"external_id":"ОП-1","external_type":"Документ.Оплата","kind":"payment","payload":{"sum":1000}}`
+
+func newHandler(store onec.SyncStore) *onec.Handler {
+	return onec.NewHandler(onec.NewUseCase(store))
+}
+
+// --- handler (assumes auth middleware already put userID in context) ---
+
+func TestWebhook_Valid(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	h := newHandler(store)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/integrations/onec/webhook", strings.NewReader(validBody))
+	req = req.WithContext(httputil.WithUserID(req.Context(), uuid.New()))
+	rec := httptest.NewRecorder()
+	h.Webhook(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if store.calls != 1 {
+		t.Errorf("store calls = %d, want 1", store.calls)
+	}
+}
+
+func TestWebhook_DuplicateReturns200(t *testing.T) {
+	store := &fakeStore{inserted: false} // dedup hit
+	h := newHandler(store)
+
+	req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(validBody))
+	req = req.WithContext(httputil.WithUserID(req.Context(), uuid.New()))
+	rec := httptest.NewRecorder()
+	h.Webhook(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("replay status = %d, want 200", rec.Code)
+	}
+}
+
+func TestWebhook_InvalidKind(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	h := newHandler(store)
+
+	body := `{"external_id":"ОП-1","external_type":"Документ","kind":"delivery","payload":{}}`
+	req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(body))
+	req = req.WithContext(httputil.WithUserID(req.Context(), uuid.New()))
+	rec := httptest.NewRecorder()
+	h.Webhook(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if store.calls != 0 {
+		t.Errorf("store must not be called on invalid kind")
+	}
+}
+
+func TestWebhook_BadJSON(t *testing.T) {
+	h := newHandler(&fakeStore{})
+	req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(`{not json`))
+	req = req.WithContext(httputil.WithUserID(req.Context(), uuid.New()))
+	rec := httptest.NewRecorder()
+	h.Webhook(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestWebhook_NoUserInContext(t *testing.T) {
+	h := newHandler(&fakeStore{})
+	req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(validBody))
+	rec := httptest.NewRecorder()
+	h.Webhook(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+// --- secret middleware (tenant resolution by webhook secret) ---
+
+func TestWebhookAuth_MissingSecret(t *testing.T) {
+	mw := onec.WebhookAuth(&fakeResolver{found: false})
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestWebhookAuth_UnknownSecret(t *testing.T) {
+	mw := onec.WebhookAuth(&fakeResolver{found: false})
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	req.Header.Set("X-Onec-Secret", "nope")
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestWebhookAuth_ValidSecretInjectsUser(t *testing.T) {
+	want := uuid.New()
+	mw := onec.WebhookAuth(&fakeResolver{user: want, found: true})
+
+	var got uuid.UUID
+	var ok bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got, ok = httputil.UserIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	req.Header.Set("X-Onec-Secret", "good")
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !ok || got != want {
+		t.Fatalf("userID in ctx = %v (ok=%v), want %v", got, ok, want)
+	}
+}
+
+func TestWebhookAuth_ResolverError(t *testing.T) {
+	mw := onec.WebhookAuth(&fakeResolver{err: errors.New("db down")})
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	req.Header.Set("X-Onec-Secret", "good")
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}

--- a/backend/internal/integrations/onec/ports.go
+++ b/backend/internal/integrations/onec/ports.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/google/uuid"
 )
 
 // SyncStore persists ledger entries. Declared in the consumer package
@@ -12,4 +13,13 @@ type SyncStore interface {
 	// InsertSyncRecord saves rec, returning inserted=false when the dedup
 	// key already exists (idempotent replay).
 	InsertSyncRecord(ctx context.Context, rec *domain.SyncRecord) (bool, error)
+}
+
+// SecretResolver maps an inbound webhook secret to its owning user. The
+// webhook carries no JWT (1C can't issue one), so the secret is the tenant
+// credential. The postgres Repository satisfies it.
+type SecretResolver interface {
+	// UserIDByWebhookSecret returns the user whose active 1C credentials match
+	// secret. found=false means no match (→ 401).
+	UserIDByWebhookSecret(ctx context.Context, secret string) (uuid.UUID, bool, error)
 }

--- a/backend/internal/integrations/onec/ports.go
+++ b/backend/internal/integrations/onec/ports.go
@@ -1,0 +1,15 @@
+package onec
+
+import (
+	"context"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+)
+
+// SyncStore persists ledger entries. Declared in the consumer package
+// (usecase side) per DIP — the postgres Repository satisfies it.
+type SyncStore interface {
+	// InsertSyncRecord saves rec, returning inserted=false when the dedup
+	// key already exists (idempotent replay).
+	InsertSyncRecord(ctx context.Context, rec *domain.SyncRecord) (bool, error)
+}

--- a/backend/internal/integrations/onec/ports.go
+++ b/backend/internal/integrations/onec/ports.go
@@ -7,12 +7,23 @@ import (
 	"github.com/google/uuid"
 )
 
+// InsertOutcome reports the result of an idempotent ledger insert.
+type InsertOutcome struct {
+	// Inserted is true when a new row was written (false on a dedup hit).
+	Inserted bool
+	// PayloadDrifted is true when the event was deduped but arrived with a
+	// different payload than the stored one — a replayed 1C document whose
+	// content changed. The caller decides what to do (we log it); a silent
+	// drop would lose a real update.
+	PayloadDrifted bool
+}
+
 // SyncStore persists ledger entries. Declared in the consumer package
 // (usecase side) per DIP — the postgres Repository satisfies it.
 type SyncStore interface {
-	// InsertSyncRecord saves rec, returning inserted=false when the dedup
-	// key already exists (idempotent replay).
-	InsertSyncRecord(ctx context.Context, rec *domain.SyncRecord) (bool, error)
+	// InsertSyncRecord saves rec idempotently: a replayed dedup key yields
+	// Inserted=false, and PayloadDrifted=true if the stored payload differs.
+	InsertSyncRecord(ctx context.Context, rec *domain.SyncRecord) (InsertOutcome, error)
 }
 
 // SecretResolver maps an inbound webhook secret to its owning user. The

--- a/backend/internal/integrations/onec/repository.go
+++ b/backend/internal/integrations/onec/repository.go
@@ -20,11 +20,12 @@ func NewRepository(pool *pgxpool.Pool) *Repository {
 	return &Repository{pool: pool}
 }
 
-// InsertSyncRecord persists a ledger entry, returning inserted=false when the
-// (user_id, external_id, external_type) dedup key already exists. This is the
-// idempotency primitive: a replayed webhook resolves to a no-op insert rather
-// than a duplicate row or an error.
-func (r *Repository) InsertSyncRecord(ctx context.Context, rec *domain.SyncRecord) (bool, error) {
+// InsertSyncRecord persists a ledger entry idempotently. On the dedup key
+// (user_id, external_id, external_type) it inserts at most once; a replay is a
+// no-op (Inserted=false). When deduped, it compares the stored payload hash to
+// detect drift — a 1C document re-sent with changed content — so the caller can
+// surface it instead of silently dropping a real update.
+func (r *Repository) InsertSyncRecord(ctx context.Context, rec *domain.SyncRecord) (InsertOutcome, error) {
 	tag, err := r.pool.Exec(ctx, `
 		INSERT INTO onec_sync_records
 			(id, user_id, external_id, external_type, direction, kind, status, payload_hash)
@@ -33,9 +34,22 @@ func (r *Repository) InsertSyncRecord(ctx context.Context, rec *domain.SyncRecor
 		rec.ID, rec.UserID, rec.ExternalID, rec.ExternalType,
 		string(rec.Direction), string(rec.Kind), string(rec.Status), rec.PayloadHash)
 	if err != nil {
-		return false, err
+		return InsertOutcome{}, err
 	}
-	return tag.RowsAffected() == 1, nil
+	if tag.RowsAffected() == 1 {
+		return InsertOutcome{Inserted: true}, nil
+	}
+
+	// Dedup hit: check whether the replayed payload differs from the stored one.
+	var storedHash string
+	err = r.pool.QueryRow(ctx, `
+		SELECT payload_hash FROM onec_sync_records
+		WHERE user_id = $1 AND external_id = $2 AND external_type = $3`,
+		rec.UserID, rec.ExternalID, rec.ExternalType).Scan(&storedHash)
+	if err != nil {
+		return InsertOutcome{}, err
+	}
+	return InsertOutcome{Inserted: false, PayloadDrifted: storedHash != rec.PayloadHash}, nil
 }
 
 // UserIDByWebhookSecret resolves the owning user from a webhook secret. Only

--- a/backend/internal/integrations/onec/repository.go
+++ b/backend/internal/integrations/onec/repository.go
@@ -1,0 +1,36 @@
+package onec
+
+import (
+	"context"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Repository is the postgres-backed store for the 1C sync ledger.
+type Repository struct {
+	pool *pgxpool.Pool
+}
+
+// NewRepository builds a Repository over the given pool.
+func NewRepository(pool *pgxpool.Pool) *Repository {
+	return &Repository{pool: pool}
+}
+
+// InsertSyncRecord persists a ledger entry, returning inserted=false when the
+// (user_id, external_id, external_type) dedup key already exists. This is the
+// idempotency primitive: a replayed webhook resolves to a no-op insert rather
+// than a duplicate row or an error.
+func (r *Repository) InsertSyncRecord(ctx context.Context, rec *domain.SyncRecord) (bool, error) {
+	tag, err := r.pool.Exec(ctx, `
+		INSERT INTO onec_sync_records
+			(id, user_id, external_id, external_type, direction, kind, status, payload_hash)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (user_id, external_id, external_type) DO NOTHING`,
+		rec.ID, rec.UserID, rec.ExternalID, rec.ExternalType,
+		string(rec.Direction), string(rec.Kind), string(rec.Status), rec.PayloadHash)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
+}

--- a/backend/internal/integrations/onec/repository.go
+++ b/backend/internal/integrations/onec/repository.go
@@ -2,8 +2,11 @@ package onec
 
 import (
 	"context"
+	"errors"
 
 	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -33,4 +36,24 @@ func (r *Repository) InsertSyncRecord(ctx context.Context, rec *domain.SyncRecor
 		return false, err
 	}
 	return tag.RowsAffected() == 1, nil
+}
+
+// UserIDByWebhookSecret resolves the owning user from a webhook secret. Only
+// active credentials with a non-empty secret match, so a blank secret never
+// authenticates. found=false when no row matches.
+func (r *Repository) UserIDByWebhookSecret(ctx context.Context, secret string) (uuid.UUID, bool, error) {
+	if secret == "" {
+		return uuid.Nil, false, nil
+	}
+	var userID uuid.UUID
+	err := r.pool.QueryRow(ctx, `
+		SELECT user_id FROM onec_credentials
+		WHERE webhook_secret = $1 AND is_active = TRUE`, secret).Scan(&userID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, false, nil
+	}
+	if err != nil {
+		return uuid.Nil, false, err
+	}
+	return userID, true, nil
 }

--- a/backend/internal/integrations/onec/repository_integration_test.go
+++ b/backend/internal/integrations/onec/repository_integration_test.go
@@ -28,23 +28,23 @@ func TestRepository_InsertSyncRecord_Dedup(t *testing.T) {
 	rec1, err := domain.NewSyncRecord(user, newEvent(t, "ОП-0001"), domain.DirectionInbound)
 	require.NoError(t, err)
 
-	inserted, err := repo.InsertSyncRecord(ctx, rec1)
+	out, err := repo.InsertSyncRecord(ctx, rec1)
 	require.NoError(t, err)
-	require.True(t, inserted, "first insert must persist")
+	require.True(t, out.Inserted, "first insert must persist")
 
 	// Same (user, external_id, external_type) → dedup, no second row.
 	rec2, err := domain.NewSyncRecord(user, newEvent(t, "ОП-0001"), domain.DirectionInbound)
 	require.NoError(t, err)
-	inserted, err = repo.InsertSyncRecord(ctx, rec2)
+	out, err = repo.InsertSyncRecord(ctx, rec2)
 	require.NoError(t, err)
-	require.False(t, inserted, "replayed event must be deduped")
+	require.False(t, out.Inserted, "replayed event must be deduped")
 
 	// Different external_id → new row.
 	rec3, err := domain.NewSyncRecord(user, newEvent(t, "ОП-0002"), domain.DirectionInbound)
 	require.NoError(t, err)
-	inserted, err = repo.InsertSyncRecord(ctx, rec3)
+	out, err = repo.InsertSyncRecord(ctx, rec3)
 	require.NoError(t, err)
-	require.True(t, inserted, "distinct event must persist")
+	require.True(t, out.Inserted, "distinct event must persist")
 }
 
 func TestRepository_InsertSyncRecord_PerUserScope(t *testing.T) {
@@ -58,15 +58,15 @@ func TestRepository_InsertSyncRecord_PerUserScope(t *testing.T) {
 	// dedup is per-user, not global.
 	recA, err := domain.NewSyncRecord(userA, newEvent(t, "ОП-SHARED"), domain.DirectionInbound)
 	require.NoError(t, err)
-	insertedA, err := repo.InsertSyncRecord(ctx, recA)
+	outA, err := repo.InsertSyncRecord(ctx, recA)
 	require.NoError(t, err)
-	require.True(t, insertedA)
+	require.True(t, outA.Inserted)
 
 	recB, err := domain.NewSyncRecord(userB, newEvent(t, "ОП-SHARED"), domain.DirectionInbound)
 	require.NoError(t, err)
-	insertedB, err := repo.InsertSyncRecord(ctx, recB)
+	outB, err := repo.InsertSyncRecord(ctx, recB)
 	require.NoError(t, err)
-	require.True(t, insertedB, "same external id under different user must not collide")
+	require.True(t, outB.Inserted, "same external id under different user must not collide")
 }
 
 func TestRepository_InsertSyncRecord_PayloadDrift(t *testing.T) {

--- a/backend/internal/integrations/onec/repository_integration_test.go
+++ b/backend/internal/integrations/onec/repository_integration_test.go
@@ -69,6 +69,38 @@ func TestRepository_InsertSyncRecord_PerUserScope(t *testing.T) {
 	require.True(t, insertedB, "same external id under different user must not collide")
 }
 
+func TestRepository_InsertSyncRecord_PayloadDrift(t *testing.T) {
+	pool := testutil.TestDB(t)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+	user := testutil.SeedUser(t, pool)
+
+	mk := func(payload string) *domain.SyncRecord {
+		ev, err := domain.NewExternalEvent("ОП-DRIFT", "Документ.Оплата", domain.EventKindPayment, []byte(payload))
+		require.NoError(t, err)
+		rec, err := domain.NewSyncRecord(user, ev, domain.DirectionInbound)
+		require.NoError(t, err)
+		return rec
+	}
+
+	out, err := repo.InsertSyncRecord(ctx, mk(`{"sum":1000}`))
+	require.NoError(t, err)
+	require.True(t, out.Inserted)
+	require.False(t, out.PayloadDrifted)
+
+	// Same dedup key, identical payload → deduped, no drift.
+	out, err = repo.InsertSyncRecord(ctx, mk(`{"sum":1000}`))
+	require.NoError(t, err)
+	require.False(t, out.Inserted)
+	require.False(t, out.PayloadDrifted)
+
+	// Same dedup key, CHANGED payload → deduped but drift detected.
+	out, err = repo.InsertSyncRecord(ctx, mk(`{"sum":9999}`))
+	require.NoError(t, err)
+	require.False(t, out.Inserted)
+	require.True(t, out.PayloadDrifted, "changed payload under same external id must be flagged as drift")
+}
+
 func TestRepository_UserIDByWebhookSecret(t *testing.T) {
 	pool := testutil.TestDB(t)
 	repo := onec.NewRepository(pool)

--- a/backend/internal/integrations/onec/repository_integration_test.go
+++ b/backend/internal/integrations/onec/repository_integration_test.go
@@ -68,3 +68,42 @@ func TestRepository_InsertSyncRecord_PerUserScope(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, insertedB, "same external id under different user must not collide")
 }
+
+func TestRepository_UserIDByWebhookSecret(t *testing.T) {
+	pool := testutil.TestDB(t)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+	user := testutil.SeedUser(t, pool)
+
+	_, err := pool.Exec(ctx,
+		`INSERT INTO onec_credentials (user_id, webhook_secret, is_active) VALUES ($1, $2, TRUE)`,
+		user, "s3cr3t")
+	require.NoError(t, err)
+
+	t.Run("active secret resolves", func(t *testing.T) {
+		got, found, err := repo.UserIDByWebhookSecret(ctx, "s3cr3t")
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, user, got)
+	})
+
+	t.Run("empty secret never matches", func(t *testing.T) {
+		_, found, err := repo.UserIDByWebhookSecret(ctx, "")
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("unknown secret not found", func(t *testing.T) {
+		_, found, err := repo.UserIDByWebhookSecret(ctx, "wrong")
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("inactive credentials excluded", func(t *testing.T) {
+		_, err := pool.Exec(ctx, `UPDATE onec_credentials SET is_active = FALSE WHERE user_id = $1`, user)
+		require.NoError(t, err)
+		_, found, err := repo.UserIDByWebhookSecret(ctx, "s3cr3t")
+		require.NoError(t, err)
+		require.False(t, found, "inactive credentials must not authenticate")
+	})
+}

--- a/backend/internal/integrations/onec/repository_integration_test.go
+++ b/backend/internal/integrations/onec/repository_integration_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+package onec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/daniil/floq/internal/integrations/onec"
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/daniil/floq/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func newEvent(t *testing.T, extID string) *domain.ExternalEvent {
+	t.Helper()
+	ev, err := domain.NewExternalEvent(extID, "Документ.ОплатаПокупателя", domain.EventKindPayment, []byte(`{"sum":1000}`))
+	require.NoError(t, err)
+	return ev
+}
+
+func TestRepository_InsertSyncRecord_Dedup(t *testing.T) {
+	pool := testutil.TestDB(t)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+	user := testutil.SeedUser(t, pool)
+
+	rec1, err := domain.NewSyncRecord(user, newEvent(t, "ОП-0001"), domain.DirectionInbound)
+	require.NoError(t, err)
+
+	inserted, err := repo.InsertSyncRecord(ctx, rec1)
+	require.NoError(t, err)
+	require.True(t, inserted, "first insert must persist")
+
+	// Same (user, external_id, external_type) → dedup, no second row.
+	rec2, err := domain.NewSyncRecord(user, newEvent(t, "ОП-0001"), domain.DirectionInbound)
+	require.NoError(t, err)
+	inserted, err = repo.InsertSyncRecord(ctx, rec2)
+	require.NoError(t, err)
+	require.False(t, inserted, "replayed event must be deduped")
+
+	// Different external_id → new row.
+	rec3, err := domain.NewSyncRecord(user, newEvent(t, "ОП-0002"), domain.DirectionInbound)
+	require.NoError(t, err)
+	inserted, err = repo.InsertSyncRecord(ctx, rec3)
+	require.NoError(t, err)
+	require.True(t, inserted, "distinct event must persist")
+}
+
+func TestRepository_InsertSyncRecord_PerUserScope(t *testing.T) {
+	pool := testutil.TestDB(t)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+	userA := testutil.SeedUser(t, pool)
+	userB := testutil.SeedUser(t, pool)
+
+	// Same external id for two different users must both persist —
+	// dedup is per-user, not global.
+	recA, err := domain.NewSyncRecord(userA, newEvent(t, "ОП-SHARED"), domain.DirectionInbound)
+	require.NoError(t, err)
+	insertedA, err := repo.InsertSyncRecord(ctx, recA)
+	require.NoError(t, err)
+	require.True(t, insertedA)
+
+	recB, err := domain.NewSyncRecord(userB, newEvent(t, "ОП-SHARED"), domain.DirectionInbound)
+	require.NoError(t, err)
+	insertedB, err := repo.InsertSyncRecord(ctx, recB)
+	require.NoError(t, err)
+	require.True(t, insertedB, "same external id under different user must not collide")
+}

--- a/backend/internal/integrations/onec/usecase.go
+++ b/backend/internal/integrations/onec/usecase.go
@@ -1,0 +1,42 @@
+package onec
+
+import (
+	"context"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/google/uuid"
+)
+
+// UseCase orchestrates inbound 1C event handling: build a ledger record,
+// persist it idempotently, and (later, #107) apply the mapped domain action.
+type UseCase struct {
+	store SyncStore
+}
+
+// NewUseCase wires the use case over a SyncStore.
+func NewUseCase(store SyncStore) *UseCase {
+	return &UseCase{store: store}
+}
+
+// ProcessResult reports the outcome of handling one inbound event.
+type ProcessResult struct {
+	// Deduped is true when the event was already seen and this call was a
+	// no-op — the webhook handler still returns 200 for replays.
+	Deduped bool
+}
+
+// ProcessInboundEvent records a validated 1C event for the given user. A
+// replay (same external id/type) is a no-op reported via Deduped. Mapping the
+// event onto a domain action (move lead, upsert prospect) is out of scope here
+// and handled in #107 — this step only guarantees idempotent capture.
+func (u *UseCase) ProcessInboundEvent(ctx context.Context, userID uuid.UUID, ev *domain.ExternalEvent) (ProcessResult, error) {
+	rec, err := domain.NewSyncRecord(userID, ev, domain.DirectionInbound)
+	if err != nil {
+		return ProcessResult{}, err
+	}
+	inserted, err := u.store.InsertSyncRecord(ctx, rec)
+	if err != nil {
+		return ProcessResult{}, err
+	}
+	return ProcessResult{Deduped: !inserted}, nil
+}

--- a/backend/internal/integrations/onec/usecase.go
+++ b/backend/internal/integrations/onec/usecase.go
@@ -2,6 +2,7 @@ package onec
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/daniil/floq/internal/integrations/onec/domain"
 	"github.com/google/uuid"
@@ -10,12 +11,25 @@ import (
 // UseCase orchestrates inbound 1C event handling: build a ledger record,
 // persist it idempotently, and (later, #107) apply the mapped domain action.
 type UseCase struct {
-	store SyncStore
+	store  SyncStore
+	logger *slog.Logger
+}
+
+// Option configures a UseCase.
+type Option func(*UseCase)
+
+// WithLogger sets the logger used for drift/anomaly reporting.
+func WithLogger(l *slog.Logger) Option {
+	return func(u *UseCase) { u.logger = l }
 }
 
 // NewUseCase wires the use case over a SyncStore.
-func NewUseCase(store SyncStore) *UseCase {
-	return &UseCase{store: store}
+func NewUseCase(store SyncStore, opts ...Option) *UseCase {
+	u := &UseCase{store: store, logger: slog.Default()}
+	for _, opt := range opts {
+		opt(u)
+	}
+	return u
 }
 
 // ProcessResult reports the outcome of handling one inbound event.
@@ -23,6 +37,10 @@ type ProcessResult struct {
 	// Deduped is true when the event was already seen and this call was a
 	// no-op — the webhook handler still returns 200 for replays.
 	Deduped bool
+	// PayloadDrifted is true when a replay arrived with changed content. The
+	// event is still deduped (not re-applied), but the drift is logged so a
+	// real update is not lost without a trace.
+	PayloadDrifted bool
 }
 
 // ProcessInboundEvent records a validated 1C event for the given user. A
@@ -34,9 +52,16 @@ func (u *UseCase) ProcessInboundEvent(ctx context.Context, userID uuid.UUID, ev 
 	if err != nil {
 		return ProcessResult{}, err
 	}
-	inserted, err := u.store.InsertSyncRecord(ctx, rec)
+	out, err := u.store.InsertSyncRecord(ctx, rec)
 	if err != nil {
 		return ProcessResult{}, err
 	}
-	return ProcessResult{Deduped: !inserted}, nil
+	if out.PayloadDrifted {
+		u.logger.Warn("onec: replayed event arrived with changed payload; not re-applied",
+			"user_id", userID,
+			"external_id", ev.ExternalID,
+			"external_type", ev.ExternalType,
+			"kind", ev.Kind.String())
+	}
+	return ProcessResult{Deduped: !out.Inserted, PayloadDrifted: out.PayloadDrifted}, nil
 }

--- a/backend/internal/integrations/onec/usecase_test.go
+++ b/backend/internal/integrations/onec/usecase_test.go
@@ -12,16 +12,17 @@ import (
 
 // fakeStore is an in-memory SyncStore for unit tests.
 type fakeStore struct {
-	inserted bool      // value to return from InsertSyncRecord
-	err      error     // error to return
-	calls    int       // how many times InsertSyncRecord was called
+	inserted bool  // InsertOutcome.Inserted to return
+	drifted  bool  // InsertOutcome.PayloadDrifted to return
+	err      error // error to return
+	calls    int   // how many times InsertSyncRecord was called
 	last     *domain.SyncRecord
 }
 
-func (f *fakeStore) InsertSyncRecord(_ context.Context, rec *domain.SyncRecord) (bool, error) {
+func (f *fakeStore) InsertSyncRecord(_ context.Context, rec *domain.SyncRecord) (onec.InsertOutcome, error) {
 	f.calls++
 	f.last = rec
-	return f.inserted, f.err
+	return onec.InsertOutcome{Inserted: f.inserted, PayloadDrifted: f.drifted}, f.err
 }
 
 func mustEvent(t *testing.T) *domain.ExternalEvent {
@@ -62,6 +63,22 @@ func TestProcessInboundEvent_Duplicate(t *testing.T) {
 	}
 	if !res.Deduped {
 		t.Error("replayed event must be marked deduped")
+	}
+}
+
+func TestProcessInboundEvent_PayloadDrift(t *testing.T) {
+	store := &fakeStore{inserted: false, drifted: true} // deduped but content changed
+	uc := onec.NewUseCase(store)
+
+	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), mustEvent(t))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !res.Deduped {
+		t.Error("drifted replay is still deduped")
+	}
+	if !res.PayloadDrifted {
+		t.Error("drift must be surfaced in the result")
 	}
 }
 

--- a/backend/internal/integrations/onec/usecase_test.go
+++ b/backend/internal/integrations/onec/usecase_test.go
@@ -1,0 +1,100 @@
+package onec_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/daniil/floq/internal/integrations/onec"
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/google/uuid"
+)
+
+// fakeStore is an in-memory SyncStore for unit tests.
+type fakeStore struct {
+	inserted bool      // value to return from InsertSyncRecord
+	err      error     // error to return
+	calls    int       // how many times InsertSyncRecord was called
+	last     *domain.SyncRecord
+}
+
+func (f *fakeStore) InsertSyncRecord(_ context.Context, rec *domain.SyncRecord) (bool, error) {
+	f.calls++
+	f.last = rec
+	return f.inserted, f.err
+}
+
+func mustEvent(t *testing.T) *domain.ExternalEvent {
+	t.Helper()
+	ev, err := domain.NewExternalEvent("ОП-1", "Документ.Оплата", domain.EventKindPayment, []byte(`{"sum":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ev
+}
+
+func TestProcessInboundEvent_New(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	uc := onec.NewUseCase(store)
+
+	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), mustEvent(t))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res.Deduped {
+		t.Error("fresh event must not be marked deduped")
+	}
+	if store.calls != 1 {
+		t.Errorf("store called %d times, want 1", store.calls)
+	}
+	if store.last == nil || store.last.Direction != domain.DirectionInbound {
+		t.Error("expected an inbound sync record to be stored")
+	}
+}
+
+func TestProcessInboundEvent_Duplicate(t *testing.T) {
+	store := &fakeStore{inserted: false} // dedup hit
+	uc := onec.NewUseCase(store)
+
+	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), mustEvent(t))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !res.Deduped {
+		t.Error("replayed event must be marked deduped")
+	}
+}
+
+func TestProcessInboundEvent_NilUser(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	uc := onec.NewUseCase(store)
+
+	_, err := uc.ProcessInboundEvent(context.Background(), uuid.Nil, mustEvent(t))
+	if !errors.Is(err, domain.ErrNilUser) {
+		t.Fatalf("err = %v, want ErrNilUser", err)
+	}
+	if store.calls != 0 {
+		t.Error("store must not be called when record construction fails")
+	}
+}
+
+func TestProcessInboundEvent_NilEvent(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	uc := onec.NewUseCase(store)
+
+	_, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), nil)
+	if !errors.Is(err, domain.ErrNilEvent) {
+		t.Fatalf("err = %v, want ErrNilEvent", err)
+	}
+}
+
+func TestProcessInboundEvent_StoreError(t *testing.T) {
+	sentinel := errors.New("db down")
+	store := &fakeStore{err: sentinel}
+	uc := onec.NewUseCase(store)
+
+	_, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), mustEvent(t))
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want sentinel", err)
+	}
+}

--- a/backend/internal/testutil/db.go
+++ b/backend/internal/testutil/db.go
@@ -4,6 +4,7 @@ package testutil
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -11,13 +12,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const dsn = "postgres://floq:floq@localhost:5432/floq?sslmode=disable"
+const defaultDSN = "postgres://floq:floq@localhost:5432/floq?sslmode=disable"
+
+// dsn returns the integration-test database connection string. It honours
+// TEST_DATABASE_URL when set (e.g. to point at a postgres on an alternate
+// port when 5432 is taken), falling back to the default local instance.
+func dsn() string {
+	if v := os.Getenv("TEST_DATABASE_URL"); v != "" {
+		return v
+	}
+	return defaultDSN
+}
 
 // TestDB returns a connection pool for integration tests.
 // The pool is closed automatically when the test finishes.
 func TestDB(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	pool, err := pgxpool.New(context.Background(), dsn)
+	pool, err := pgxpool.New(context.Background(), dsn())
 	require.NoError(t, err, "connect to test database")
 	t.Cleanup(func() { pool.Close() })
 	return pool

--- a/backend/migrations/033_onec_integration.down.sql
+++ b/backend/migrations/033_onec_integration.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS onec_credentials;
+DROP TABLE IF EXISTS onec_sync_records;

--- a/backend/migrations/033_onec_integration.up.sql
+++ b/backend/migrations/033_onec_integration.up.sql
@@ -1,0 +1,47 @@
+-- 1C integration: inbound/outbound sync ledger + per-user credentials.
+--
+-- onec_sync_records is the idempotency ledger. Every 1C event received via
+-- webhook (and every action Floq pushes back, later) lands here exactly once.
+-- The UNIQUE (user_id, external_id, external_type) constraint is the dedup
+-- backbone: a replayed webhook hits the conflict and becomes a no-op instead
+-- of double-applying. payload_hash lets a future reconciliation notice that
+-- the same 1C object arrived with changed content.
+--
+-- Status/direction/kind are TEXT + CHECK (same convention as pending_replies
+-- and audit_log) rather than pg ENUMs — cheaper to evolve as the event
+-- vocabulary grows.
+CREATE TABLE onec_sync_records (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    external_id   TEXT NOT NULL,
+    external_type TEXT NOT NULL,
+    direction     TEXT NOT NULL,
+    kind          TEXT NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'received',
+    payload_hash  TEXT NOT NULL DEFAULT '',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT onec_sync_direction_check CHECK (direction IN ('inbound', 'outbound')),
+    CONSTRAINT onec_sync_status_check    CHECK (status IN ('received', 'processed', 'error')),
+    CONSTRAINT onec_sync_kind_check      CHECK (kind IN ('payment', 'counterparty_created', 'order_status', 'shipment')),
+    CONSTRAINT onec_sync_external_id_nonempty   CHECK (length(btrim(external_id)) > 0),
+    CONSTRAINT onec_sync_external_type_nonempty CHECK (length(btrim(external_type)) > 0),
+    CONSTRAINT onec_sync_dedup UNIQUE (user_id, external_id, external_type)
+);
+
+-- Primary read pattern: recent sync activity for a user, newest first.
+CREATE INDEX idx_onec_sync_user_created ON onec_sync_records (user_id, created_at DESC);
+
+-- Per-user 1C connection + secrets, isolated from user_settings so the
+-- webhook secret and 1C credentials live apart from channel/AI config and
+-- can be masked/rotated independently. One configuration per user.
+CREATE TABLE onec_credentials (
+    user_id        UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    base_url       TEXT NOT NULL DEFAULT '',
+    auth_type      TEXT NOT NULL DEFAULT 'basic',
+    auth_secret    TEXT NOT NULL DEFAULT '',
+    webhook_secret TEXT NOT NULL DEFAULT '',
+    is_active      BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT onec_credentials_auth_type_check CHECK (auth_type IN ('basic', 'token'))
+);

--- a/backend/migrations/033_onec_integration.up.sql
+++ b/backend/migrations/033_onec_integration.up.sql
@@ -11,7 +11,7 @@
 -- and audit_log) rather than pg ENUMs — cheaper to evolve as the event
 -- vocabulary grows.
 CREATE TABLE onec_sync_records (
-    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    id            UUID PRIMARY KEY,
     user_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     external_id   TEXT NOT NULL,
     external_type TEXT NOT NULL,
@@ -21,7 +21,10 @@ CREATE TABLE onec_sync_records (
     payload_hash  TEXT NOT NULL DEFAULT '',
     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT onec_sync_direction_check CHECK (direction IN ('inbound', 'outbound')),
-    CONSTRAINT onec_sync_status_check    CHECK (status IN ('received', 'processed', 'error')),
+    -- Only 'received' for now (#106). 'processed'/'error' arrive with the
+    -- mapping lifecycle in #107 via a follow-up migration — not pre-seeded
+    -- here to avoid an unused-state CHECK.
+    CONSTRAINT onec_sync_status_check    CHECK (status IN ('received')),
     CONSTRAINT onec_sync_kind_check      CHECK (kind IN ('payment', 'counterparty_created', 'order_status', 'shipment')),
     CONSTRAINT onec_sync_external_id_nonempty   CHECK (length(btrim(external_id)) > 0),
     CONSTRAINT onec_sync_external_type_nonempty CHECK (length(btrim(external_type)) > 0),
@@ -34,6 +37,10 @@ CREATE INDEX idx_onec_sync_user_created ON onec_sync_records (user_id, created_a
 -- Per-user 1C connection + secrets, isolated from user_settings so the
 -- webhook secret and 1C credentials live apart from channel/AI config and
 -- can be masked/rotated independently. One configuration per user.
+--
+-- webhook_secret MUST be a high-entropy random token (generated server-side
+-- in #110, never a user-chosen string): it is the sole credential
+-- authenticating inbound 1C webhooks, looked up directly in the index below.
 CREATE TABLE onec_credentials (
     user_id        UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
     base_url       TEXT NOT NULL DEFAULT '',
@@ -45,3 +52,10 @@ CREATE TABLE onec_credentials (
     updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT onec_credentials_auth_type_check CHECK (auth_type IN ('basic', 'token'))
 );
+
+-- The webhook secret resolves the tenant on every inbound call, so it must be
+-- globally unique (a collision would let one tenant's event hit another's
+-- data) and indexed (avoid a full scan per webhook). Partial: the empty
+-- default is "not configured" and must not collide across users.
+CREATE UNIQUE INDEX idx_onec_credentials_webhook_secret
+    ON onec_credentials (webhook_secret) WHERE webhook_secret <> '';


### PR DESCRIPTION
Первый PR серии интеграции с 1С. Приём webhook-событий из 1С с идемпотентным дедупом — фундамент под маппинг (#107), исходящий клиент (#108) и сверку (#109).

## Что сделано
- Новый bounded context `internal/integrations/onec` (Clean Architecture: domain → usecase → repository → handler).
- **Domain**: typed enum `EventKind` (payment / counterparty_created / order_status / shipment), VO `ExternalEvent`, entity `SyncRecord` — инварианты через фабрики `NewXxx`, доменные ошибки через `errors.Is`.
- **Миграция 033**: `onec_sync_records` (дедуп `UNIQUE (user_id, external_id, external_type)`) + `onec_credentials` (секреты изолированы от `user_settings`, partial UNIQUE на `webhook_secret`).
- **Webhook** `POST /api/integrations/onec/webhook` — публичный (1С не выдаёт JWT), аутентификация по per-user секрету (`X-Onec-Secret`) с резолвом тенанта; реплеи идемпотентны (200); body-cap → 413; невалидный payload → 400.
- **Payload drift**: повторное событие с изменённым содержимым не теряется молча — логируется.

## Безопасность
- Дедуп по `(user_id, external_id, external_type)`; реплей — no-op.
- `webhook_secret` глобально уникален (partial index) — нет кросс-тенантной коллизии; lookup индексирован.
- Параметризованный SQL, глобальный `JSONBodyCap`, изоляция секретов.

## Тесты (TDD, RED→GREEN)
- Domain: 96% (table-driven по EventKind/ExternalEvent/SyncRecord).
- Repository (integration): дедуп, per-user scope, drift, резолв секрета.
- Usecase (unit): идемпотентность, drift, ошибки.
- Handler (unit): 200/400/401/413, secret-middleware, end-to-end через RegisterRoutes.
- Пакет onec: 87.5% (integration).

## Ревью
Пройдено независимое ревью (TDD 9 / DDD 10 / CA 9), все замечания устранены отдельными RED→GREEN парами.

Closes #106
Refs #105