### PR TITLE
feat(onec): Floq→1C outbound client — counterparty on qualification (#108)

### DIFF
--- a/backend/cmd/server/adapters.go
+++ b/backend/cmd/server/adapters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/daniil/floq/internal/ai"
 	"github.com/daniil/floq/internal/chat"
@@ -700,9 +701,20 @@ func newOnecQualificationAdapter(outbound *onec.OutboundUseCase, logger *slog.Lo
 	return &onecQualificationAdapter{outbound: outbound, logger: logger}
 }
 
+// onecPushTimeout bounds the detached counterparty push (HTTP to 1C with
+// retries) independently of the request that triggered qualification.
+const onecPushTimeout = 35 * time.Second
+
 // OnLeadQualified builds a counterparty draft from the lead and pushes it to 1C.
 // A lead with neither name nor email cannot become a counterparty — skipped.
-func (a *onecQualificationAdapter) OnLeadQualified(ctx context.Context, lead *leadsdomain.Lead) {
+//
+// The push runs in a detached goroutine on a fresh background context: it is a
+// side-effect that must not couple its latency to (or be cancelled by) the HTTP
+// request that qualified the lead. If it were on the request context, a slow 1C
+// would block the user's /qualify call, and a client disconnect would cancel the
+// push mid-flight — losing even the 'error' ledger entry the push records. A
+// push lost to process shutdown is the safety net of reconciliation (#109).
+func (a *onecQualificationAdapter) OnLeadQualified(_ context.Context, lead *leadsdomain.Lead) {
 	email := ""
 	if lead.EmailAddress != nil {
 		email = *lead.EmailAddress
@@ -712,9 +724,14 @@ func (a *onecQualificationAdapter) OnLeadQualified(ctx context.Context, lead *le
 		a.logger.Info("onec: qualified lead has no name/email; counterparty push skipped", "lead_id", lead.ID)
 		return
 	}
-	if err := a.outbound.PushCounterparty(ctx, lead.UserID, draft); err != nil {
-		a.logger.Warn("onec: counterparty push to 1C failed", "lead_id", lead.ID, "err", err)
-	}
+	userID, leadID := lead.UserID, lead.ID
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), onecPushTimeout)
+		defer cancel()
+		if err := a.outbound.PushCounterparty(ctx, userID, draft); err != nil {
+			a.logger.Warn("onec: counterparty push to 1C failed", "lead_id", leadID, "err", err)
+		}
+	}()
 }
 
 // Compile-time check that the adapter satisfies the leads observer port.

--- a/backend/cmd/server/adapters.go
+++ b/backend/cmd/server/adapters.go
@@ -692,12 +692,19 @@ var _ onec.EventApplier = (*onecApplierAdapter)(nil)
 // post-qualification side-effect without importing onec. It translates a
 // qualified Lead into a CounterpartyDraft and pushes it to 1C. All failures are
 // swallowed (logged) — qualification must never fail because the 1C push did.
+// counterpartyPusher is the narrow slice of the onec outbound use case this
+// adapter needs — kept an interface (not the concrete *onec.OutboundUseCase) so
+// the adapter's branching and goroutine can be unit-tested with a fake.
+type counterpartyPusher interface {
+	PushCounterparty(ctx context.Context, userID uuid.UUID, draft *onecdomain.CounterpartyDraft) error
+}
+
 type onecQualificationAdapter struct {
-	outbound *onec.OutboundUseCase
+	outbound counterpartyPusher
 	logger   *slog.Logger
 }
 
-func newOnecQualificationAdapter(outbound *onec.OutboundUseCase, logger *slog.Logger) *onecQualificationAdapter {
+func newOnecQualificationAdapter(outbound counterpartyPusher, logger *slog.Logger) *onecQualificationAdapter {
 	return &onecQualificationAdapter{outbound: outbound, logger: logger}
 }
 
@@ -708,12 +715,18 @@ const onecPushTimeout = 35 * time.Second
 // OnLeadQualified builds a counterparty draft from the lead and pushes it to 1C.
 // A lead with neither name nor email cannot become a counterparty — skipped.
 //
-// The push runs in a detached goroutine on a fresh background context: it is a
-// side-effect that must not couple its latency to (or be cancelled by) the HTTP
-// request that qualified the lead. If it were on the request context, a slow 1C
-// would block the user's /qualify call, and a client disconnect would cancel the
-// push mid-flight — losing even the 'error' ledger entry the push records. A
-// push lost to process shutdown is the safety net of reconciliation (#109).
+// The push runs in a detached goroutine on a fresh background context for two
+// distinct reasons:
+//
+//  1. Latency/cancellation isolation (the reason for detaching from the REQUEST
+//     context): a slow 1C must not block the user's /qualify call, and a client
+//     disconnect must not cancel the push mid-flight — which would lose even the
+//     'error' ledger entry the push records.
+//  2. Not bound to the APP-lifecycle context: like the outbound email cron
+//     goroutine, an in-flight push is not awaited on server shutdown, so a push
+//     started inside the shutdown window can be lost. This is a deliberate
+//     trade-off — outbound pushes lost to shutdown (or any gap) are exactly what
+//     the scheduled reconciliation (#109) re-applies idempotently.
 func (a *onecQualificationAdapter) OnLeadQualified(_ context.Context, lead *leadsdomain.Lead) {
 	email := ""
 	if lead.EmailAddress != nil {

--- a/backend/cmd/server/adapters.go
+++ b/backend/cmd/server/adapters.go
@@ -10,6 +10,7 @@ import (
 	"github.com/daniil/floq/internal/db"
 	"github.com/daniil/floq/internal/inbox"
 	"github.com/daniil/floq/internal/integrations/onec"
+	onecdomain "github.com/daniil/floq/internal/integrations/onec/domain"
 	"github.com/daniil/floq/internal/leads"
 	leadsdomain "github.com/daniil/floq/internal/leads/domain"
 	"github.com/daniil/floq/internal/outbound"
@@ -683,3 +684,38 @@ func (a *onecApplierAdapter) HandleCounterpartyCreated(ctx context.Context, user
 
 // Compile-time check that the adapter satisfies onec.EventApplier.
 var _ onec.EventApplier = (*onecApplierAdapter)(nil)
+
+// --- 1C qualification observer (leads → onec outbound boundary) ---
+//
+// Implements leadsdomain.QualificationObserver so the leads context can fire a
+// post-qualification side-effect without importing onec. It translates a
+// qualified Lead into a CounterpartyDraft and pushes it to 1C. All failures are
+// swallowed (logged) — qualification must never fail because the 1C push did.
+type onecQualificationAdapter struct {
+	outbound *onec.OutboundUseCase
+	logger   *slog.Logger
+}
+
+func newOnecQualificationAdapter(outbound *onec.OutboundUseCase, logger *slog.Logger) *onecQualificationAdapter {
+	return &onecQualificationAdapter{outbound: outbound, logger: logger}
+}
+
+// OnLeadQualified builds a counterparty draft from the lead and pushes it to 1C.
+// A lead with neither name nor email cannot become a counterparty — skipped.
+func (a *onecQualificationAdapter) OnLeadQualified(ctx context.Context, lead *leadsdomain.Lead) {
+	email := ""
+	if lead.EmailAddress != nil {
+		email = *lead.EmailAddress
+	}
+	draft, err := onecdomain.NewCounterpartyDraft(lead.ContactName, email, lead.Company)
+	if err != nil {
+		a.logger.Info("onec: qualified lead has no name/email; counterparty push skipped", "lead_id", lead.ID)
+		return
+	}
+	if err := a.outbound.PushCounterparty(ctx, lead.UserID, draft); err != nil {
+		a.logger.Warn("onec: counterparty push to 1C failed", "lead_id", lead.ID, "err", err)
+	}
+}
+
+// Compile-time check that the adapter satisfies the leads observer port.
+var _ leadsdomain.QualificationObserver = (*onecQualificationAdapter)(nil)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -239,6 +239,11 @@ func main() {
 		onec.WithLogger(slog.Default()))
 	onec.RegisterRoutes(r, onec.NewHandler(onecUC), onecRepo)
 
+	// Floq→1C outbound: push a counterparty when a lead is qualified. Reuses the
+	// proxy-aware shared HTTP client. Wired onto leadsUC via the observer hook.
+	onecOutboundUC := onec.NewOutboundUseCase(onecRepo, onec.NewHTTPClient(httpClient), slog.Default())
+	leadsUC.SetQualificationObserver(newOnecQualificationAdapter(onecOutboundUC, slog.Default()))
+
 	// Protected routes
 	r.Group(func(r chi.Router) {
 		r.Use(auth.AuthMiddleware(cfg.JWTSecret))

--- a/backend/cmd/server/qualification_adapter_test.go
+++ b/backend/cmd/server/qualification_adapter_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	onecdomain "github.com/daniil/floq/internal/integrations/onec/domain"
+	leadsdomain "github.com/daniil/floq/internal/leads/domain"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCounterpartyPusher struct {
+	calls     int32
+	done      chan struct{}
+	gotUserID uuid.UUID
+	gotDraft  *onecdomain.CounterpartyDraft
+}
+
+func (f *fakeCounterpartyPusher) PushCounterparty(_ context.Context, userID uuid.UUID, draft *onecdomain.CounterpartyDraft) error {
+	atomic.AddInt32(&f.calls, 1)
+	f.gotUserID = userID
+	f.gotDraft = draft
+	if f.done != nil {
+		close(f.done)
+	}
+	return nil
+}
+
+func quietAdapter(p counterpartyPusher) *onecQualificationAdapter {
+	return newOnecQualificationAdapter(p, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func TestOnecQualificationAdapter_SkipsWhenNoNameOrEmail(t *testing.T) {
+	pusher := &fakeCounterpartyPusher{}
+	adapter := quietAdapter(pusher)
+
+	// No name, no email → cannot form a counterparty draft. The skip branch is
+	// synchronous (no goroutine spawned), so the call count is settled on return.
+	adapter.OnLeadQualified(context.Background(), &leadsdomain.Lead{
+		ID:     uuid.New(),
+		UserID: uuid.New(),
+	})
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&pusher.calls), "no name/email must not push")
+}
+
+func TestOnecQualificationAdapter_PushesQualifiedLead(t *testing.T) {
+	email := "iv@ex.ru"
+	userID := uuid.New()
+	pusher := &fakeCounterpartyPusher{done: make(chan struct{})}
+	adapter := quietAdapter(pusher)
+
+	adapter.OnLeadQualified(context.Background(), &leadsdomain.Lead{
+		ID:           uuid.New(),
+		UserID:       userID,
+		ContactName:  "Иван",
+		Company:      "ООО Ромашка",
+		EmailAddress: &email,
+	})
+
+	// The push is detached into a goroutine — wait for it (bounded).
+	select {
+	case <-pusher.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("push goroutine did not run within 2s")
+	}
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&pusher.calls))
+	assert.Equal(t, userID, pusher.gotUserID)
+	require.NotNil(t, pusher.gotDraft)
+	assert.Equal(t, "Иван", pusher.gotDraft.Name)
+	assert.Equal(t, "iv@ex.ru", pusher.gotDraft.Email)
+	assert.Equal(t, "ООО Ромашка", pusher.gotDraft.Company)
+}

--- a/backend/internal/integrations/onec/client.go
+++ b/backend/internal/integrations/onec/client.go
@@ -1,0 +1,164 @@
+package onec
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+)
+
+// counterpartyCatalogPath is the OData resource for counterparties. The
+// connector is universal (the concrete 1C config is out of scope, #108), so we
+// target the standard catalog name with a JSON format hint; install-specific
+// field/catalog overrides are deferred.
+const counterpartyCatalogPath = "/Catalog_Контрагенты"
+
+// clientMaxAttempts caps retries at 3 — first try + two backoffs. Mirrors the
+// outbound email sender: enough to ride out a transient 5xx, not so many that a
+// caller blocks behind a sticky failure.
+const clientMaxAttempts = 3
+
+// clientInitialBackoff is the wait before the second attempt, doubled for the
+// third (200ms → 400ms), matching internal/outbound.
+const clientInitialBackoff = 200 * time.Millisecond
+
+// HTTPClient is the HTTP/OData implementation of OneCClient. It is stateless
+// per tenant — credentials are passed per call — so a single instance serves
+// every user.
+type HTTPClient struct {
+	httpClient *http.Client
+	backoff    time.Duration
+}
+
+// HTTPClientOption configures an HTTPClient.
+type HTTPClientOption func(*HTTPClient)
+
+// WithClientBackoff overrides the initial retry backoff (tests shrink it so the
+// retry paths don't add real wall-clock delay).
+func WithClientBackoff(d time.Duration) HTTPClientOption {
+	return func(c *HTTPClient) { c.backoff = d }
+}
+
+// NewHTTPClient builds an HTTPClient over hc (falls back to http.DefaultClient
+// when nil).
+func NewHTTPClient(hc *http.Client, opts ...HTTPClientOption) *HTTPClient {
+	c := &HTTPClient{httpClient: hc, backoff: clientInitialBackoff}
+	if c.httpClient == nil {
+		c.httpClient = http.DefaultClient
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// counterpartyPayload is the OData create body. Field names follow the standard
+// 1C catalog; the universal connector keeps them fixed (per-field mapping is
+// out of scope for #108).
+type counterpartyPayload struct {
+	Description string `json:"Description"`
+	Email       string `json:"Email"`
+	Company     string `json:"Company"`
+}
+
+// createResponse is the slice of the OData create response we read back: the
+// reference 1C assigns to the new object.
+type createResponse struct {
+	RefKey string `json:"Ref_Key"`
+}
+
+// CreateCounterparty POSTs a counterparty to 1C and returns its Ref_Key.
+// Retries transport errors and 5xx with exponential backoff; a 4xx is terminal
+// (the same body cannot succeed on retry). The error wraps the status so the
+// caller can record it in the ledger.
+func (c *HTTPClient) CreateCounterparty(ctx context.Context, creds *domain.OutboundCredentials, draft *domain.CounterpartyDraft) (string, error) {
+	body, err := json.Marshal(counterpartyPayload{
+		Description: draft.Name,
+		Email:       draft.Email,
+		Company:     draft.Company,
+	})
+	if err != nil {
+		return "", fmt.Errorf("onec: marshal counterparty: %w", err)
+	}
+	url := creds.BaseURL + counterpartyCatalogPath + "?$format=json"
+
+	var lastErr error
+	backoff := c.backoff
+	for attempt := 1; attempt <= clientMaxAttempts; attempt++ {
+		// New Request per attempt — bytes.Reader's cursor is consumed by Do.
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			return "", fmt.Errorf("onec: build request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+		setAuth(req, creds)
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("onec: create counterparty (attempt %d): %w", attempt, err)
+		} else {
+			ref, retry, hErr := handleCreateResponse(resp)
+			if hErr == nil {
+				return ref, nil
+			}
+			lastErr = hErr
+			if !retry {
+				return "", lastErr // 4xx — terminal.
+			}
+		}
+
+		if attempt < clientMaxAttempts {
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+		}
+	}
+	return "", lastErr
+}
+
+// setAuth attaches the tenant credential per its auth type.
+func setAuth(req *http.Request, creds *domain.OutboundCredentials) {
+	switch creds.AuthType {
+	case domain.AuthTypeToken:
+		req.Header.Set("Authorization", "Bearer "+creds.AuthSecret)
+	default: // basic
+		req.Header.Set("Authorization", "Basic "+creds.AuthSecret)
+	}
+}
+
+// handleCreateResponse classifies a response: (ref, _, nil) on 2xx,
+// (_, true, err) on a retryable 5xx/transport-ish status, (_, false, err) on a
+// terminal 4xx. It always drains and closes the body.
+func handleCreateResponse(resp *http.Response) (string, bool, error) {
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		var cr createResponse
+		_ = json.Unmarshal(raw, &cr) // empty/non-JSON body → empty ref, still success
+		return cr.RefKey, false, nil
+	case resp.StatusCode >= 500:
+		return "", true, fmt.Errorf("onec: 1C returned %d: %s", resp.StatusCode, snippet(raw))
+	default: // 4xx and other non-2xx
+		return "", false, fmt.Errorf("onec: 1C rejected request %d: %s", resp.StatusCode, snippet(raw))
+	}
+}
+
+// snippet trims a response body for error messages.
+func snippet(b []byte) string {
+	const max = 200
+	if len(b) > max {
+		return string(b[:max])
+	}
+	return string(b)
+}

--- a/backend/internal/integrations/onec/client_test.go
+++ b/backend/internal/integrations/onec/client_test.go
@@ -1,0 +1,127 @@
+package onec
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testCreds(t *testing.T, baseURL string, at domain.AuthType, secret string) *domain.OutboundCredentials {
+	t.Helper()
+	c, err := domain.NewOutboundCredentials(baseURL, at, secret)
+	require.NoError(t, err)
+	return c
+}
+
+func testDraft(t *testing.T) *domain.CounterpartyDraft {
+	t.Helper()
+	d, err := domain.NewCounterpartyDraft("Иван", "iv@ex.ru", "ООО Ромашка")
+	require.NoError(t, err)
+	return d
+}
+
+func fastClient() *HTTPClient {
+	return NewHTTPClient(http.DefaultClient, WithClientBackoff(time.Millisecond))
+}
+
+func TestHTTPClient_CreateCounterparty_Success(t *testing.T) {
+	var gotMethod, gotAuth, gotPath string
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotAuth, gotPath = r.Method, r.Header.Get("Authorization"), r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"Ref_Key":"ctr-123"}`))
+	}))
+	defer srv.Close()
+
+	ref, err := fastClient().CreateCounterparty(context.Background(),
+		testCreds(t, srv.URL, domain.AuthTypeBasic, "dXNlcjpwYXNz"), testDraft(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, "ctr-123", ref)
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "Basic dXNlcjpwYXNz", gotAuth)
+	assert.Contains(t, gotPath, "Контрагенты")
+	assert.Equal(t, "Иван", body["Description"])
+	assert.Equal(t, "iv@ex.ru", body["Email"])
+}
+
+func TestHTTPClient_CreateCounterparty_TokenAuth(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"Ref_Key":"x"}`))
+	}))
+	defer srv.Close()
+
+	_, err := fastClient().CreateCounterparty(context.Background(),
+		testCreds(t, srv.URL, domain.AuthTypeToken, "tok-abc"), testDraft(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer tok-abc", gotAuth)
+}
+
+func TestHTTPClient_CreateCounterparty_RetriesThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"Ref_Key":"ok"}`))
+	}))
+	defer srv.Close()
+
+	ref, err := fastClient().CreateCounterparty(context.Background(),
+		testCreds(t, srv.URL, domain.AuthTypeBasic, "s"), testDraft(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", ref)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "should retry the transient 503 exactly once")
+}
+
+func TestHTTPClient_CreateCounterparty_4xxIsTerminal(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	_, err := fastClient().CreateCounterparty(context.Background(),
+		testCreds(t, srv.URL, domain.AuthTypeBasic, "s"), testDraft(t))
+
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "4xx must not be retried")
+}
+
+func TestHTTPClient_CreateCounterparty_ExhaustsRetries(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	_, err := fastClient().CreateCounterparty(context.Background(),
+		testCreds(t, srv.URL, domain.AuthTypeBasic, "s"), testDraft(t))
+
+	require.Error(t, err)
+	assert.Equal(t, int32(clientMaxAttempts), atomic.LoadInt32(&calls), "5xx must surface after max attempts")
+}
+
+// Compile-time check that the HTTP client satisfies the port.
+var _ OneCClient = (*HTTPClient)(nil)

--- a/backend/internal/integrations/onec/domain/entity.go
+++ b/backend/internal/integrations/onec/domain/entity.go
@@ -23,6 +23,8 @@ var (
 	ErrNilEvent          = errors.New("onec: external event is required")
 	ErrInvalidSyncStatus = errors.New("onec: invalid sync status")
 	ErrEmptyCounterparty = errors.New("onec: counterparty needs at least a name or email")
+	ErrInvalidAuthType   = errors.New("onec: invalid auth type")
+	ErrEmptyBaseURL      = errors.New("onec: base url is required")
 )
 
 // EventKind is the ubiquitous-language enum of 1C events Floq reacts to.

--- a/backend/internal/integrations/onec/domain/entity.go
+++ b/backend/internal/integrations/onec/domain/entity.go
@@ -21,6 +21,8 @@ var (
 	ErrInvalidDirection  = errors.New("onec: invalid sync direction")
 	ErrNilUser           = errors.New("onec: user id is required")
 	ErrNilEvent          = errors.New("onec: external event is required")
+	ErrInvalidSyncStatus = errors.New("onec: invalid sync status")
+	ErrEmptyCounterparty = errors.New("onec: counterparty needs at least a name or email")
 )
 
 // EventKind is the ubiquitous-language enum of 1C events Floq reacts to.
@@ -72,14 +74,26 @@ func (d SyncDirection) IsValid() bool {
 	return d == DirectionInbound || d == DirectionOutbound
 }
 
-// SyncStatus is the lifecycle state of a ledger entry. #106 only ever records
-// Received (capture). The processed/error transitions arrive with the mapping
-// layer (#107) — intentionally not declared here to avoid dead states.
+// SyncStatus is the lifecycle state of a ledger entry. Inbound capture lands as
+// Received (#106). Outbound pushes to 1C (#108) record their result directly:
+// Processed on a successful POST, Error when 1C rejected/was unreachable.
 type SyncStatus string
 
 const (
-	SyncStatusReceived SyncStatus = "received" // принято, ещё не применено
+	SyncStatusReceived  SyncStatus = "received"  // принято от 1С, ещё не применено
+	SyncStatusProcessed SyncStatus = "processed" // действие успешно выполнено в 1С
+	SyncStatusError     SyncStatus = "error"     // 1С отверг/недоступен
 )
+
+// IsValid reports whether s is a known sync status.
+func (s SyncStatus) IsValid() bool {
+	switch s {
+	case SyncStatusReceived, SyncStatusProcessed, SyncStatusError:
+		return true
+	default:
+		return false
+	}
+}
 
 // ExternalEvent is a value object wrapping a single 1C event. ExternalID +
 // ExternalType form the natural dedup key (a 1C object is uniquely a

--- a/backend/internal/integrations/onec/domain/outbound.go
+++ b/backend/internal/integrations/onec/domain/outbound.go
@@ -1,0 +1,65 @@
+package domain
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// CounterpartyDraft is the value object Floq pushes to 1C to create a
+// counterparty (контрагент) when a lead is qualified. It is built from
+// Floq-side data, not from a 1C event, so it carries no external id yet —
+// 1C assigns one on creation. The factory enforces the single invariant
+// that 1C needs to identify the party: at least a name or an email.
+type CounterpartyDraft struct {
+	Name    string
+	Email   string
+	Company string
+}
+
+// NewCounterpartyDraft trims its inputs and rejects a draft that carries
+// neither a name nor an email (1C cannot create an anonymous counterparty).
+func NewCounterpartyDraft(name, email, company string) (*CounterpartyDraft, error) {
+	name = strings.TrimSpace(name)
+	email = strings.TrimSpace(email)
+	company = strings.TrimSpace(company)
+	if name == "" && email == "" {
+		return nil, ErrEmptyCounterparty
+	}
+	return &CounterpartyDraft{Name: name, Email: email, Company: company}, nil
+}
+
+// NewOutboundSyncRecord builds a ledger entry for an action Floq pushed to 1C.
+// Unlike the inbound NewSyncRecord, the dedup key is Floq-side: externalType is
+// the 1C object kind being created (e.g. "counterparty") and externalID is a
+// stable Floq identity for the source entity, so a re-qualification dedups
+// instead of creating a duplicate. The status is set by the caller to reflect
+// the POST result (Processed / Error). PayloadHash stays empty — there is no
+// inbound 1C payload on the outbound path.
+func NewOutboundSyncRecord(userID uuid.UUID, externalID, externalType string, kind EventKind, status SyncStatus) (*SyncRecord, error) {
+	if userID == uuid.Nil {
+		return nil, ErrNilUser
+	}
+	if externalID == "" {
+		return nil, ErrEmptyExternalID
+	}
+	if externalType == "" {
+		return nil, ErrEmptyExternalType
+	}
+	if !kind.IsValid() {
+		return nil, ErrInvalidEventKind
+	}
+	if !status.IsValid() {
+		return nil, ErrInvalidSyncStatus
+	}
+	return &SyncRecord{
+		ID:           uuid.New(),
+		UserID:       userID,
+		ExternalID:   externalID,
+		ExternalType: externalType,
+		Direction:    DirectionOutbound,
+		Kind:         kind,
+		Status:       status,
+		PayloadHash:  "",
+	}, nil
+}

--- a/backend/internal/integrations/onec/domain/outbound.go
+++ b/backend/internal/integrations/onec/domain/outbound.go
@@ -6,6 +6,53 @@ import (
 	"github.com/google/uuid"
 )
 
+// AuthType is how Floq authenticates outbound calls to a tenant's 1C endpoint.
+// Mirrors the onec_credentials.auth_type CHECK (basic | token).
+type AuthType string
+
+const (
+	AuthTypeBasic AuthType = "basic" // HTTP Basic (base64 user:pass in AuthSecret)
+	AuthTypeToken AuthType = "token" // Bearer token in AuthSecret
+)
+
+// IsValid reports whether a is a known auth type.
+func (a AuthType) IsValid() bool {
+	return a == AuthTypeBasic || a == AuthTypeToken
+}
+
+// ParseAuthType converts a wire string into an AuthType, rejecting unknown
+// values with ErrInvalidAuthType.
+func ParseAuthType(s string) (AuthType, error) {
+	a := AuthType(s)
+	if !a.IsValid() {
+		return "", ErrInvalidAuthType
+	}
+	return a, nil
+}
+
+// OutboundCredentials is the per-user connection Floq uses to push objects to a
+// 1C endpoint. BaseURL is the OData/HTTP-service root; AuthSecret is the opaque
+// credential interpreted per AuthType. The factory enforces a usable endpoint:
+// a non-empty base URL (trailing slash trimmed so path joins are predictable)
+// and a valid auth type.
+type OutboundCredentials struct {
+	BaseURL    string
+	AuthType   AuthType
+	AuthSecret string
+}
+
+// NewOutboundCredentials validates and normalises an outbound connection.
+func NewOutboundCredentials(baseURL string, authType AuthType, authSecret string) (*OutboundCredentials, error) {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return nil, ErrEmptyBaseURL
+	}
+	if !authType.IsValid() {
+		return nil, ErrInvalidAuthType
+	}
+	return &OutboundCredentials{BaseURL: baseURL, AuthType: authType, AuthSecret: authSecret}, nil
+}
+
 // CounterpartyDraft is the value object Floq pushes to 1C to create a
 // counterparty (контрагент) when a lead is qualified. It is built from
 // Floq-side data, not from a 1C event, so it carries no external id yet —

--- a/backend/internal/integrations/onec/domain/outbound_test.go
+++ b/backend/internal/integrations/onec/domain/outbound_test.go
@@ -1,0 +1,98 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestNewCounterpartyDraft(t *testing.T) {
+	tests := []struct {
+		name              string
+		inName            string
+		inEmail           string
+		inCompany         string
+		wantErr           error
+		wantName          string
+		wantEmail         string
+		wantCompany       string
+	}{
+		{"name and email", "Иван", "iv@ex.ru", "ООО Ромашка", nil, "Иван", "iv@ex.ru", "ООО Ромашка"},
+		{"email only", "", "iv@ex.ru", "", nil, "", "iv@ex.ru", ""},
+		{"name only", "Иван", "", "", nil, "Иван", "", ""},
+		{"trims whitespace", "  Иван  ", "  iv@ex.ru ", " ООО ", nil, "Иван", "iv@ex.ru", "ООО"},
+		{"both blank", "   ", "", "Company", ErrEmptyCounterparty, "", "", ""},
+		{"all empty", "", "", "", ErrEmptyCounterparty, "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewCounterpartyDraft(tt.inName, tt.inEmail, tt.inCompany)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr != nil {
+				return
+			}
+			if got.Name != tt.wantName || got.Email != tt.wantEmail || got.Company != tt.wantCompany {
+				t.Fatalf("draft = %+v, want name=%q email=%q company=%q", got, tt.wantName, tt.wantEmail, tt.wantCompany)
+			}
+		})
+	}
+}
+
+func TestSyncStatus_IsValid(t *testing.T) {
+	valid := []SyncStatus{SyncStatusReceived, SyncStatusProcessed, SyncStatusError}
+	for _, s := range valid {
+		if !s.IsValid() {
+			t.Errorf("SyncStatus(%q).IsValid() = false, want true", s)
+		}
+	}
+	invalid := []SyncStatus{"", "pending", "sent", "done"}
+	for _, s := range invalid {
+		if s.IsValid() {
+			t.Errorf("SyncStatus(%q).IsValid() = true, want false", s)
+		}
+	}
+}
+
+func TestNewOutboundSyncRecord(t *testing.T) {
+	user := uuid.New()
+	tests := []struct {
+		name         string
+		userID       uuid.UUID
+		externalID   string
+		externalType string
+		kind         EventKind
+		status       SyncStatus
+		wantErr      error
+	}{
+		{"valid processed", user, "prospect:iv@ex.ru", "counterparty", EventKindCounterpartyCreated, SyncStatusProcessed, nil},
+		{"valid error", user, "prospect:iv@ex.ru", "counterparty", EventKindCounterpartyCreated, SyncStatusError, nil},
+		{"nil user", uuid.Nil, "x", "counterparty", EventKindCounterpartyCreated, SyncStatusProcessed, ErrNilUser},
+		{"empty external id", user, "", "counterparty", EventKindCounterpartyCreated, SyncStatusProcessed, ErrEmptyExternalID},
+		{"empty external type", user, "x", "", EventKindCounterpartyCreated, SyncStatusProcessed, ErrEmptyExternalType},
+		{"invalid kind", user, "x", "counterparty", EventKind("bogus"), SyncStatusProcessed, ErrInvalidEventKind},
+		{"invalid status", user, "x", "counterparty", EventKindCounterpartyCreated, SyncStatus("bogus"), ErrInvalidSyncStatus},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewOutboundSyncRecord(tt.userID, tt.externalID, tt.externalType, tt.kind, tt.status)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr != nil {
+				return
+			}
+			if got.Direction != DirectionOutbound {
+				t.Errorf("Direction = %q, want outbound", got.Direction)
+			}
+			if got.Status != tt.status {
+				t.Errorf("Status = %q, want %q", got.Status, tt.status)
+			}
+			if got.ID == uuid.Nil {
+				t.Error("ID not generated")
+			}
+		})
+	}
+}

--- a/backend/internal/integrations/onec/domain/outbound_test.go
+++ b/backend/internal/integrations/onec/domain/outbound_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestNewCounterpartyDraft(t *testing.T) {
 	tests := []struct {
-		name              string
-		inName            string
-		inEmail           string
-		inCompany         string
-		wantErr           error
-		wantName          string
-		wantEmail         string
-		wantCompany       string
+		name        string
+		inName      string
+		inEmail     string
+		inCompany   string
+		wantErr     error
+		wantName    string
+		wantEmail   string
+		wantCompany string
 	}{
 		{"name and email", "Иван", "iv@ex.ru", "ООО Ромашка", nil, "Иван", "iv@ex.ru", "ООО Ромашка"},
 		{"email only", "", "iv@ex.ru", "", nil, "", "iv@ex.ru", ""},

--- a/backend/internal/integrations/onec/domain/outbound_test.go
+++ b/backend/internal/integrations/onec/domain/outbound_test.go
@@ -41,6 +41,65 @@ func TestNewCounterpartyDraft(t *testing.T) {
 	}
 }
 
+func TestParseAuthType(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    AuthType
+		wantErr error
+	}{
+		{"basic", AuthTypeBasic, nil},
+		{"token", AuthTypeToken, nil},
+		{"", "", ErrInvalidAuthType},
+		{"oauth", "", ErrInvalidAuthType},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := ParseAuthType(tt.in)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewOutboundCredentials(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseURL  string
+		authType AuthType
+		secret   string
+		wantErr  error
+		wantURL  string
+	}{
+		{"valid basic", "https://1c.example/odata", AuthTypeBasic, "dXNlcjpwYXNz", nil, "https://1c.example/odata"},
+		{"valid token", "https://1c.example/odata", AuthTypeToken, "tok", nil, "https://1c.example/odata"},
+		{"trims trailing slash", "https://1c.example/odata/", AuthTypeBasic, "s", nil, "https://1c.example/odata"},
+		{"empty base url", "", AuthTypeBasic, "s", ErrEmptyBaseURL, ""},
+		{"blank base url", "   ", AuthTypeBasic, "s", ErrEmptyBaseURL, ""},
+		{"invalid auth type", "https://1c.example", AuthType("oauth"), "s", ErrInvalidAuthType, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewOutboundCredentials(tt.baseURL, tt.authType, tt.secret)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr != nil {
+				return
+			}
+			if got.BaseURL != tt.wantURL {
+				t.Errorf("BaseURL = %q, want %q", got.BaseURL, tt.wantURL)
+			}
+			if got.AuthType != tt.authType || got.AuthSecret != tt.secret {
+				t.Errorf("got %+v", got)
+			}
+		})
+	}
+}
+
 func TestSyncStatus_IsValid(t *testing.T) {
 	valid := []SyncStatus{SyncStatusReceived, SyncStatusProcessed, SyncStatusError}
 	for _, s := range valid {

--- a/backend/internal/integrations/onec/outbound_repository.go
+++ b/backend/internal/integrations/onec/outbound_repository.go
@@ -1,0 +1,68 @@
+package onec
+
+import (
+	"context"
+	"errors"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// ErrOutboundNotConfigured is returned when a user has no usable outbound 1C
+// connection — no credentials row, inactive, or a blank base URL. The outbound
+// flow treats it as "1C push disabled for this tenant", not a hard error.
+var ErrOutboundNotConfigured = errors.New("onec: outbound 1C not configured")
+
+// GetOutboundCredentials loads a user's outbound connection. Only an active row
+// with a non-empty base URL is usable; anything else yields
+// ErrOutboundNotConfigured. The domain factory validates/normalises the result.
+func (r *Repository) GetOutboundCredentials(ctx context.Context, userID uuid.UUID) (*domain.OutboundCredentials, error) {
+	var baseURL, authType, authSecret string
+	err := r.pool.QueryRow(ctx, `
+		SELECT base_url, auth_type, auth_secret FROM onec_credentials
+		WHERE user_id = $1 AND is_active = TRUE AND base_url <> ''`, userID).
+		Scan(&baseURL, &authType, &authSecret)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrOutboundNotConfigured
+	}
+	if err != nil {
+		return nil, err
+	}
+	at, err := domain.ParseAuthType(authType)
+	if err != nil {
+		return nil, err
+	}
+	return domain.NewOutboundCredentials(baseURL, at, authSecret)
+}
+
+// UpsertOutboundRecord writes the ledger entry for an outbound push, keyed on
+// the dedup tuple. A retry of the same (user, external_id, external_type) flips
+// the stored status/kind in place rather than inserting a duplicate, so an
+// earlier 'error' becomes 'processed' once a later push succeeds.
+func (r *Repository) UpsertOutboundRecord(ctx context.Context, rec *domain.SyncRecord) error {
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO onec_sync_records
+			(id, user_id, external_id, external_type, direction, kind, status, payload_hash)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (user_id, external_id, external_type) DO UPDATE
+			SET status = EXCLUDED.status, kind = EXCLUDED.kind`,
+		rec.ID, rec.UserID, rec.ExternalID, rec.ExternalType,
+		string(rec.Direction), string(rec.Kind), string(rec.Status), rec.PayloadHash)
+	return err
+}
+
+// OutboundProcessedExists reports whether the object was already pushed to 1C
+// successfully (a 'processed' record for the dedup key). The outbound flow uses
+// it to skip re-creating a counterparty; an 'error' record does NOT count, so a
+// failed push is retried on the next trigger.
+func (r *Repository) OutboundProcessedExists(ctx context.Context, userID uuid.UUID, externalID, externalType string) (bool, error) {
+	var exists bool
+	err := r.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM onec_sync_records
+			WHERE user_id = $1 AND external_id = $2 AND external_type = $3
+			  AND direction = 'outbound' AND status = 'processed'
+		)`, userID, externalID, externalType).Scan(&exists)
+	return exists, err
+}

--- a/backend/internal/integrations/onec/outbound_repository.go
+++ b/backend/internal/integrations/onec/outbound_repository.go
@@ -46,7 +46,7 @@ func (r *Repository) UpsertOutboundRecord(ctx context.Context, rec *domain.SyncR
 			(id, user_id, external_id, external_type, direction, kind, status, payload_hash)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT (user_id, external_id, external_type) DO UPDATE
-			SET status = EXCLUDED.status, kind = EXCLUDED.kind`,
+			SET status = EXCLUDED.status, kind = EXCLUDED.kind, direction = EXCLUDED.direction`,
 		rec.ID, rec.UserID, rec.ExternalID, rec.ExternalType,
 		string(rec.Direction), string(rec.Kind), string(rec.Status), rec.PayloadHash)
 	return err

--- a/backend/internal/integrations/onec/outbound_repository_integration_test.go
+++ b/backend/internal/integrations/onec/outbound_repository_integration_test.go
@@ -1,0 +1,98 @@
+//go:build integration
+
+package onec_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/daniil/floq/internal/integrations/onec"
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/daniil/floq/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepository_GetOutboundCredentials(t *testing.T) {
+	pool := testutil.TestDB(t)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+
+	t.Run("active with base url", func(t *testing.T) {
+		user := testutil.SeedUser(t, pool)
+		_, err := pool.Exec(ctx, `
+			INSERT INTO onec_credentials (user_id, base_url, auth_type, auth_secret, is_active)
+			VALUES ($1, 'https://1c.example/odata/', 'token', 'tok-123', TRUE)`, user)
+		require.NoError(t, err)
+
+		creds, err := repo.GetOutboundCredentials(ctx, user)
+		require.NoError(t, err)
+		assert.Equal(t, "https://1c.example/odata", creds.BaseURL) // trailing slash trimmed by VO
+		assert.Equal(t, domain.AuthTypeToken, creds.AuthType)
+		assert.Equal(t, "tok-123", creds.AuthSecret)
+	})
+
+	t.Run("no row", func(t *testing.T) {
+		user := testutil.SeedUser(t, pool)
+		_, err := repo.GetOutboundCredentials(ctx, user)
+		assert.True(t, errors.Is(err, onec.ErrOutboundNotConfigured), "got %v", err)
+	})
+
+	t.Run("inactive", func(t *testing.T) {
+		user := testutil.SeedUser(t, pool)
+		_, err := pool.Exec(ctx, `
+			INSERT INTO onec_credentials (user_id, base_url, auth_type, is_active)
+			VALUES ($1, 'https://1c.example', 'basic', FALSE)`, user)
+		require.NoError(t, err)
+
+		_, err = repo.GetOutboundCredentials(ctx, user)
+		assert.True(t, errors.Is(err, onec.ErrOutboundNotConfigured), "inactive must not resolve; got %v", err)
+	})
+
+	t.Run("active but base url empty", func(t *testing.T) {
+		user := testutil.SeedUser(t, pool)
+		_, err := pool.Exec(ctx, `
+			INSERT INTO onec_credentials (user_id, base_url, auth_type, is_active)
+			VALUES ($1, '', 'basic', TRUE)`, user)
+		require.NoError(t, err)
+
+		_, err = repo.GetOutboundCredentials(ctx, user)
+		assert.True(t, errors.Is(err, onec.ErrOutboundNotConfigured), "empty base_url is not usable; got %v", err)
+	})
+}
+
+func TestRepository_OutboundRecord_UpsertAndExists(t *testing.T) {
+	pool := testutil.TestDB(t)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+	user := testutil.SeedUser(t, pool)
+
+	const extID, extType = "prospect:iv@ex.ru", "counterparty"
+
+	// First push failed → error record. Not "processed" yet.
+	errRec, err := domain.NewOutboundSyncRecord(user, extID, extType, domain.EventKindCounterpartyCreated, domain.SyncStatusError)
+	require.NoError(t, err)
+	require.NoError(t, repo.UpsertOutboundRecord(ctx, errRec))
+
+	exists, err := repo.OutboundProcessedExists(ctx, user, extID, extType)
+	require.NoError(t, err)
+	assert.False(t, exists, "an error record must not count as already-processed")
+
+	// Retry succeeded → upsert flips the same row to processed.
+	okRec, err := domain.NewOutboundSyncRecord(user, extID, extType, domain.EventKindCounterpartyCreated, domain.SyncStatusProcessed)
+	require.NoError(t, err)
+	require.NoError(t, repo.UpsertOutboundRecord(ctx, okRec))
+
+	exists, err = repo.OutboundProcessedExists(ctx, user, extID, extType)
+	require.NoError(t, err)
+	assert.True(t, exists, "after a successful push the record must read as processed")
+
+	// Dedup: still exactly one row for the key.
+	var count int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM onec_sync_records
+		WHERE user_id = $1 AND external_id = $2 AND external_type = $3`,
+		user, extID, extType).Scan(&count))
+	assert.Equal(t, 1, count, "upsert must not create a duplicate row")
+}

--- a/backend/internal/integrations/onec/outbound_usecase.go
+++ b/backend/internal/integrations/onec/outbound_usecase.go
@@ -71,9 +71,10 @@ func (u *OutboundUseCase) PushCounterparty(ctx context.Context, userID uuid.UUID
 		return fmt.Errorf("onec: build outbound record: %w", err)
 	}
 	if upErr := u.store.UpsertOutboundRecord(ctx, rec); upErr != nil {
-		// Recording failed too — surface the more actionable error.
+		// Recording failed too — keep both in the chain so errors.Is sees each.
 		if pushErr != nil {
-			return fmt.Errorf("onec: 1C push failed (%v) and ledger write failed: %w", pushErr, upErr)
+			return errors.Join(fmt.Errorf("onec: push counterparty: %w", pushErr),
+				fmt.Errorf("onec: ledger write: %w", upErr))
 		}
 		return fmt.Errorf("onec: ledger write: %w", upErr)
 	}

--- a/backend/internal/integrations/onec/outbound_usecase.go
+++ b/backend/internal/integrations/onec/outbound_usecase.go
@@ -1,0 +1,90 @@
+package onec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/google/uuid"
+)
+
+// counterpartyExternalType is the dedup external_type for counterparties Floq
+// creates in 1C. Paired with a Floq-side external_id (the lead's email, else
+// name), it keeps re-qualifying the same lead from creating duplicates.
+const counterpartyExternalType = "counterparty"
+
+// OutboundUseCase pushes Floq-side objects to a tenant's 1C endpoint. It is the
+// Floq→1C direction, mirroring the inbound UseCase. Failures are recorded in the
+// sync ledger so reconciliation (#109) and the settings UI can see them.
+type OutboundUseCase struct {
+	store  OutboundStore
+	client OneCClient
+	logger *slog.Logger
+}
+
+// NewOutboundUseCase wires the outbound use case. A nil logger falls back to the
+// default so callers (and tests) need not supply one.
+func NewOutboundUseCase(store OutboundStore, client OneCClient, logger *slog.Logger) *OutboundUseCase {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &OutboundUseCase{store: store, client: client, logger: logger}
+}
+
+// PushCounterparty creates a counterparty in the user's 1C from a qualified
+// lead. It is idempotent (a counterparty already pushed is skipped) and a no-op
+// when the tenant has not configured an outbound endpoint. A 1C failure is
+// recorded as an 'error' ledger entry and returned for observability — callers
+// triggered by a qualification must NOT let that error fail their flow.
+func (u *OutboundUseCase) PushCounterparty(ctx context.Context, userID uuid.UUID, draft *domain.CounterpartyDraft) error {
+	creds, err := u.store.GetOutboundCredentials(ctx, userID)
+	if errors.Is(err, ErrOutboundNotConfigured) {
+		return nil // outbound disabled for this tenant — silent no-op
+	}
+	if err != nil {
+		return fmt.Errorf("onec: resolve outbound credentials: %w", err)
+	}
+
+	externalID := draft.Email
+	if externalID == "" {
+		externalID = draft.Name
+	}
+
+	already, err := u.store.OutboundProcessedExists(ctx, userID, externalID, counterpartyExternalType)
+	if err != nil {
+		return fmt.Errorf("onec: dedup check: %w", err)
+	}
+	if already {
+		return nil // counterparty already created in 1C
+	}
+
+	ref, pushErr := u.client.CreateCounterparty(ctx, creds, draft)
+	status := domain.SyncStatusProcessed
+	if pushErr != nil {
+		status = domain.SyncStatusError
+	}
+
+	rec, err := domain.NewOutboundSyncRecord(userID, externalID, counterpartyExternalType, domain.EventKindCounterpartyCreated, status)
+	if err != nil {
+		return fmt.Errorf("onec: build outbound record: %w", err)
+	}
+	if upErr := u.store.UpsertOutboundRecord(ctx, rec); upErr != nil {
+		// Recording failed too — surface the more actionable error.
+		if pushErr != nil {
+			return fmt.Errorf("onec: 1C push failed (%v) and ledger write failed: %w", pushErr, upErr)
+		}
+		return fmt.Errorf("onec: ledger write: %w", upErr)
+	}
+
+	if pushErr != nil {
+		u.logger.Warn("onec: counterparty push to 1C failed; recorded as error",
+			"user_id", userID, "external_id", externalID, "err", pushErr)
+		return fmt.Errorf("onec: push counterparty: %w", pushErr)
+	}
+
+	u.logger.Info("onec: counterparty created in 1C",
+		"user_id", userID, "external_id", externalID, "ref", ref)
+	return nil
+}

--- a/backend/internal/integrations/onec/outbound_usecase_test.go
+++ b/backend/internal/integrations/onec/outbound_usecase_test.go
@@ -109,6 +109,20 @@ func TestPushCounterparty_OneCError_RecordedNotFatal(t *testing.T) {
 	assert.Equal(t, domain.SyncStatusError, store.upserted[0].Status)
 }
 
+func TestPushCounterparty_PushAndLedgerBothFail_JoinsErrors(t *testing.T) {
+	pushErr := errors.New("1C down")
+	ledgerErr := errors.New("db down")
+	store := &fakeOutboundStore{creds: okCreds(t), upsertErr: ledgerErr}
+	client := &fakeClient{err: pushErr}
+	uc := NewOutboundUseCase(store, client, nil)
+
+	err := uc.PushCounterparty(context.Background(), uuid.New(), draftWithEmail(t))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, pushErr, "push error must stay in the chain")
+	assert.ErrorIs(t, err, ledgerErr, "ledger error must stay in the chain")
+}
+
 func TestPushCounterparty_CredsLookupError_Propagates(t *testing.T) {
 	store := &fakeOutboundStore{credsErr: errors.New("db boom")}
 	client := &fakeClient{}

--- a/backend/internal/integrations/onec/outbound_usecase_test.go
+++ b/backend/internal/integrations/onec/outbound_usecase_test.go
@@ -1,0 +1,121 @@
+package onec
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeOutboundStore struct {
+	creds        *domain.OutboundCredentials
+	credsErr     error
+	processed    bool
+	processedErr error
+	upserted     []*domain.SyncRecord
+	upsertErr    error
+}
+
+func (f *fakeOutboundStore) GetOutboundCredentials(_ context.Context, _ uuid.UUID) (*domain.OutboundCredentials, error) {
+	return f.creds, f.credsErr
+}
+func (f *fakeOutboundStore) OutboundProcessedExists(_ context.Context, _ uuid.UUID, _, _ string) (bool, error) {
+	return f.processed, f.processedErr
+}
+func (f *fakeOutboundStore) UpsertOutboundRecord(_ context.Context, rec *domain.SyncRecord) error {
+	f.upserted = append(f.upserted, rec)
+	return f.upsertErr
+}
+
+type fakeClient struct {
+	ref   string
+	err   error
+	calls int
+}
+
+func (f *fakeClient) CreateCounterparty(_ context.Context, _ *domain.OutboundCredentials, _ *domain.CounterpartyDraft) (string, error) {
+	f.calls++
+	return f.ref, f.err
+}
+
+func okCreds(t *testing.T) *domain.OutboundCredentials {
+	t.Helper()
+	c, err := domain.NewOutboundCredentials("https://1c.example", domain.AuthTypeBasic, "s")
+	require.NoError(t, err)
+	return c
+}
+
+func draftWithEmail(t *testing.T) *domain.CounterpartyDraft {
+	t.Helper()
+	d, err := domain.NewCounterpartyDraft("Иван", "iv@ex.ru", "ООО Ромашка")
+	require.NoError(t, err)
+	return d
+}
+
+func TestPushCounterparty_Success(t *testing.T) {
+	store := &fakeOutboundStore{creds: okCreds(t)}
+	client := &fakeClient{ref: "ctr-1"}
+	uc := NewOutboundUseCase(store, client, nil)
+
+	err := uc.PushCounterparty(context.Background(), uuid.New(), draftWithEmail(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, client.calls)
+	require.Len(t, store.upserted, 1)
+	rec := store.upserted[0]
+	assert.Equal(t, domain.SyncStatusProcessed, rec.Status)
+	assert.Equal(t, domain.DirectionOutbound, rec.Direction)
+	assert.Equal(t, "iv@ex.ru", rec.ExternalID, "email is the dedup identity")
+	assert.Equal(t, "counterparty", rec.ExternalType)
+	assert.Equal(t, domain.EventKindCounterpartyCreated, rec.Kind)
+}
+
+func TestPushCounterparty_NotConfigured_NoOp(t *testing.T) {
+	store := &fakeOutboundStore{credsErr: ErrOutboundNotConfigured}
+	client := &fakeClient{}
+	uc := NewOutboundUseCase(store, client, nil)
+
+	err := uc.PushCounterparty(context.Background(), uuid.New(), draftWithEmail(t))
+
+	require.NoError(t, err, "no 1C endpoint configured is a silent no-op, not an error")
+	assert.Equal(t, 0, client.calls, "must not call 1C when unconfigured")
+	assert.Empty(t, store.upserted, "must not write a ledger record when unconfigured")
+}
+
+func TestPushCounterparty_AlreadyProcessed_Dedup(t *testing.T) {
+	store := &fakeOutboundStore{creds: okCreds(t), processed: true}
+	client := &fakeClient{}
+	uc := NewOutboundUseCase(store, client, nil)
+
+	err := uc.PushCounterparty(context.Background(), uuid.New(), draftWithEmail(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, client.calls, "already-processed counterparty must not be re-created")
+}
+
+func TestPushCounterparty_OneCError_RecordedNotFatal(t *testing.T) {
+	store := &fakeOutboundStore{creds: okCreds(t)}
+	client := &fakeClient{err: errors.New("1C down")}
+	uc := NewOutboundUseCase(store, client, nil)
+
+	err := uc.PushCounterparty(context.Background(), uuid.New(), draftWithEmail(t))
+
+	require.Error(t, err, "the failure is surfaced for observability")
+	require.Len(t, store.upserted, 1, "the failed push must still land in the ledger")
+	assert.Equal(t, domain.SyncStatusError, store.upserted[0].Status)
+}
+
+func TestPushCounterparty_CredsLookupError_Propagates(t *testing.T) {
+	store := &fakeOutboundStore{credsErr: errors.New("db boom")}
+	client := &fakeClient{}
+	uc := NewOutboundUseCase(store, client, nil)
+
+	err := uc.PushCounterparty(context.Background(), uuid.New(), draftWithEmail(t))
+
+	require.Error(t, err, "a transient creds lookup failure is not the same as 'not configured'")
+	assert.Equal(t, 0, client.calls)
+}

--- a/backend/internal/integrations/onec/ports.go
+++ b/backend/internal/integrations/onec/ports.go
@@ -42,6 +42,15 @@ type MappingStore interface {
 	GetActiveMappingConfig(ctx context.Context, userID uuid.UUID) (*domain.MappingConfig, error)
 }
 
+// OneCClient pushes objects to a tenant's 1C endpoint. The HTTP/OData
+// implementation (client.go) satisfies it; the usecase depends on this port so
+// it can be faked in unit tests. CreateCounterparty returns the 1C-assigned
+// reference (Ref_Key) on success — empty is allowed when 1C accepts the create
+// but returns no body.
+type OneCClient interface {
+	CreateCounterparty(ctx context.Context, creds *domain.OutboundCredentials, draft *domain.CounterpartyDraft) (externalRef string, err error)
+}
+
 // EventApplier performs the domain action for a resolved 1C event. Implemented
 // by a cross-context adapter (cmd/server/adapters.go) over leads/prospects —
 // onec never imports those contexts directly. Actions that target an existing

--- a/backend/internal/integrations/onec/ports.go
+++ b/backend/internal/integrations/onec/ports.go
@@ -42,6 +42,15 @@ type MappingStore interface {
 	GetActiveMappingConfig(ctx context.Context, userID uuid.UUID) (*domain.MappingConfig, error)
 }
 
+// OutboundStore resolves a tenant's outbound connection and persists the push
+// ledger. The postgres Repository satisfies it. GetOutboundCredentials returns
+// ErrOutboundNotConfigured when the tenant has no usable 1C endpoint.
+type OutboundStore interface {
+	GetOutboundCredentials(ctx context.Context, userID uuid.UUID) (*domain.OutboundCredentials, error)
+	OutboundProcessedExists(ctx context.Context, userID uuid.UUID, externalID, externalType string) (bool, error)
+	UpsertOutboundRecord(ctx context.Context, rec *domain.SyncRecord) error
+}
+
 // OneCClient pushes objects to a tenant's 1C endpoint. The HTTP/OData
 // implementation (client.go) satisfies it; the usecase depends on this port so
 // it can be faked in unit tests. CreateCounterparty returns the 1C-assigned

--- a/backend/internal/leads/domain/ports.go
+++ b/backend/internal/leads/domain/ports.go
@@ -73,6 +73,16 @@ type Notifier interface {
 	SendAlert(ctx context.Context, leadName string, company string, message string) error
 }
 
+// QualificationObserver is notified after a lead is successfully qualified, so
+// cross-context side-effects (e.g. creating a counterparty in 1C, #108) can fire
+// without the leads context importing those modules. The implementation lives in
+// the composition root and bridges to the onec context. A nil observer disables
+// the hook. The method returns nothing on purpose: a failing side-effect must
+// never fail qualification — the observer owns its own error handling.
+type QualificationObserver interface {
+	OnLeadQualified(ctx context.Context, lead *Lead)
+}
+
 // --- Prospect suggestion (cross-channel dedup) ---
 
 // SuggestionConfidence classifies how strong the cross-channel match signal is.

--- a/backend/internal/leads/usecase.go
+++ b/backend/internal/leads/usecase.go
@@ -69,6 +69,13 @@ func (uc *UseCase) SetSender(sender domain.MessageSender) {
 	uc.sender = sender
 }
 
+// SetQualificationObserver wires the post-qualification hook after construction,
+// needed because the onec outbound use case (which the observer bridges to) is
+// built later in the composition root than the leads use case.
+func (uc *UseCase) SetQualificationObserver(o domain.QualificationObserver) {
+	uc.qualObserver = o
+}
+
 func (uc *UseCase) ListLeads(ctx context.Context, userID uuid.UUID) ([]domain.LeadWithSource, error) {
 	return uc.repo.ListLeads(ctx, userID)
 }

--- a/backend/internal/leads/usecase.go
+++ b/backend/internal/leads/usecase.go
@@ -22,6 +22,7 @@ type UseCase struct {
 	suggestionFinder domain.ProspectSuggestionFinder
 	identityReader   IdentityReader
 	pendingCounter   PendingReplyCounter
+	qualObserver     domain.QualificationObserver
 	logger           *slog.Logger
 }
 
@@ -34,6 +35,13 @@ type Option func(*UseCase)
 // adapter is built.
 func WithSuggestionFinder(f domain.ProspectSuggestionFinder) Option {
 	return func(uc *UseCase) { uc.suggestionFinder = f }
+}
+
+// WithQualificationObserver wires the post-qualification hook (issue #108).
+// Supplied from the composition root via an adapter that bridges to the onec
+// context. nil leaves the hook disabled.
+func WithQualificationObserver(o domain.QualificationObserver) Option {
+	return func(uc *UseCase) { uc.qualObserver = o }
 }
 
 // WithLogger overrides the default slog.Logger so the use case emits
@@ -170,6 +178,13 @@ func (uc *UseCase) QualifyLead(ctx context.Context, leadID uuid.UUID) (*domain.Q
 	}
 	if err := uc.repo.UpdateLeadStatus(ctx, leadID, domain.StatusQualified); err != nil {
 		return nil, err
+	}
+	lead.Status = domain.StatusQualified
+
+	// Fire the post-qualification side-effect (e.g. push a counterparty to 1C).
+	// The observer owns its errors — a failure here must not fail qualification.
+	if uc.qualObserver != nil {
+		uc.qualObserver.OnLeadQualified(ctx, lead)
 	}
 
 	return q, nil

--- a/backend/internal/leads/usecase_test.go
+++ b/backend/internal/leads/usecase_test.go
@@ -277,6 +277,54 @@ func TestQualifyLead_HappyPath(t *testing.T) {
 	assert.NotNil(t, repo.upsertedQualification)
 }
 
+type fakeQualObserver struct {
+	calls      int
+	calledWith *domain.Lead
+}
+
+func (f *fakeQualObserver) OnLeadQualified(_ context.Context, lead *domain.Lead) {
+	f.calls++
+	f.calledWith = lead
+}
+
+func TestQualifyLead_NotifiesObserver(t *testing.T) {
+	repo := newMockRepo()
+	leadID := uuid.New()
+	repo.leads[leadID] = &domain.Lead{
+		ID:          leadID,
+		UserID:      uuid.New(),
+		ContactName: "Ivan",
+		Channel:     domain.ChannelTelegram,
+		Status:      domain.StatusNew,
+	}
+	aiSvc := &mockAI{qualifyResult: &domain.Qualification{Score: 90, ProviderUsed: "test"}}
+	obs := &fakeQualObserver{}
+
+	uc := NewUseCase(repo, aiSvc, nil, WithQualificationObserver(obs))
+
+	_, err := uc.QualifyLead(context.Background(), leadID)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, obs.calls, "observer must be notified after a successful qualification")
+	require.NotNil(t, obs.calledWith)
+	assert.Equal(t, leadID, obs.calledWith.ID)
+	assert.Equal(t, domain.StatusQualified, obs.calledWith.Status, "observer sees the qualified lead")
+}
+
+func TestQualifyLead_ObserverNotCalledOnFailure(t *testing.T) {
+	repo := newMockRepo()
+	leadID := uuid.New()
+	repo.leads[leadID] = &domain.Lead{ID: leadID, ContactName: "Ivan", Channel: domain.ChannelTelegram, Status: domain.StatusNew}
+	aiSvc := &mockAI{qualifyErr: fmt.Errorf("ai down")}
+	obs := &fakeQualObserver{}
+
+	uc := NewUseCase(repo, aiSvc, nil, WithQualificationObserver(obs))
+
+	_, err := uc.QualifyLead(context.Background(), leadID)
+	require.Error(t, err)
+	assert.Equal(t, 0, obs.calls, "no qualification → no notification")
+}
+
 func TestQualifyLead_NotFound(t *testing.T) {
 	repo := newMockRepo()
 	uc := NewUseCase(repo, &mockAI{}, nil)

--- a/backend/migrations/035_onec_outbound.down.sql
+++ b/backend/migrations/035_onec_outbound.down.sql
@@ -1,0 +1,5 @@
+-- Revert to the inbound-only status CHECK. Fails if any outbound rows in a
+-- 'processed'/'error' state remain — clear them before rolling back.
+ALTER TABLE onec_sync_records DROP CONSTRAINT onec_sync_status_check;
+ALTER TABLE onec_sync_records ADD CONSTRAINT onec_sync_status_check
+    CHECK (status IN ('received'));

--- a/backend/migrations/035_onec_outbound.up.sql
+++ b/backend/migrations/035_onec_outbound.up.sql
@@ -1,0 +1,8 @@
+-- Outbound 1C pushes (#108) record their result in the same ledger as inbound
+-- capture. Migration 033 deliberately constrained status to 'received' only
+-- (inbound capture) to avoid an unused-state CHECK; the outbound lifecycle now
+-- needs the terminal states it foreshadowed: 'processed' (POST to 1C succeeded)
+-- and 'error' (1C rejected or was unreachable). Drop and re-add the CHECK.
+ALTER TABLE onec_sync_records DROP CONSTRAINT onec_sync_status_check;
+ALTER TABLE onec_sync_records ADD CONSTRAINT onec_sync_status_check
+    CHECK (status IN ('received', 'processed', 'error'));


### PR DESCRIPTION
Третий PR серии интеграции с 1С. Реализует **исходящий канал**: при квалификации лида Floq создаёт контрагента в 1С через настраиваемый OData/HTTP-эндпоинт. Универсальный контракт + мок (конкретная конфигурация 1С — out of scope).

## Что сделано
- **Domain** (`onec/domain`): `CounterpartyDraft` VO (инвариант: нужен name или email), `OutboundCredentials` VO + `AuthType` (basic/token, trim base_url), статусы `processed`/`error`, фабрика `NewOutboundSyncRecord`. Все инварианты через фабрики, доменные ошибки через `errors.Is`.
- **Миграция 035**: расширяет `onec_sync_records.status` CHECK (`+processed`, `+error`) — они и планировались в 033. Outbound переиспользует тот же ledger (`direction='outbound'`) и `onec_credentials` (`base_url`/`auth_type`/`auth_secret` уже были).
- **`OneCClient`** порт + HTTP/OData реализация: POST `Catalog_Контрагенты`, ретраи 5xx/transport (3 попытки, backoff ×2), 4xx терминально, парс `Ref_Key`. Зеркало `outbound.Sender`.
- **Repository**: `GetOutboundCredentials` (только active + непустой base_url → `ErrOutboundNotConfigured`), `UpsertOutboundRecord` (дедуп-ключ, error→processed при ретрае), `OutboundProcessedExists`.
- **Usecase `PushCounterparty`**: резолв creds → дедуп (processed уже есть → skip) → POST → запись `processed`/`error`. No-op при unconfigured; ошибка 1С → запись `error`, не фатальна.
- **Cross-context**: порт `QualificationObserver` в `leads/domain`; `QualifyLead` зовёт его после transition; адаптер в `cmd/server` (через narrow `counterpartyPusher`) мостит на onec, **detached в фоновую горутину** на отдельном context (latency-изоляция + переживание cancel). onec НЕ импортирует leads, leads НЕ импортирует onec.

## Идемпотентность и безопасность
- Дедуп по `(user_id, external_id='<email|name>', external_type='counterparty')` — ре-квалификация не плодит дублей; `error`-запись ретраится, `processed` блокирует.
- Tenant scope через `lead.UserID`; SQL параметризован; секреты не логируются.

## Тесты (TDD, RED→GREEN)
- Domain: фабрики/VO table-driven (draft, creds, auth, statuses, record).
- Client (httptest): success, basic/token auth, retry-then-success, 4xx terminal, exhaust.
- Repository (integration): creds-резолв (active/inactive/empty), upsert error→processed, дедуп single-row.
- Usecase (unit): success, unconfigured no-op, dedup, 1С-error-not-fatal, creds-lookup-error, double-error join.
- Adapter (unit, `cmd/server`): skip без name/email, detached push с проверкой draft.
- `-race` чисто. onec coverage 66.8% (domain 98.6%).

## Ревью
Два прохода независимого ревью. Финал: TDD 9 / DDD 9 / CA 8 (все оси ≥8). Important (синхронный блокирующий пуш на request-ctx) устранён detached-горутиной; minor'ы (upsert direction, errors.Join, тесты double-error + адаптера) закрыты.

Closes #108
Refs #105
