### PR TITLE
feat(onec): configurable 1C mapping + event application (#107)

### DIFF
--- a/backend/cmd/server/adapters.go
+++ b/backend/cmd/server/adapters.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/daniil/floq/internal/ai"
 	"github.com/daniil/floq/internal/chat"
 	"github.com/daniil/floq/internal/db"
 	"github.com/daniil/floq/internal/inbox"
+	"github.com/daniil/floq/internal/integrations/onec"
 	"github.com/daniil/floq/internal/leads"
 	leadsdomain "github.com/daniil/floq/internal/leads/domain"
 	"github.com/daniil/floq/internal/outbound"
@@ -533,7 +535,6 @@ func (s *sqlBackfillSource) ProspectsForBackfill(ctx context.Context) ([]leads.P
 	return out, rows.Err()
 }
 
-
 // pendingReplyCounterAdapter bridges inbox.PendingReplyRepository to
 // leads.PendingReplyCounter so the leads inbox-list view can render
 // the badge count without the leads context importing the inbox
@@ -581,3 +582,90 @@ func (a *inboxEmailSenderAdapter) SendEmail(ctx context.Context, userID uuid.UUI
 // Compile-time check that the adapter satisfies inbox.EmailSender so
 // signature drift on the port breaks the build at the wiring edge.
 var _ inbox.EmailSender = (*inboxEmailSenderAdapter)(nil)
+
+// --- 1C EventApplier adapter (onec → leads/prospects boundary) ---
+//
+// Implements onec.EventApplier so the onec context never imports leads or
+// prospects directly. Each handler resolves the Floq entity by the
+// counterparty email extracted from the 1C payload. Actions that target an
+// existing entity (payment/order/shipment) no-op when no lead matches or when
+// the lead's state machine forbids the transition — surfaced as a log line, not
+// an error, since a 1C webhook must not be failed for a benign mismatch.
+// counterparty-created upserts a prospect.
+type onecApplierAdapter struct {
+	leadsRepo   *leads.Repository
+	leadsUC     *leads.UseCase
+	prospectsUC *prospects.UseCase
+	logger      *slog.Logger
+}
+
+func newOnecApplierAdapter(leadsRepo *leads.Repository, leadsUC *leads.UseCase, prospectsUC *prospects.UseCase, logger *slog.Logger) *onecApplierAdapter {
+	return &onecApplierAdapter{leadsRepo: leadsRepo, leadsUC: leadsUC, prospectsUC: prospectsUC, logger: logger}
+}
+
+// HandlePayment: counterparty paid → close the matching lead.
+func (a *onecApplierAdapter) HandlePayment(ctx context.Context, userID uuid.UUID, email string) error {
+	return a.moveLeadByEmail(ctx, userID, email, leadsdomain.StatusClosed)
+}
+
+// HandleOrderStatus: order moved → mark the lead as in active conversation.
+func (a *onecApplierAdapter) HandleOrderStatus(ctx context.Context, userID uuid.UUID, email string) error {
+	return a.moveLeadByEmail(ctx, userID, email, leadsdomain.StatusInConversation)
+}
+
+// HandleShipment: goods shipped → flag the lead for follow-up.
+func (a *onecApplierAdapter) HandleShipment(ctx context.Context, userID uuid.UUID, email string) error {
+	return a.moveLeadByEmail(ctx, userID, email, leadsdomain.StatusFollowup)
+}
+
+// moveLeadByEmail transitions the lead matched by email to target, skipping
+// benignly when there is no match or the transition is illegal for the lead's
+// current state.
+func (a *onecApplierAdapter) moveLeadByEmail(ctx context.Context, userID uuid.UUID, email string, target leadsdomain.LeadStatus) error {
+	if email == "" {
+		return nil
+	}
+	lead, err := a.leadsRepo.GetLeadByEmailAddress(ctx, userID, email)
+	if err != nil {
+		return err
+	}
+	if lead == nil {
+		a.logger.Info("onec: no lead for counterparty email; action skipped", "target", target.String())
+		return nil
+	}
+	if !lead.Status.CanTransitionTo(target) {
+		a.logger.Info("onec: lead transition not allowed; action skipped",
+			"lead_id", lead.ID, "from", lead.Status.String(), "to", target.String())
+		return nil
+	}
+	return a.leadsUC.UpdateStatus(ctx, lead.ID, target.String())
+}
+
+// HandleCounterpartyCreated upserts a prospect for a new 1C counterparty. An
+// existing prospect (matched by email) is left untouched; a missing name falls
+// back to the email so the prospect invariant (non-empty name) holds.
+func (a *onecApplierAdapter) HandleCounterpartyCreated(ctx context.Context, userID uuid.UUID, email, name, company string) error {
+	if email == "" {
+		return nil
+	}
+	existing, err := a.prospectsUC.FindByEmail(ctx, userID, email)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		return nil
+	}
+	if name == "" {
+		name = email
+	}
+	_, err = a.prospectsUC.CreateProspect(ctx, prospects.CreateProspectInput{
+		UserID:  userID,
+		Name:    name,
+		Company: company,
+		Email:   email,
+	})
+	return err
+}
+
+// Compile-time check that the adapter satisfies onec.EventApplier.
+var _ onec.EventApplier = (*onecApplierAdapter)(nil)

--- a/backend/cmd/server/adapters.go
+++ b/backend/cmd/server/adapters.go
@@ -592,20 +592,34 @@ var _ inbox.EmailSender = (*inboxEmailSenderAdapter)(nil)
 // the lead's state machine forbids the transition — surfaced as a log line, not
 // an error, since a 1C webhook must not be failed for a benign mismatch.
 // counterparty-created upserts a prospect.
+//
+// Dependencies are narrow interfaces (not concrete *leads/*prospects types) so
+// the routing/transition logic is unit-testable with fakes.
+type onecLeadLookup interface {
+	GetLeadByEmailAddress(ctx context.Context, userID uuid.UUID, email string) (*leadsdomain.Lead, error)
+}
+type onecLeadMover interface {
+	UpdateStatus(ctx context.Context, id uuid.UUID, status string) error
+}
+type onecProspectStore interface {
+	FindByEmail(ctx context.Context, userID uuid.UUID, email string) (*prospectsdomain.Prospect, error)
+	CreateProspect(ctx context.Context, input prospects.CreateProspectInput) (*prospectsdomain.Prospect, error)
+}
+
 type onecApplierAdapter struct {
-	leadsRepo   *leads.Repository
-	leadsUC     *leads.UseCase
-	prospectsUC *prospects.UseCase
-	logger      *slog.Logger
+	leadLookup onecLeadLookup
+	leadMover  onecLeadMover
+	prospects  onecProspectStore
+	logger     *slog.Logger
 }
 
-func newOnecApplierAdapter(leadsRepo *leads.Repository, leadsUC *leads.UseCase, prospectsUC *prospects.UseCase, logger *slog.Logger) *onecApplierAdapter {
-	return &onecApplierAdapter{leadsRepo: leadsRepo, leadsUC: leadsUC, prospectsUC: prospectsUC, logger: logger}
+func newOnecApplierAdapter(leadLookup onecLeadLookup, leadMover onecLeadMover, prospectStore onecProspectStore, logger *slog.Logger) *onecApplierAdapter {
+	return &onecApplierAdapter{leadLookup: leadLookup, leadMover: leadMover, prospects: prospectStore, logger: logger}
 }
 
-// HandlePayment: counterparty paid → close the matching lead.
+// HandlePayment: counterparty paid → the deal is won.
 func (a *onecApplierAdapter) HandlePayment(ctx context.Context, userID uuid.UUID, email string) error {
-	return a.moveLeadByEmail(ctx, userID, email, leadsdomain.StatusClosed)
+	return a.moveLeadByEmail(ctx, userID, email, leadsdomain.StatusWon)
 }
 
 // HandleOrderStatus: order moved → mark the lead as in active conversation.
@@ -625,7 +639,7 @@ func (a *onecApplierAdapter) moveLeadByEmail(ctx context.Context, userID uuid.UU
 	if email == "" {
 		return nil
 	}
-	lead, err := a.leadsRepo.GetLeadByEmailAddress(ctx, userID, email)
+	lead, err := a.leadLookup.GetLeadByEmailAddress(ctx, userID, email)
 	if err != nil {
 		return err
 	}
@@ -638,7 +652,7 @@ func (a *onecApplierAdapter) moveLeadByEmail(ctx context.Context, userID uuid.UU
 			"lead_id", lead.ID, "from", lead.Status.String(), "to", target.String())
 		return nil
 	}
-	return a.leadsUC.UpdateStatus(ctx, lead.ID, target.String())
+	return a.leadMover.UpdateStatus(ctx, lead.ID, target.String())
 }
 
 // HandleCounterpartyCreated upserts a prospect for a new 1C counterparty. An
@@ -648,7 +662,7 @@ func (a *onecApplierAdapter) HandleCounterpartyCreated(ctx context.Context, user
 	if email == "" {
 		return nil
 	}
-	existing, err := a.prospectsUC.FindByEmail(ctx, userID, email)
+	existing, err := a.prospects.FindByEmail(ctx, userID, email)
 	if err != nil {
 		return err
 	}
@@ -658,7 +672,7 @@ func (a *onecApplierAdapter) HandleCounterpartyCreated(ctx context.Context, user
 	if name == "" {
 		name = email
 	}
-	_, err = a.prospectsUC.CreateProspect(ctx, prospects.CreateProspectInput{
+	_, err = a.prospects.CreateProspect(ctx, prospects.CreateProspectInput{
 		UserID:  userID,
 		Name:    name,
 		Company: company,

--- a/backend/cmd/server/adapters_test.go
+++ b/backend/cmd/server/adapters_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	leadsdomain "github.com/daniil/floq/internal/leads/domain"
+	"github.com/daniil/floq/internal/prospects"
+	prospectsdomain "github.com/daniil/floq/internal/prospects/domain"
+	"github.com/google/uuid"
+)
+
+type fakeLeadLookup struct {
+	lead *leadsdomain.Lead
+	err  error
+}
+
+func (f *fakeLeadLookup) GetLeadByEmailAddress(_ context.Context, _ uuid.UUID, _ string) (*leadsdomain.Lead, error) {
+	return f.lead, f.err
+}
+
+type fakeLeadMover struct {
+	calls  int
+	id     uuid.UUID
+	status string
+	err    error
+}
+
+func (f *fakeLeadMover) UpdateStatus(_ context.Context, id uuid.UUID, status string) error {
+	f.calls++
+	f.id, f.status = id, status
+	return f.err
+}
+
+type fakeProspects struct {
+	existing   *prospectsdomain.Prospect
+	created    *prospects.CreateProspectInput
+	createErr  error
+	createCall int
+}
+
+func (f *fakeProspects) FindByEmail(_ context.Context, _ uuid.UUID, _ string) (*prospectsdomain.Prospect, error) {
+	return f.existing, nil
+}
+
+func (f *fakeProspects) CreateProspect(_ context.Context, input prospects.CreateProspectInput) (*prospectsdomain.Prospect, error) {
+	f.createCall++
+	f.created = &input
+	return &prospectsdomain.Prospect{}, f.createErr
+}
+
+func quietLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func leadWith(status leadsdomain.LeadStatus) *leadsdomain.Lead {
+	return &leadsdomain.Lead{ID: uuid.New(), Status: status}
+}
+
+func TestOnecApplier_HandlePayment(t *testing.T) {
+	tests := []struct {
+		name       string
+		email      string
+		lead       *leadsdomain.Lead
+		wantMoved  bool
+		wantStatus string
+	}{
+		{"qualified lead → won", "a@b.ru", leadWith(leadsdomain.StatusQualified), true, "won"},
+		{"new lead can't go to won → skip", "a@b.ru", leadWith(leadsdomain.StatusNew), false, ""},
+		{"no lead → skip", "a@b.ru", nil, false, ""},
+		{"empty email → skip", "", leadWith(leadsdomain.StatusQualified), false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mover := &fakeLeadMover{}
+			a := newOnecApplierAdapter(&fakeLeadLookup{lead: tt.lead}, mover, &fakeProspects{}, quietLogger())
+
+			if err := a.HandlePayment(context.Background(), uuid.New(), tt.email); err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if tt.wantMoved && mover.calls != 1 {
+				t.Fatalf("expected UpdateStatus call, got %d", mover.calls)
+			}
+			if !tt.wantMoved && mover.calls != 0 {
+				t.Fatalf("expected no transition, got %d calls", mover.calls)
+			}
+			if tt.wantMoved && mover.status != tt.wantStatus {
+				t.Errorf("status = %q, want %q", mover.status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestOnecApplier_TransitionTargets(t *testing.T) {
+	// From in_conversation, both followup (shipment) and won (payment) are legal;
+	// order_status keeps in_conversation (a self-transition is not legal, so it
+	// skips). Verifies each handler picks the right target.
+	tests := []struct {
+		name   string
+		invoke func(a *onecApplierAdapter) error
+		from   leadsdomain.LeadStatus
+		want   string
+		moved  bool
+	}{
+		{"shipment→followup", func(a *onecApplierAdapter) error {
+			return a.HandleShipment(context.Background(), uuid.New(), "a@b.ru")
+		}, leadsdomain.StatusInConversation, "followup", true},
+		{"order→in_conversation from qualified", func(a *onecApplierAdapter) error {
+			return a.HandleOrderStatus(context.Background(), uuid.New(), "a@b.ru")
+		}, leadsdomain.StatusQualified, "in_conversation", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mover := &fakeLeadMover{}
+			a := newOnecApplierAdapter(&fakeLeadLookup{lead: leadWith(tt.from)}, mover, &fakeProspects{}, quietLogger())
+			if err := tt.invoke(a); err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if tt.moved && (mover.calls != 1 || mover.status != tt.want) {
+				t.Fatalf("calls=%d status=%q, want 1/%q", mover.calls, mover.status, tt.want)
+			}
+		})
+	}
+}
+
+func TestOnecApplier_HandleCounterpartyCreated(t *testing.T) {
+	t.Run("new → creates prospect", func(t *testing.T) {
+		ps := &fakeProspects{existing: nil}
+		a := newOnecApplierAdapter(&fakeLeadLookup{}, &fakeLeadMover{}, ps, quietLogger())
+
+		err := a.HandleCounterpartyCreated(context.Background(), uuid.New(), "a@b.ru", "ООО Тест", "Тест")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if ps.createCall != 1 {
+			t.Fatalf("expected CreateProspect, got %d", ps.createCall)
+		}
+		if ps.created.Name != "ООО Тест" || ps.created.Email != "a@b.ru" {
+			t.Errorf("created with wrong fields: %+v", ps.created)
+		}
+	})
+
+	t.Run("missing name falls back to email", func(t *testing.T) {
+		ps := &fakeProspects{existing: nil}
+		a := newOnecApplierAdapter(&fakeLeadLookup{}, &fakeLeadMover{}, ps, quietLogger())
+
+		_ = a.HandleCounterpartyCreated(context.Background(), uuid.New(), "a@b.ru", "", "")
+		if ps.created.Name != "a@b.ru" {
+			t.Errorf("name = %q, want email fallback", ps.created.Name)
+		}
+	})
+
+	t.Run("existing prospect → no create", func(t *testing.T) {
+		ps := &fakeProspects{existing: &prospectsdomain.Prospect{ID: uuid.New()}}
+		a := newOnecApplierAdapter(&fakeLeadLookup{}, &fakeLeadMover{}, ps, quietLogger())
+
+		_ = a.HandleCounterpartyCreated(context.Background(), uuid.New(), "a@b.ru", "N", "C")
+		if ps.createCall != 0 {
+			t.Error("must not create when prospect already exists")
+		}
+	})
+
+	t.Run("empty email → skip", func(t *testing.T) {
+		ps := &fakeProspects{}
+		a := newOnecApplierAdapter(&fakeLeadLookup{}, &fakeLeadMover{}, ps, quietLogger())
+
+		_ = a.HandleCounterpartyCreated(context.Background(), uuid.New(), "", "N", "C")
+		if ps.createCall != 0 {
+			t.Error("empty email must skip")
+		}
+	})
+}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -228,9 +228,16 @@ func main() {
 	// Auth (public)
 	auth.RegisterRoutes(r, authHandler)
 
-	// 1C inbound webhook (public — authenticated by per-user secret, not JWT)
+	// 1C inbound webhook (public — authenticated by per-user secret, not JWT).
+	// Mapping resolves event kinds + counterparty fields; the applier routes
+	// mapped events to leads/prospects via a cross-context adapter.
 	onecRepo := onec.NewRepository(pool)
-	onec.RegisterRoutes(r, onec.NewHandler(onec.NewUseCase(onecRepo, onec.WithLogger(slog.Default()))), onecRepo)
+	onecApplier := newOnecApplierAdapter(leadsRepo, leadsUC, prospectsUC, slog.Default())
+	onecUC := onec.NewUseCase(onecRepo,
+		onec.WithMapping(onecRepo),
+		onec.WithApplier(onecApplier),
+		onec.WithLogger(slog.Default()))
+	onec.RegisterRoutes(r, onec.NewHandler(onecUC), onecRepo)
 
 	// Protected routes
 	r.Group(func(r chi.Router) {

--- a/backend/internal/integrations/onec/domain/mapping.go
+++ b/backend/internal/integrations/onec/domain/mapping.go
@@ -1,0 +1,69 @@
+package domain
+
+import (
+	"errors"
+
+	"github.com/google/uuid"
+)
+
+// Mapping domain errors.
+var (
+	ErrNoRules               = errors.New("onec: mapping config needs at least one rule")
+	ErrDuplicateExternalType = errors.New("onec: duplicate external type in mapping rules")
+)
+
+// MappingRule maps one 1C document type onto a canonical EventKind, plus where
+// in the raw payload to find the counterparty's email — the key Floq uses to
+// link the event to an existing lead/prospect. This is what makes the
+// integration configuration-agnostic: a УТ install and an ERP install can send
+// different ExternalType strings that both map to EventKindPayment.
+type MappingRule struct {
+	ExternalType string    // 1C document/object type, e.g. "Документ.ОплатаПокупателя"
+	Kind         EventKind // canonical Floq event
+	EmailField   string    // JSON key in payload holding the counterparty email (optional)
+}
+
+// MappingConfig is a user's full set of 1C→Floq mapping rules. Built and
+// validated through NewMappingConfig; rules are unique by ExternalType so
+// resolution is unambiguous.
+type MappingConfig struct {
+	UserID uuid.UUID
+	Rules  []MappingRule
+}
+
+// NewMappingConfig validates and constructs a MappingConfig. It requires a
+// non-nil user, at least one rule, and each rule to carry a non-empty external
+// type and a valid kind, with no duplicate external types.
+func NewMappingConfig(userID uuid.UUID, rules []MappingRule) (*MappingConfig, error) {
+	if userID == uuid.Nil {
+		return nil, ErrNilUser
+	}
+	if len(rules) == 0 {
+		return nil, ErrNoRules
+	}
+	seen := make(map[string]struct{}, len(rules))
+	for _, r := range rules {
+		if r.ExternalType == "" {
+			return nil, ErrEmptyExternalType
+		}
+		if !r.Kind.IsValid() {
+			return nil, ErrInvalidEventKind
+		}
+		if _, dup := seen[r.ExternalType]; dup {
+			return nil, ErrDuplicateExternalType
+		}
+		seen[r.ExternalType] = struct{}{}
+	}
+	return &MappingConfig{UserID: userID, Rules: rules}, nil
+}
+
+// Resolve returns the rule for a 1C external type, or ok=false when no rule
+// matches (the event is then ignored as unmapped).
+func (c *MappingConfig) Resolve(externalType string) (MappingRule, bool) {
+	for _, r := range c.Rules {
+		if r.ExternalType == externalType {
+			return r, true
+		}
+	}
+	return MappingRule{}, false
+}

--- a/backend/internal/integrations/onec/domain/mapping.go
+++ b/backend/internal/integrations/onec/domain/mapping.go
@@ -20,7 +20,9 @@ var (
 type MappingRule struct {
 	ExternalType string    // 1C document/object type, e.g. "Документ.ОплатаПокупателя"
 	Kind         EventKind // canonical Floq event
-	EmailField   string    // JSON key in payload holding the counterparty email (optional)
+	EmailField   string    // JSON key in payload holding the counterparty email (match key)
+	NameField    string    // JSON key holding the counterparty name (for counterparty upsert)
+	CompanyField string    // JSON key holding the counterparty company (optional)
 }
 
 // MappingConfig is a user's full set of 1C→Floq mapping rules. Built and

--- a/backend/internal/integrations/onec/domain/mapping_test.go
+++ b/backend/internal/integrations/onec/domain/mapping_test.go
@@ -1,0 +1,84 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func rule(extType string, kind EventKind) MappingRule {
+	return MappingRule{ExternalType: extType, Kind: kind, EmailField: "counterparty_email"}
+}
+
+func TestNewMappingConfig(t *testing.T) {
+	user := uuid.New()
+	tests := []struct {
+		name    string
+		userID  uuid.UUID
+		rules   []MappingRule
+		wantErr error
+	}{
+		{
+			name:   "valid",
+			userID: user,
+			rules: []MappingRule{
+				rule("Документ.ОплатаПокупателя", EventKindPayment),
+				rule("Справочник.Контрагенты", EventKindCounterpartyCreated),
+			},
+			wantErr: nil,
+		},
+		{"nil user", uuid.Nil, []MappingRule{rule("Документ.Оплата", EventKindPayment)}, ErrNilUser},
+		{"no rules", user, nil, ErrNoRules},
+		{"empty external type", user, []MappingRule{rule("", EventKindPayment)}, ErrEmptyExternalType},
+		{"invalid kind", user, []MappingRule{rule("Документ", EventKind("bad"))}, ErrInvalidEventKind},
+		{
+			name:   "duplicate external type",
+			userID: user,
+			rules: []MappingRule{
+				rule("Документ.Оплата", EventKindPayment),
+				rule("Документ.Оплata", EventKindShipment), // note: different string
+				rule("Документ.Оплата", EventKindShipment), // duplicate of first
+			},
+			wantErr: ErrDuplicateExternalType,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := NewMappingConfig(tt.userID, tt.rules)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil && cfg == nil {
+				t.Fatal("expected non-nil config")
+			}
+		})
+	}
+}
+
+func TestMappingConfig_Resolve(t *testing.T) {
+	user := uuid.New()
+	cfg, err := NewMappingConfig(user, []MappingRule{
+		rule("Документ.ОплатаПокупателя", EventKindPayment),
+		rule("Справочник.Контрагенты", EventKindCounterpartyCreated),
+	})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	t.Run("known type resolves", func(t *testing.T) {
+		r, ok := cfg.Resolve("Документ.ОплатаПокупателя")
+		if !ok {
+			t.Fatal("expected match")
+		}
+		if r.Kind != EventKindPayment {
+			t.Fatalf("kind = %q, want payment", r.Kind)
+		}
+	})
+
+	t.Run("unknown type does not resolve", func(t *testing.T) {
+		if _, ok := cfg.Resolve("Документ.Неизвестный"); ok {
+			t.Fatal("unknown external type must not resolve")
+		}
+	})
+}

--- a/backend/internal/integrations/onec/handler.go
+++ b/backend/internal/integrations/onec/handler.go
@@ -64,20 +64,26 @@ func (h *Handler) Webhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	kind, err := domain.ParseEventKind(req.Kind)
-	if err != nil {
-		http.Error(w, "invalid event kind", http.StatusBadRequest)
+	res, err := h.uc.ProcessInboundEvent(r.Context(), userID, RawInboundEvent{
+		ExternalID:   req.ExternalID,
+		ExternalType: req.ExternalType,
+		Kind:         req.Kind,
+		Payload:      req.Payload,
+	})
+	switch {
+	case err == nil:
+		// ok
+	case errors.Is(err, ErrUnresolvableKind):
+		// External type isn't in the user's mapping and no kind was given —
+		// Floq can't classify the event.
+		http.Error(w, "unmapped event: no kind and no mapping rule", http.StatusUnprocessableEntity)
 		return
-	}
-
-	ev, err := domain.NewExternalEvent(req.ExternalID, req.ExternalType, kind, req.Payload)
-	if err != nil {
+	case errors.Is(err, domain.ErrInvalidEventKind),
+		errors.Is(err, domain.ErrEmptyExternalID),
+		errors.Is(err, domain.ErrEmptyExternalType):
 		http.Error(w, "invalid event", http.StatusBadRequest)
 		return
-	}
-
-	res, err := h.uc.ProcessInboundEvent(r.Context(), userID, ev)
-	if err != nil {
+	default:
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/backend/internal/integrations/onec/handler_test.go
+++ b/backend/internal/integrations/onec/handler_test.go
@@ -209,6 +209,27 @@ func TestRegisterRoutes_EndToEnd(t *testing.T) {
 	})
 }
 
+// An event with no kind whose external type isn't mapped can't be classified →
+// 422 (so 1C surfaces it as unprocessable rather than retrying forever).
+func TestWebhook_UnmappedNoKindReturns422(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	mapping := &fakeMapping{err: onec.ErrMappingNotFound} // no active mapping
+	h := onec.NewHandler(onec.NewUseCase(store, onec.WithMapping(mapping)))
+
+	body := `{"external_id":"X-1","external_type":"Документ.Неизвестный","payload":{}}`
+	req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(body))
+	req = req.WithContext(httputil.WithUserID(req.Context(), uuid.New()))
+	rec := httptest.NewRecorder()
+	h.Webhook(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if store.calls != 0 {
+		t.Error("unclassifiable event must not be recorded")
+	}
+}
+
 // Oversized JSON body under JSONBodyCap must yield 413, not 400 — the public
 // webhook is the only unauthenticated-by-JWT route and must reject large
 // bodies with the right status.

--- a/backend/internal/integrations/onec/mapping_repository.go
+++ b/backend/internal/integrations/onec/mapping_repository.go
@@ -19,6 +19,8 @@ type mappingRuleDTO struct {
 	ExternalType string `json:"external_type"`
 	Kind         string `json:"kind"`
 	EmailField   string `json:"email_field"`
+	NameField    string `json:"name_field,omitempty"`
+	CompanyField string `json:"company_field,omitempty"`
 }
 
 // SaveMappingConfig upserts a user's mapping rules (one config per user). The
@@ -30,6 +32,8 @@ func (r *Repository) SaveMappingConfig(ctx context.Context, cfg *domain.MappingC
 			ExternalType: rule.ExternalType,
 			Kind:         rule.Kind.String(),
 			EmailField:   rule.EmailField,
+			NameField:    rule.NameField,
+			CompanyField: rule.CompanyField,
 		}
 	}
 	raw, err := json.Marshal(dtos)
@@ -69,7 +73,13 @@ func (r *Repository) GetMappingConfig(ctx context.Context, userID uuid.UUID) (*d
 		if err != nil {
 			return nil, err
 		}
-		rules[i] = domain.MappingRule{ExternalType: d.ExternalType, Kind: kind, EmailField: d.EmailField}
+		rules[i] = domain.MappingRule{
+			ExternalType: d.ExternalType,
+			Kind:         kind,
+			EmailField:   d.EmailField,
+			NameField:    d.NameField,
+			CompanyField: d.CompanyField,
+		}
 	}
 	return domain.NewMappingConfig(userID, rules)
 }

--- a/backend/internal/integrations/onec/mapping_repository.go
+++ b/backend/internal/integrations/onec/mapping_repository.go
@@ -49,13 +49,26 @@ func (r *Repository) SaveMappingConfig(ctx context.Context, cfg *domain.MappingC
 	return err
 }
 
-// GetMappingConfig loads and reconstructs a user's mapping config, re-validating
-// invariants through the domain factory. Returns ErrMappingNotFound when the
-// user has no config.
+// GetMappingConfig loads and reconstructs a user's mapping config regardless of
+// active state (for the settings UI). Returns ErrMappingNotFound when absent.
 func (r *Repository) GetMappingConfig(ctx context.Context, userID uuid.UUID) (*domain.MappingConfig, error) {
+	return r.loadMappingConfig(ctx, userID, false)
+}
+
+// GetActiveMappingConfig loads a user's config only when is_active = TRUE, so an
+// inactive config disables application. Returns ErrMappingNotFound otherwise.
+// This is the MappingStore method the inbound flow uses.
+func (r *Repository) GetActiveMappingConfig(ctx context.Context, userID uuid.UUID) (*domain.MappingConfig, error) {
+	return r.loadMappingConfig(ctx, userID, true)
+}
+
+func (r *Repository) loadMappingConfig(ctx context.Context, userID uuid.UUID, activeOnly bool) (*domain.MappingConfig, error) {
+	query := `SELECT rules FROM onec_mapping_configs WHERE user_id = $1`
+	if activeOnly {
+		query += ` AND is_active = TRUE`
+	}
 	var raw []byte
-	err := r.pool.QueryRow(ctx,
-		`SELECT rules FROM onec_mapping_configs WHERE user_id = $1`, userID).Scan(&raw)
+	err := r.pool.QueryRow(ctx, query, userID).Scan(&raw)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrMappingNotFound
 	}

--- a/backend/internal/integrations/onec/mapping_repository.go
+++ b/backend/internal/integrations/onec/mapping_repository.go
@@ -1,0 +1,75 @@
+package onec
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// ErrMappingNotFound is returned when a user has no stored mapping config.
+var ErrMappingNotFound = errors.New("onec: mapping config not found")
+
+// mappingRuleDTO is the JSON serialization shape for a rule. Kept separate from
+// domain.MappingRule so the domain stays free of storage/json concerns.
+type mappingRuleDTO struct {
+	ExternalType string `json:"external_type"`
+	Kind         string `json:"kind"`
+	EmailField   string `json:"email_field"`
+}
+
+// SaveMappingConfig upserts a user's mapping rules (one config per user). The
+// rules are stored as a jsonb array; isActive gates whether mapping is applied.
+func (r *Repository) SaveMappingConfig(ctx context.Context, cfg *domain.MappingConfig, isActive bool) error {
+	dtos := make([]mappingRuleDTO, len(cfg.Rules))
+	for i, rule := range cfg.Rules {
+		dtos[i] = mappingRuleDTO{
+			ExternalType: rule.ExternalType,
+			Kind:         rule.Kind.String(),
+			EmailField:   rule.EmailField,
+		}
+	}
+	raw, err := json.Marshal(dtos)
+	if err != nil {
+		return err
+	}
+	_, err = r.pool.Exec(ctx, `
+		INSERT INTO onec_mapping_configs (user_id, rules, is_active, updated_at)
+		VALUES ($1, $2, $3, NOW())
+		ON CONFLICT (user_id) DO UPDATE
+			SET rules = EXCLUDED.rules, is_active = EXCLUDED.is_active, updated_at = NOW()`,
+		cfg.UserID, raw, isActive)
+	return err
+}
+
+// GetMappingConfig loads and reconstructs a user's mapping config, re-validating
+// invariants through the domain factory. Returns ErrMappingNotFound when the
+// user has no config.
+func (r *Repository) GetMappingConfig(ctx context.Context, userID uuid.UUID) (*domain.MappingConfig, error) {
+	var raw []byte
+	err := r.pool.QueryRow(ctx,
+		`SELECT rules FROM onec_mapping_configs WHERE user_id = $1`, userID).Scan(&raw)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrMappingNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var dtos []mappingRuleDTO
+	if err := json.Unmarshal(raw, &dtos); err != nil {
+		return nil, err
+	}
+	rules := make([]domain.MappingRule, len(dtos))
+	for i, d := range dtos {
+		kind, err := domain.ParseEventKind(d.Kind)
+		if err != nil {
+			return nil, err
+		}
+		rules[i] = domain.MappingRule{ExternalType: d.ExternalType, Kind: kind, EmailField: d.EmailField}
+	}
+	return domain.NewMappingConfig(userID, rules)
+}

--- a/backend/internal/integrations/onec/mapping_repository_integration_test.go
+++ b/backend/internal/integrations/onec/mapping_repository_integration_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+package onec_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/daniil/floq/internal/integrations/onec"
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/daniil/floq/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepository_MappingConfig_RoundTrip(t *testing.T) {
+	pool := testutil.TestDB(t)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+	user := testutil.SeedUser(t, pool)
+
+	cfg, err := domain.NewMappingConfig(user, []domain.MappingRule{
+		{ExternalType: "Документ.ОплатаПокупателя", Kind: domain.EventKindPayment, EmailField: "counterparty_email"},
+		{ExternalType: "Справочник.Контрагенты", Kind: domain.EventKindCounterpartyCreated, EmailField: "email"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, repo.SaveMappingConfig(ctx, cfg, true))
+
+	loaded, err := repo.GetMappingConfig(ctx, user)
+	require.NoError(t, err)
+	require.Equal(t, user, loaded.UserID)
+	require.Len(t, loaded.Rules, 2)
+
+	r, ok := loaded.Resolve("Документ.ОплатаПокупателя")
+	require.True(t, ok)
+	require.Equal(t, domain.EventKindPayment, r.Kind)
+	require.Equal(t, "counterparty_email", r.EmailField)
+}
+
+func TestRepository_GetMappingConfig_NotFound(t *testing.T) {
+	pool := testutil.TestDB(t)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+	user := testutil.SeedUser(t, pool)
+
+	_, err := repo.GetMappingConfig(ctx, user)
+	require.True(t, errors.Is(err, onec.ErrMappingNotFound), "got %v", err)
+}
+
+func TestRepository_SaveMappingConfig_Upsert(t *testing.T) {
+	pool := testutil.TestDB(t)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+	user := testutil.SeedUser(t, pool)
+
+	first, err := domain.NewMappingConfig(user, []domain.MappingRule{
+		{ExternalType: "Документ.Оплата", Kind: domain.EventKindPayment},
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.SaveMappingConfig(ctx, first, true))
+
+	second, err := domain.NewMappingConfig(user, []domain.MappingRule{
+		{ExternalType: "Документ.Отгрузка", Kind: domain.EventKindShipment},
+		{ExternalType: "Справочник.Контрагенты", Kind: domain.EventKindCounterpartyCreated},
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.SaveMappingConfig(ctx, second, false))
+
+	loaded, err := repo.GetMappingConfig(ctx, user)
+	require.NoError(t, err)
+	require.Len(t, loaded.Rules, 2, "upsert must replace rules, not append")
+	_, ok := loaded.Resolve("Документ.Отгрузка")
+	require.True(t, ok)
+	_, ok = loaded.Resolve("Документ.Оплата")
+	require.False(t, ok, "old rule must be gone after upsert")
+}

--- a/backend/internal/integrations/onec/mapping_repository_integration_test.go
+++ b/backend/internal/integrations/onec/mapping_repository_integration_test.go
@@ -48,6 +48,33 @@ func TestRepository_GetMappingConfig_NotFound(t *testing.T) {
 	require.True(t, errors.Is(err, onec.ErrMappingNotFound), "got %v", err)
 }
 
+func TestRepository_GetActiveMappingConfig_RespectsIsActive(t *testing.T) {
+	pool := testutil.TestDB(t)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+	user := testutil.SeedUser(t, pool)
+
+	cfg, err := domain.NewMappingConfig(user, []domain.MappingRule{
+		{ExternalType: "Документ.Оплата", Kind: domain.EventKindPayment},
+	})
+	require.NoError(t, err)
+
+	// Saved inactive → not returned by the active getter (mapping disabled).
+	require.NoError(t, repo.SaveMappingConfig(ctx, cfg, false))
+	_, err = repo.GetActiveMappingConfig(ctx, user)
+	require.True(t, errors.Is(err, onec.ErrMappingNotFound), "inactive config must not be active; got %v", err)
+
+	// The general getter still loads it (for the settings UI).
+	_, err = repo.GetMappingConfig(ctx, user)
+	require.NoError(t, err)
+
+	// Activate → now returned by the active getter.
+	require.NoError(t, repo.SaveMappingConfig(ctx, cfg, true))
+	got, err := repo.GetActiveMappingConfig(ctx, user)
+	require.NoError(t, err)
+	require.Len(t, got.Rules, 1)
+}
+
 func TestRepository_SaveMappingConfig_Upsert(t *testing.T) {
 	pool := testutil.TestDB(t)
 	repo := onec.NewRepository(pool)

--- a/backend/internal/integrations/onec/ports.go
+++ b/backend/internal/integrations/onec/ports.go
@@ -35,10 +35,11 @@ type SecretResolver interface {
 	UserIDByWebhookSecret(ctx context.Context, secret string) (uuid.UUID, bool, error)
 }
 
-// MappingStore loads a user's 1C→Floq mapping config. The postgres Repository
-// satisfies it; returns ErrMappingNotFound when the user has none.
+// MappingStore loads a user's ACTIVE 1C→Floq mapping config for application.
+// The postgres Repository satisfies it; returns ErrMappingNotFound when the
+// user has no active config (so an inactive config genuinely disables mapping).
 type MappingStore interface {
-	GetMappingConfig(ctx context.Context, userID uuid.UUID) (*domain.MappingConfig, error)
+	GetActiveMappingConfig(ctx context.Context, userID uuid.UUID) (*domain.MappingConfig, error)
 }
 
 // EventApplier performs the domain action for a resolved 1C event. Implemented

--- a/backend/internal/integrations/onec/ports.go
+++ b/backend/internal/integrations/onec/ports.go
@@ -34,3 +34,21 @@ type SecretResolver interface {
 	// secret. found=false means no match (→ 401).
 	UserIDByWebhookSecret(ctx context.Context, secret string) (uuid.UUID, bool, error)
 }
+
+// MappingStore loads a user's 1C→Floq mapping config. The postgres Repository
+// satisfies it; returns ErrMappingNotFound when the user has none.
+type MappingStore interface {
+	GetMappingConfig(ctx context.Context, userID uuid.UUID) (*domain.MappingConfig, error)
+}
+
+// EventApplier performs the domain action for a resolved 1C event. Implemented
+// by a cross-context adapter (cmd/server/adapters.go) over leads/prospects —
+// onec never imports those contexts directly. Actions that target an existing
+// entity (payment/order/shipment) no-op when the counterparty is unknown; only
+// counterparty-created upserts.
+type EventApplier interface {
+	HandlePayment(ctx context.Context, userID uuid.UUID, email string) error
+	HandleCounterpartyCreated(ctx context.Context, userID uuid.UUID, email, name, company string) error
+	HandleOrderStatus(ctx context.Context, userID uuid.UUID, email string) error
+	HandleShipment(ctx context.Context, userID uuid.UUID, email string) error
+}

--- a/backend/internal/integrations/onec/usecase.go
+++ b/backend/internal/integrations/onec/usecase.go
@@ -73,9 +73,9 @@ type ProcessResult struct {
 //     event is already durably recorded, so an apply failure is logged rather
 //     than propagated (a 1C retry would only duplicate; reconciliation re-applies).
 func (u *UseCase) ProcessInboundEvent(ctx context.Context, userID uuid.UUID, in RawInboundEvent) (ProcessResult, error) {
-	rule, hasRule := u.lookupRule(ctx, userID, in.ExternalType)
+	rule, hasRule, lookupErr := u.lookupRule(ctx, userID, in.ExternalType)
 
-	kind, err := resolveKind(in.Kind, rule, hasRule)
+	kind, err := resolveKind(in.Kind, rule, hasRule, lookupErr)
 	if err != nil {
 		return ProcessResult{}, err
 	}
@@ -106,24 +106,35 @@ func (u *UseCase) ProcessInboundEvent(ctx context.Context, userID uuid.UUID, in 
 	return ProcessResult{Deduped: !out.Inserted, PayloadDrifted: out.PayloadDrifted}, nil
 }
 
-// lookupRule resolves the mapping rule for an external type, tolerating a
-// missing/unconfigured mapping (no rule → application is skipped).
-func (u *UseCase) lookupRule(ctx context.Context, userID uuid.UUID, externalType string) (domain.MappingRule, bool) {
+// lookupRule resolves the mapping rule for an external type. A missing active
+// config (ErrMappingNotFound) is not an error — it just means no rule. Any other
+// error (transient DB failure) is returned so the caller can decide whether to
+// fail the request rather than silently treat it as "unmapped".
+func (u *UseCase) lookupRule(ctx context.Context, userID uuid.UUID, externalType string) (domain.MappingRule, bool, error) {
 	if u.mapping == nil {
-		return domain.MappingRule{}, false
+		return domain.MappingRule{}, false, nil
 	}
-	cfg, err := u.mapping.GetMappingConfig(ctx, userID)
+	cfg, err := u.mapping.GetActiveMappingConfig(ctx, userID)
+	if errors.Is(err, ErrMappingNotFound) {
+		return domain.MappingRule{}, false, nil
+	}
 	if err != nil {
-		return domain.MappingRule{}, false // not configured → no rule
+		return domain.MappingRule{}, false, err
 	}
-	return cfg.Resolve(externalType)
+	rule, ok := cfg.Resolve(externalType)
+	return rule, ok, nil
 }
 
-// resolveKind implements hybrid resolution: explicit kind wins; else the
-// mapping rule's kind; else unresolvable.
-func resolveKind(explicit string, rule domain.MappingRule, hasRule bool) (domain.EventKind, error) {
+// resolveKind implements hybrid resolution: an explicit kind always wins (so a
+// classifiable event survives a mapping outage). Otherwise the kind must come
+// from the mapping: a transient lookup error propagates (→ 500, retryable),
+// genuinely no rule → ErrUnresolvableKind (→ 422).
+func resolveKind(explicit string, rule domain.MappingRule, hasRule bool, lookupErr error) (domain.EventKind, error) {
 	if explicit != "" {
 		return domain.ParseEventKind(explicit) // invalid → ErrInvalidEventKind
+	}
+	if lookupErr != nil {
+		return "", lookupErr
 	}
 	if hasRule {
 		return rule.Kind, nil

--- a/backend/internal/integrations/onec/usecase.go
+++ b/backend/internal/integrations/onec/usecase.go
@@ -2,28 +2,51 @@ package onec
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"log/slog"
 
 	"github.com/daniil/floq/internal/integrations/onec/domain"
 	"github.com/google/uuid"
 )
 
-// UseCase orchestrates inbound 1C event handling: build a ledger record,
-// persist it idempotently, and (later, #107) apply the mapped domain action.
+// ErrUnresolvableKind is returned when an event carries no kind and no mapping
+// rule matches its external type — Floq cannot classify it, so it is rejected
+// (the handler maps this to 422) rather than recorded with an unknown kind.
+var ErrUnresolvableKind = errors.New("onec: cannot resolve event kind (no kind and no mapping rule)")
+
+// RawInboundEvent is the unparsed event as received from 1C. Kind is optional:
+// when empty it is derived from the user's mapping by ExternalType (hybrid
+// resolution); when present it wins.
+type RawInboundEvent struct {
+	ExternalID   string
+	ExternalType string
+	Kind         string
+	Payload      []byte
+}
+
+// UseCase orchestrates inbound 1C event handling: resolve the canonical kind,
+// record the event idempotently, and apply the mapped domain action.
 type UseCase struct {
-	store  SyncStore
-	logger *slog.Logger
+	store   SyncStore
+	mapping MappingStore // optional; nil → no mapping/application
+	applier EventApplier // optional; nil → record only
+	logger  *slog.Logger
 }
 
 // Option configures a UseCase.
 type Option func(*UseCase)
 
 // WithLogger sets the logger used for drift/anomaly reporting.
-func WithLogger(l *slog.Logger) Option {
-	return func(u *UseCase) { u.logger = l }
-}
+func WithLogger(l *slog.Logger) Option { return func(u *UseCase) { u.logger = l } }
 
-// NewUseCase wires the use case over a SyncStore.
+// WithMapping enables mapping-based kind resolution and email extraction.
+func WithMapping(m MappingStore) Option { return func(u *UseCase) { u.mapping = m } }
+
+// WithApplier enables applying mapped events to domain actions.
+func WithApplier(a EventApplier) Option { return func(u *UseCase) { u.applier = a } }
+
+// NewUseCase wires the use case over a SyncStore and optional collaborators.
 func NewUseCase(store SyncStore, opts ...Option) *UseCase {
 	u := &UseCase{store: store, logger: slog.Default()}
 	for _, opt := range opts {
@@ -37,17 +60,30 @@ type ProcessResult struct {
 	// Deduped is true when the event was already seen and this call was a
 	// no-op — the webhook handler still returns 200 for replays.
 	Deduped bool
-	// PayloadDrifted is true when a replay arrived with changed content. The
-	// event is still deduped (not re-applied), but the drift is logged so a
-	// real update is not lost without a trace.
+	// PayloadDrifted is true when a replay arrived with changed content.
 	PayloadDrifted bool
 }
 
-// ProcessInboundEvent records a validated 1C event for the given user. A
-// replay (same external id/type) is a no-op reported via Deduped. Mapping the
-// event onto a domain action (move lead, upsert prospect) is out of scope here
-// and handled in #107 — this step only guarantees idempotent capture.
-func (u *UseCase) ProcessInboundEvent(ctx context.Context, userID uuid.UUID, ev *domain.ExternalEvent) (ProcessResult, error) {
+// ProcessInboundEvent resolves, records, and applies one 1C event for a user.
+//
+//  1. Resolve the canonical kind: explicit Kind wins; otherwise derive from the
+//     mapping rule for ExternalType. Unresolvable → ErrUnresolvableKind.
+//  2. Record idempotently (replays are no-ops, drift is logged).
+//  3. On a fresh insert, apply the mapped domain action via the applier. The
+//     event is already durably recorded, so an apply failure is logged rather
+//     than propagated (a 1C retry would only duplicate; reconciliation re-applies).
+func (u *UseCase) ProcessInboundEvent(ctx context.Context, userID uuid.UUID, in RawInboundEvent) (ProcessResult, error) {
+	rule, hasRule := u.lookupRule(ctx, userID, in.ExternalType)
+
+	kind, err := resolveKind(in.Kind, rule, hasRule)
+	if err != nil {
+		return ProcessResult{}, err
+	}
+
+	ev, err := domain.NewExternalEvent(in.ExternalID, in.ExternalType, kind, in.Payload)
+	if err != nil {
+		return ProcessResult{}, err
+	}
 	rec, err := domain.NewSyncRecord(userID, ev, domain.DirectionInbound)
 	if err != nil {
 		return ProcessResult{}, err
@@ -58,10 +94,82 @@ func (u *UseCase) ProcessInboundEvent(ctx context.Context, userID uuid.UUID, ev 
 	}
 	if out.PayloadDrifted {
 		u.logger.Warn("onec: replayed event arrived with changed payload; not re-applied",
-			"user_id", userID,
-			"external_id", ev.ExternalID,
-			"external_type", ev.ExternalType,
-			"kind", ev.Kind.String())
+			"user_id", userID, "external_id", ev.ExternalID, "external_type", ev.ExternalType, "kind", kind.String())
 	}
+
+	// Apply only on a fresh insert, and only when a rule exists (we need its
+	// fields to extract the counterparty). Replays are not re-applied.
+	if out.Inserted && hasRule && u.applier != nil {
+		u.apply(ctx, userID, kind, rule, in.Payload)
+	}
+
 	return ProcessResult{Deduped: !out.Inserted, PayloadDrifted: out.PayloadDrifted}, nil
+}
+
+// lookupRule resolves the mapping rule for an external type, tolerating a
+// missing/unconfigured mapping (no rule → application is skipped).
+func (u *UseCase) lookupRule(ctx context.Context, userID uuid.UUID, externalType string) (domain.MappingRule, bool) {
+	if u.mapping == nil {
+		return domain.MappingRule{}, false
+	}
+	cfg, err := u.mapping.GetMappingConfig(ctx, userID)
+	if err != nil {
+		return domain.MappingRule{}, false // not configured → no rule
+	}
+	return cfg.Resolve(externalType)
+}
+
+// resolveKind implements hybrid resolution: explicit kind wins; else the
+// mapping rule's kind; else unresolvable.
+func resolveKind(explicit string, rule domain.MappingRule, hasRule bool) (domain.EventKind, error) {
+	if explicit != "" {
+		return domain.ParseEventKind(explicit) // invalid → ErrInvalidEventKind
+	}
+	if hasRule {
+		return rule.Kind, nil
+	}
+	return "", ErrUnresolvableKind
+}
+
+// apply routes a recorded event to its domain action. Apply failures are logged,
+// not returned — the event is already persisted.
+func (u *UseCase) apply(ctx context.Context, userID uuid.UUID, kind domain.EventKind, rule domain.MappingRule, payload []byte) {
+	email := extractField(payload, rule.EmailField)
+	var err error
+	switch kind {
+	case domain.EventKindPayment:
+		err = u.applier.HandlePayment(ctx, userID, email)
+	case domain.EventKindCounterpartyCreated:
+		err = u.applier.HandleCounterpartyCreated(ctx, userID, email,
+			extractField(payload, rule.NameField), extractField(payload, rule.CompanyField))
+	case domain.EventKindOrderStatus:
+		err = u.applier.HandleOrderStatus(ctx, userID, email)
+	case domain.EventKindShipment:
+		err = u.applier.HandleShipment(ctx, userID, email)
+	}
+	if err != nil {
+		u.logger.Warn("onec: applying event failed; recorded but not applied",
+			"user_id", userID, "kind", kind.String(), "err", err)
+	}
+}
+
+// extractField pulls a string value from a raw JSON payload by key. Missing key,
+// empty field name, or non-string value yields "".
+func extractField(payload []byte, field string) string {
+	if field == "" {
+		return ""
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &m); err != nil {
+		return ""
+	}
+	raw, ok := m[field]
+	if !ok {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s
 }

--- a/backend/internal/integrations/onec/usecase.go
+++ b/backend/internal/integrations/onec/usecase.go
@@ -145,14 +145,14 @@ func resolveKind(explicit string, rule domain.MappingRule, hasRule bool, lookupE
 // apply routes a recorded event to its domain action. Apply failures are logged,
 // not returned — the event is already persisted.
 func (u *UseCase) apply(ctx context.Context, userID uuid.UUID, kind domain.EventKind, rule domain.MappingRule, payload []byte) {
-	email := extractField(payload, rule.EmailField)
+	fields := parseStringFields(payload)
+	email := fields[rule.EmailField]
 	var err error
 	switch kind {
 	case domain.EventKindPayment:
 		err = u.applier.HandlePayment(ctx, userID, email)
 	case domain.EventKindCounterpartyCreated:
-		err = u.applier.HandleCounterpartyCreated(ctx, userID, email,
-			extractField(payload, rule.NameField), extractField(payload, rule.CompanyField))
+		err = u.applier.HandleCounterpartyCreated(ctx, userID, email, fields[rule.NameField], fields[rule.CompanyField])
 	case domain.EventKindOrderStatus:
 		err = u.applier.HandleOrderStatus(ctx, userID, email)
 	case domain.EventKindShipment:
@@ -164,23 +164,21 @@ func (u *UseCase) apply(ctx context.Context, userID uuid.UUID, kind domain.Event
 	}
 }
 
-// extractField pulls a string value from a raw JSON payload by key. Missing key,
-// empty field name, or non-string value yields "".
-func extractField(payload []byte, field string) string {
-	if field == "" {
-		return ""
+// parseStringFields flattens a raw JSON object's string-valued top-level keys
+// into a map (parsed once per event). A non-object/invalid payload yields an
+// empty map, so every field lookup safely returns "". Empty field names in a
+// rule then resolve to "" via the missing-key path.
+func parseStringFields(payload []byte) map[string]string {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return map[string]string{}
 	}
-	var m map[string]json.RawMessage
-	if err := json.Unmarshal(payload, &m); err != nil {
-		return ""
+	out := make(map[string]string, len(raw))
+	for k, v := range raw {
+		var s string
+		if json.Unmarshal(v, &s) == nil {
+			out[k] = s
+		}
 	}
-	raw, ok := m[field]
-	if !ok {
-		return ""
-	}
-	var s string
-	if err := json.Unmarshal(raw, &s); err != nil {
-		return ""
-	}
-	return s
+	return out
 }

--- a/backend/internal/integrations/onec/usecase_test.go
+++ b/backend/internal/integrations/onec/usecase_test.go
@@ -31,7 +31,7 @@ type fakeMapping struct {
 	err error
 }
 
-func (f *fakeMapping) GetMappingConfig(_ context.Context, _ uuid.UUID) (*domain.MappingConfig, error) {
+func (f *fakeMapping) GetActiveMappingConfig(_ context.Context, _ uuid.UUID) (*domain.MappingConfig, error) {
 	return f.cfg, f.err
 }
 
@@ -141,6 +141,43 @@ func TestProcessInbound_UnresolvableKind(t *testing.T) {
 	}
 	if store.calls != 0 {
 		t.Error("unresolvable event must not record")
+	}
+}
+
+func TestProcessInbound_TransientMappingErrorPropagates(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	boom := errors.New("db pool exhausted")
+	mapping := &fakeMapping{err: boom}
+	uc := onec.NewUseCase(store, onec.WithMapping(mapping))
+
+	// No explicit kind → kind resolution needs the mapping; a transient error
+	// must propagate (→ 500, retryable), NOT collapse into ErrUnresolvableKind.
+	_, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), raw(""))
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want transient boom propagated", err)
+	}
+	if store.calls != 0 {
+		t.Error("must not record when kind unresolved due to transient error")
+	}
+}
+
+func TestProcessInbound_ExplicitKindToleratesMappingError(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	mapping := &fakeMapping{err: errors.New("boom")}
+	applier := &fakeApplier{}
+	uc := onec.NewUseCase(store, onec.WithMapping(mapping), onec.WithApplier(applier))
+
+	// Explicit kind makes the event classifiable regardless of mapping health;
+	// it is recorded, application is skipped (no rule available).
+	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), raw("payment"))
+	if err != nil {
+		t.Fatalf("explicit kind must tolerate mapping error: %v", err)
+	}
+	if store.calls != 1 || res.Deduped {
+		t.Error("event should be recorded despite mapping error")
+	}
+	if applier.action != "" {
+		t.Error("no rule available → application must be skipped")
 	}
 }
 

--- a/backend/internal/integrations/onec/usecase_test.go
+++ b/backend/internal/integrations/onec/usecase_test.go
@@ -217,6 +217,38 @@ func TestProcessInbound_Routing(t *testing.T) {
 	}
 }
 
+func TestProcessInbound_ExtractionEdgeCases(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"missing email field", `{"other":"x"}`},
+		{"non-json payload", `not json at all`},
+		{"empty object", `{}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			store := &fakeStore{inserted: true}
+			mapping := activeMapping(t, "Документ.Оплата", domain.EventKindPayment)
+			applier := &fakeApplier{}
+			uc := onec.NewUseCase(store, onec.WithMapping(mapping), onec.WithApplier(applier))
+
+			ev := onec.RawInboundEvent{ExternalID: "X", ExternalType: "Документ.Оплата", Payload: []byte(c.payload)}
+			if _, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), ev); err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			// Routing still happens; the applier just receives an empty email and
+			// is expected to no-op safely downstream.
+			if applier.action != "payment" {
+				t.Errorf("action = %q, want payment", applier.action)
+			}
+			if applier.email != "" {
+				t.Errorf("email = %q, want empty when unextractable", applier.email)
+			}
+		})
+	}
+}
+
 func TestProcessInbound_DedupSkipsApply(t *testing.T) {
 	store := &fakeStore{inserted: false} // dedup hit
 	mapping := activeMapping(t, "Документ.Оплата", domain.EventKindPayment)

--- a/backend/internal/integrations/onec/usecase_test.go
+++ b/backend/internal/integrations/onec/usecase_test.go
@@ -25,93 +25,202 @@ func (f *fakeStore) InsertSyncRecord(_ context.Context, rec *domain.SyncRecord) 
 	return onec.InsertOutcome{Inserted: f.inserted, PayloadDrifted: f.drifted}, f.err
 }
 
-func mustEvent(t *testing.T) *domain.ExternalEvent {
+// fakeMapping is an in-memory MappingStore.
+type fakeMapping struct {
+	cfg *domain.MappingConfig
+	err error
+}
+
+func (f *fakeMapping) GetMappingConfig(_ context.Context, _ uuid.UUID) (*domain.MappingConfig, error) {
+	return f.cfg, f.err
+}
+
+// fakeApplier records the action method invoked and its args.
+type fakeApplier struct {
+	action  string
+	email   string
+	name    string
+	company string
+	err     error
+}
+
+func (f *fakeApplier) HandlePayment(_ context.Context, _ uuid.UUID, email string) error {
+	f.action, f.email = "payment", email
+	return f.err
+}
+func (f *fakeApplier) HandleCounterpartyCreated(_ context.Context, _ uuid.UUID, email, name, company string) error {
+	f.action, f.email, f.name, f.company = "counterparty", email, name, company
+	return f.err
+}
+func (f *fakeApplier) HandleOrderStatus(_ context.Context, _ uuid.UUID, email string) error {
+	f.action, f.email = "order_status", email
+	return f.err
+}
+func (f *fakeApplier) HandleShipment(_ context.Context, _ uuid.UUID, email string) error {
+	f.action, f.email = "shipment", email
+	return f.err
+}
+
+func raw(kind string) onec.RawInboundEvent {
+	return onec.RawInboundEvent{
+		ExternalID:   "ОП-1",
+		ExternalType: "Документ.Оплата",
+		Kind:         kind,
+		Payload:      []byte(`{"counterparty_email":"a@b.ru","counterparty_name":"ООО Тест","counterparty_company":"Тест"}`),
+	}
+}
+
+func activeMapping(t *testing.T, extType string, kind domain.EventKind) *fakeMapping {
 	t.Helper()
-	ev, err := domain.NewExternalEvent("ОП-1", "Документ.Оплата", domain.EventKindPayment, []byte(`{"sum":1}`))
+	cfg, err := domain.NewMappingConfig(uuid.New(), []domain.MappingRule{{
+		ExternalType: extType, Kind: kind,
+		EmailField: "counterparty_email", NameField: "counterparty_name", CompanyField: "counterparty_company",
+	}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	return ev
+	return &fakeMapping{cfg: cfg}
 }
 
-func TestProcessInboundEvent_New(t *testing.T) {
+func TestProcessInbound_RecordOnly_NoMapping(t *testing.T) {
 	store := &fakeStore{inserted: true}
-	uc := onec.NewUseCase(store)
+	uc := onec.NewUseCase(store) // no mapping, no applier
 
-	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), mustEvent(t))
+	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), raw("payment"))
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	if res.Deduped {
-		t.Error("fresh event must not be marked deduped")
+		t.Error("fresh event must not be deduped")
 	}
-	if store.calls != 1 {
-		t.Errorf("store called %d times, want 1", store.calls)
-	}
-	if store.last == nil || store.last.Direction != domain.DirectionInbound {
-		t.Error("expected an inbound sync record to be stored")
+	if store.calls != 1 || store.last.Kind != domain.EventKindPayment {
+		t.Errorf("expected one payment record, got calls=%d kind=%v", store.calls, store.last.Kind)
 	}
 }
 
-func TestProcessInboundEvent_Duplicate(t *testing.T) {
-	store := &fakeStore{inserted: false} // dedup hit
-	uc := onec.NewUseCase(store)
-
-	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), mustEvent(t))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if !res.Deduped {
-		t.Error("replayed event must be marked deduped")
-	}
-}
-
-func TestProcessInboundEvent_PayloadDrift(t *testing.T) {
-	store := &fakeStore{inserted: false, drifted: true} // deduped but content changed
-	uc := onec.NewUseCase(store)
-
-	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), mustEvent(t))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if !res.Deduped {
-		t.Error("drifted replay is still deduped")
-	}
-	if !res.PayloadDrifted {
-		t.Error("drift must be surfaced in the result")
-	}
-}
-
-func TestProcessInboundEvent_NilUser(t *testing.T) {
+func TestProcessInbound_InvalidRequestKind(t *testing.T) {
 	store := &fakeStore{inserted: true}
 	uc := onec.NewUseCase(store)
 
-	_, err := uc.ProcessInboundEvent(context.Background(), uuid.Nil, mustEvent(t))
-	if !errors.Is(err, domain.ErrNilUser) {
-		t.Fatalf("err = %v, want ErrNilUser", err)
+	_, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), raw("nonsense"))
+	if !errors.Is(err, domain.ErrInvalidEventKind) {
+		t.Fatalf("err = %v, want ErrInvalidEventKind", err)
 	}
 	if store.calls != 0 {
-		t.Error("store must not be called when record construction fails")
+		t.Error("invalid kind must not record")
 	}
 }
 
-func TestProcessInboundEvent_NilEvent(t *testing.T) {
+func TestProcessInbound_HybridDerivesKindFromMapping(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	mapping := activeMapping(t, "Документ.Оплата", domain.EventKindPayment)
+	applier := &fakeApplier{}
+	uc := onec.NewUseCase(store, onec.WithMapping(mapping), onec.WithApplier(applier))
+
+	// empty kind → derived from mapping rule
+	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), raw(""))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res.Deduped {
+		t.Error("fresh event not deduped")
+	}
+	if store.last.Kind != domain.EventKindPayment {
+		t.Errorf("kind = %v, want payment (from mapping)", store.last.Kind)
+	}
+}
+
+func TestProcessInbound_UnresolvableKind(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	mapping := &fakeMapping{err: onec.ErrMappingNotFound} // no config
+	uc := onec.NewUseCase(store, onec.WithMapping(mapping))
+
+	_, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), raw("")) // no kind, no mapping
+	if !errors.Is(err, onec.ErrUnresolvableKind) {
+		t.Fatalf("err = %v, want ErrUnresolvableKind", err)
+	}
+	if store.calls != 0 {
+		t.Error("unresolvable event must not record")
+	}
+}
+
+func TestProcessInbound_Routing(t *testing.T) {
+	tests := []struct {
+		extType    string
+		kind       domain.EventKind
+		wantAction string
+	}{
+		{"Документ.Оплата", domain.EventKindPayment, "payment"},
+		{"Справочник.Контрагенты", domain.EventKindCounterpartyCreated, "counterparty"},
+		{"Документ.Заказ", domain.EventKindOrderStatus, "order_status"},
+		{"Документ.Отгрузка", domain.EventKindShipment, "shipment"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.wantAction, func(t *testing.T) {
+			store := &fakeStore{inserted: true}
+			mapping := activeMapping(t, tt.extType, tt.kind)
+			applier := &fakeApplier{}
+			uc := onec.NewUseCase(store, onec.WithMapping(mapping), onec.WithApplier(applier))
+
+			ev := onec.RawInboundEvent{
+				ExternalID: "X-1", ExternalType: tt.extType, Kind: "",
+				Payload: []byte(`{"counterparty_email":"a@b.ru","counterparty_name":"N","counterparty_company":"C"}`),
+			}
+			_, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), ev)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if applier.action != tt.wantAction {
+				t.Fatalf("action = %q, want %q", applier.action, tt.wantAction)
+			}
+			if applier.email != "a@b.ru" {
+				t.Errorf("email = %q, want extracted a@b.ru", applier.email)
+			}
+		})
+	}
+}
+
+func TestProcessInbound_DedupSkipsApply(t *testing.T) {
+	store := &fakeStore{inserted: false} // dedup hit
+	mapping := activeMapping(t, "Документ.Оплата", domain.EventKindPayment)
+	applier := &fakeApplier{}
+	uc := onec.NewUseCase(store, onec.WithMapping(mapping), onec.WithApplier(applier))
+
+	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), raw(""))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !res.Deduped {
+		t.Error("expected deduped")
+	}
+	if applier.action != "" {
+		t.Errorf("deduped replay must not re-apply, got %q", applier.action)
+	}
+}
+
+func TestProcessInbound_ApplierErrorNotFatal(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	mapping := activeMapping(t, "Документ.Оплата", domain.EventKindPayment)
+	applier := &fakeApplier{err: errors.New("downstream boom")}
+	uc := onec.NewUseCase(store, onec.WithMapping(mapping), onec.WithApplier(applier))
+
+	// applier failure is logged, not propagated — the event was recorded and a
+	// 1C retry would only duplicate. Reconciliation (#109) handles re-apply.
+	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), raw(""))
+	if err != nil {
+		t.Fatalf("applier error must not fail the webhook: %v", err)
+	}
+	if res.Deduped {
+		t.Error("event was still recorded")
+	}
+}
+
+func TestProcessInbound_NilUser(t *testing.T) {
 	store := &fakeStore{inserted: true}
 	uc := onec.NewUseCase(store)
 
-	_, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), nil)
-	if !errors.Is(err, domain.ErrNilEvent) {
-		t.Fatalf("err = %v, want ErrNilEvent", err)
-	}
-}
-
-func TestProcessInboundEvent_StoreError(t *testing.T) {
-	sentinel := errors.New("db down")
-	store := &fakeStore{err: sentinel}
-	uc := onec.NewUseCase(store)
-
-	_, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), mustEvent(t))
-	if !errors.Is(err, sentinel) {
-		t.Fatalf("err = %v, want sentinel", err)
+	_, err := uc.ProcessInboundEvent(context.Background(), uuid.Nil, raw("payment"))
+	if !errors.Is(err, domain.ErrNilUser) {
+		t.Fatalf("err = %v, want ErrNilUser", err)
 	}
 }

--- a/backend/migrations/034_onec_mapping.down.sql
+++ b/backend/migrations/034_onec_mapping.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS onec_mapping_configs;

--- a/backend/migrations/034_onec_mapping.up.sql
+++ b/backend/migrations/034_onec_mapping.up.sql
@@ -1,0 +1,13 @@
+-- Per-user 1C→Floq mapping rules. Decouples the concrete 1C configuration
+-- (which document types a given install emits) from Floq's canonical event
+-- vocabulary: each user configures how their 1C's ExternalType strings map to
+-- EventKind, plus where the counterparty email sits in the payload. Stored as
+-- jsonb (a small, read-mostly array interpreted by onec/domain.MappingConfig);
+-- one config per user, mirroring onec_credentials.
+CREATE TABLE onec_mapping_configs (
+    user_id    UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    rules      JSONB NOT NULL DEFAULT '[]'::jsonb,
+    is_active  BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
Второй PR серии интеграции с 1С. Поверх webhook (#106), уже в main; ветка перебазирована на main после релиза v0.29.0. Пересоздан вместо закрытого #112 (база удалилась при мёрже #111).

Превращает принятое событие 1С в доменное действие через **настраиваемый маппинг** — решает «конфигурация 1С неизвестна» без хардкода под УТ/ERP.

## Что сделано
- **Domain `MappingConfig`/`MappingRule`** — правила `external_type 1С → EventKind` + поля payload (email/name/company). Фабрика с валидацией (нет дублей, валидный kind), `Resolve`.
- **Миграция 034** — `onec_mapping_configs` (rules jsonb, is_active).
- **Repository** — jsonb persistence с ревалидацией через фабрику на load; `GetActiveMappingConfig` (фильтр is_active) для применения, `GetMappingConfig` (любой) для будущего UI.
- **Гибридный резолв kind** — explicit kind из запроса выигрывает; иначе выводится из маппинга по external_type. Неклассифицируемое (нет kind + нет правила) → 422; транзиентная ошибка БД → 500 (retryable), не ложный 422.
- **Применение** — `EventApplier` порт + кросс-контекстный адаптер (onec НЕ импортирует leads/prospects):
  - `payment` → лид в **Won**
  - `counterparty_created` → upsert проспекта
  - `order_status` → лид в in_conversation
  - `shipment` → лид в followup
- Действия на существующую сущность: skip+log если не найдено или переход нелегален (через domain `CanTransitionTo`); applier-ошибки не фейлят webhook (событие уже записано, сверка в #109 подхватит).

## Идемпотентность и безопасность
- Применение только при свежей вставке (replay не переприменяется).
- `is_active=false` реально отключает применение.
- Параметризованный SQL, секреты не логируются.

## Тесты (TDD, RED→GREEN)
- Domain mapping: фабрика (table-driven), Resolve.
- Repository (integration): round-trip, upsert, active-gate, not-found.
- Usecase (unit): гибридный резолв, routing (table 4 типа), dedup-skip, applier-error non-fatal, transient-error propagation, extraction edge cases.
- Adapter (unit): transition gating против реальной state-machine, name fallback, dedup, skip.
- Handler: 422 на unmapped.
- Пакет onec: ~91% (integration).

## Ревью
Два прохода независимого ревью; блокеры (is_active gate, ложный 422) и important (payment→Won, тесты адаптера) устранены. Финал: TDD 8 / DDD 8 / CA 9, вердикт «мёржить».

Closes #107
Refs #105
