### PR TITLE
feat(onec): scheduled reconciliation safety-net for lost 1C webhooks (#109)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -239,10 +239,16 @@ func main() {
 		onec.WithLogger(slog.Default()))
 	onec.RegisterRoutes(r, onec.NewHandler(onecUC), onecRepo)
 
-	// Floq→1C outbound: push a counterparty when a lead is qualified. Reuses the
-	// proxy-aware shared HTTP client. Wired onto leadsUC via the observer hook.
-	onecOutboundUC := onec.NewOutboundUseCase(onecRepo, onec.NewHTTPClient(httpClient), slog.Default())
+	// Floq→1C outbound: one proxy-aware HTTP client serves both the counterparty
+	// write path and the reconciliation read path.
+	onecClient := onec.NewHTTPClient(httpClient)
+	onecOutboundUC := onec.NewOutboundUseCase(onecRepo, onecClient, slog.Default())
 	leadsUC.SetQualificationObserver(newOnecQualificationAdapter(onecOutboundUC, slog.Default()))
+
+	// Reconciliation safety net (#109): re-feed recent 1C events through the
+	// inbound use case to recover any webhook that was lost. Cron started below
+	// once the app-lifecycle context exists.
+	onecReconcileUC := onec.NewReconcileUseCase(onecRepo, onecClient, onecUC, slog.Default())
 
 	// Protected routes
 	r.Group(func(r chi.Router) {
@@ -288,6 +294,9 @@ func main() {
 		}
 	}()
 	log.Println("outbound email sender started (every 30s)")
+
+	// 1C reconciliation cron — recovers lost webhooks every 15 minutes, stops on ctx.
+	go onec.NewReconcileCron(onecReconcileUC, 15*time.Minute, slog.Default()).Start(ctx)
 
 	// 8. Optional: Telegram inbox bot
 	// Read token from DB first, fall back to .env

--- a/backend/internal/integrations/onec/client.go
+++ b/backend/internal/integrations/onec/client.go
@@ -27,6 +27,19 @@ const clientMaxAttempts = 3
 // third (200ms → 400ms), matching internal/outbound.
 const clientInitialBackoff = 200 * time.Millisecond
 
+// Response body read caps: a created object is a single small record; a
+// reconcile read is a bounded array (see reconcileWindow), so it gets more room
+// but is still capped to bound memory on a misbehaving endpoint.
+const (
+	maxCreateRespBytes = 1 << 20 // 1 MiB
+	maxListRespBytes   = 8 << 20 // 8 MiB
+)
+
+// reconcileWindow bounds how many recent events Floq asks 1C for per pass via
+// OData $top, so the read endpoint cannot return an unbounded backlog. A tenant
+// with more missed events than this is caught over successive passes.
+const reconcileWindow = 500
+
 // HTTPClient is the HTTP/OData implementation of OneCClient. It is stateless
 // per tenant — credentials are passed per call — so a single instance serves
 // every user.
@@ -113,7 +126,7 @@ type eventDTO struct {
 // ListEvents GETs the tenant's recent 1C events for reconciliation. Retries
 // transport errors and 5xx; a 4xx is terminal.
 func (c *HTTPClient) ListEvents(ctx context.Context, creds *domain.OutboundCredentials) ([]RawInboundEvent, error) {
-	url := creds.BaseURL + reconcileEventsPath + "?$format=json"
+	url := fmt.Sprintf("%s%s?$format=json&$top=%d", creds.BaseURL, reconcileEventsPath, reconcileWindow)
 
 	var events []RawInboundEvent
 	err := c.doRetrying(ctx, http.MethodGet, url, nil, creds, func(resp *http.Response) (bool, error) {
@@ -180,7 +193,7 @@ func (c *HTTPClient) doRetrying(ctx context.Context, method, url string, body []
 // array on 2xx. Signature mirrors handleCreateResponse.
 func handleListResponse(resp *http.Response) ([]RawInboundEvent, bool, error) {
 	defer resp.Body.Close()
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, maxListRespBytes))
 
 	switch {
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
@@ -220,7 +233,7 @@ func setAuth(req *http.Request, creds *domain.OutboundCredentials) {
 // terminal 4xx. It always drains and closes the body.
 func handleCreateResponse(resp *http.Response) (string, bool, error) {
 	defer resp.Body.Close()
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, maxCreateRespBytes))
 
 	switch {
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:

--- a/backend/internal/integrations/onec/client.go
+++ b/backend/internal/integrations/onec/client.go
@@ -87,42 +87,122 @@ func (c *HTTPClient) CreateCounterparty(ctx context.Context, creds *domain.Outbo
 	}
 	url := creds.BaseURL + counterpartyCatalogPath + "?$format=json"
 
+	var ref string
+	err = c.doRetrying(ctx, http.MethodPost, url, body, creds, func(resp *http.Response) (bool, error) {
+		r, retry, hErr := handleCreateResponse(resp)
+		ref = r
+		return retry, hErr
+	})
+	return ref, err
+}
+
+// reconcileEventsPath is the 1C HTTP-service Floq polls for recent events during
+// reconciliation. Like the write path, the concrete 1C config is out of scope —
+// the endpoint returns events already in Floq's canonical shape.
+const reconcileEventsPath = "/floq_events"
+
+// eventDTO is one event as returned by the reconcile read endpoint. Kind is
+// optional (derived from mapping when empty); Payload is the raw 1C body.
+type eventDTO struct {
+	ExternalID   string          `json:"external_id"`
+	ExternalType string          `json:"external_type"`
+	Kind         string          `json:"kind"`
+	Payload      json.RawMessage `json:"payload"`
+}
+
+// ListEvents GETs the tenant's recent 1C events for reconciliation. Retries
+// transport errors and 5xx; a 4xx is terminal.
+func (c *HTTPClient) ListEvents(ctx context.Context, creds *domain.OutboundCredentials) ([]RawInboundEvent, error) {
+	url := creds.BaseURL + reconcileEventsPath + "?$format=json"
+
+	var events []RawInboundEvent
+	err := c.doRetrying(ctx, http.MethodGet, url, nil, creds, func(resp *http.Response) (bool, error) {
+		evs, retry, hErr := handleListResponse(resp)
+		events = evs
+		return retry, hErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+// doRetrying issues method+url with creds auth, retrying transport errors and
+// 5xx with exponential backoff. handle classifies each response: it returns
+// (retry, err) — a nil err stops successfully, a non-nil err with retry=false is
+// terminal (4xx), retry=true loops until attempts are exhausted.
+func (c *HTTPClient) doRetrying(ctx context.Context, method, url string, body []byte, creds *domain.OutboundCredentials, handle func(*http.Response) (bool, error)) error {
 	var lastErr error
 	backoff := c.backoff
 	for attempt := 1; attempt <= clientMaxAttempts; attempt++ {
 		// New Request per attempt — bytes.Reader's cursor is consumed by Do.
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-		if err != nil {
-			return "", fmt.Errorf("onec: build request: %w", err)
+		var reqBody io.Reader
+		if body != nil {
+			reqBody = bytes.NewReader(body)
 		}
-		req.Header.Set("Content-Type", "application/json")
+		req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+		if err != nil {
+			return fmt.Errorf("onec: build request: %w", err)
+		}
 		req.Header.Set("Accept", "application/json")
+		if body != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
 		setAuth(req, creds)
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
-			lastErr = fmt.Errorf("onec: create counterparty (attempt %d): %w", attempt, err)
+			lastErr = fmt.Errorf("onec: %s %s (attempt %d): %w", method, url, attempt, err)
 		} else {
-			ref, retry, hErr := handleCreateResponse(resp)
+			retry, hErr := handle(resp)
 			if hErr == nil {
-				return ref, nil
+				return nil
 			}
 			lastErr = hErr
 			if !retry {
-				return "", lastErr // 4xx — terminal.
+				return lastErr // terminal (4xx)
 			}
 		}
 
 		if attempt < clientMaxAttempts {
 			select {
 			case <-ctx.Done():
-				return "", ctx.Err()
+				return ctx.Err()
 			case <-time.After(backoff):
 			}
 			backoff *= 2
 		}
 	}
-	return "", lastErr
+	return lastErr
+}
+
+// handleListResponse classifies a reconcile read response, parsing the event
+// array on 2xx. Signature mirrors handleCreateResponse.
+func handleListResponse(resp *http.Response) ([]RawInboundEvent, bool, error) {
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		var dtos []eventDTO
+		if err := json.Unmarshal(raw, &dtos); err != nil {
+			return nil, false, fmt.Errorf("onec: decode events: %w", err)
+		}
+		events := make([]RawInboundEvent, len(dtos))
+		for i, d := range dtos {
+			events[i] = RawInboundEvent{
+				ExternalID:   d.ExternalID,
+				ExternalType: d.ExternalType,
+				Kind:         d.Kind,
+				Payload:      d.Payload,
+			}
+		}
+		return events, false, nil
+	case resp.StatusCode >= 500:
+		return nil, true, fmt.Errorf("onec: 1C returned %d: %s", resp.StatusCode, snippet(raw))
+	default:
+		return nil, false, fmt.Errorf("onec: 1C rejected read %d: %s", resp.StatusCode, snippet(raw))
+	}
 }
 
 // setAuth attaches the tenant credential per its auth type.

--- a/backend/internal/integrations/onec/client_reader_test.go
+++ b/backend/internal/integrations/onec/client_reader_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func TestHTTPClient_ListEvents_Success(t *testing.T) {
-	var gotMethod, gotAuth, gotPath string
+	var gotMethod, gotAuth, gotPath, gotQuery string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod, gotAuth, gotPath = r.Method, r.Header.Get("Authorization"), r.URL.Path
+		gotMethod, gotAuth, gotPath, gotQuery = r.Method, r.Header.Get("Authorization"), r.URL.Path, r.URL.RawQuery
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`[
 			{"external_id":"doc-1","external_type":"Документ.Оплата","kind":"payment","payload":{"email":"a@b.ru"}},
@@ -32,6 +32,7 @@ func TestHTTPClient_ListEvents_Success(t *testing.T) {
 	assert.Equal(t, http.MethodGet, gotMethod)
 	assert.Equal(t, "Bearer tok", gotAuth)
 	assert.Contains(t, gotPath, "floq_events")
+	assert.Contains(t, gotQuery, "$top=500", "read must request a bounded window")
 	assert.Equal(t, "doc-1", events[0].ExternalID)
 	assert.Equal(t, "Документ.Оплата", events[0].ExternalType)
 	assert.Equal(t, "payment", events[0].Kind)

--- a/backend/internal/integrations/onec/client_reader_test.go
+++ b/backend/internal/integrations/onec/client_reader_test.go
@@ -1,0 +1,92 @@
+package onec
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPClient_ListEvents_Success(t *testing.T) {
+	var gotMethod, gotAuth, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotAuth, gotPath = r.Method, r.Header.Get("Authorization"), r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[
+			{"external_id":"doc-1","external_type":"Документ.Оплата","kind":"payment","payload":{"email":"a@b.ru"}},
+			{"external_id":"doc-2","external_type":"Справочник.Контрагенты","payload":{"email":"c@d.ru"}}
+		]`))
+	}))
+	defer srv.Close()
+
+	events, err := fastClient().ListEvents(context.Background(),
+		testCreds(t, srv.URL, domain.AuthTypeToken, "tok"))
+
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	assert.Equal(t, http.MethodGet, gotMethod)
+	assert.Equal(t, "Bearer tok", gotAuth)
+	assert.Contains(t, gotPath, "floq_events")
+	assert.Equal(t, "doc-1", events[0].ExternalID)
+	assert.Equal(t, "Документ.Оплата", events[0].ExternalType)
+	assert.Equal(t, "payment", events[0].Kind)
+	assert.JSONEq(t, `{"email":"a@b.ru"}`, string(events[0].Payload))
+	assert.Equal(t, "doc-2", events[1].ExternalID)
+	assert.Empty(t, events[1].Kind, "kind is optional — derived from mapping downstream")
+}
+
+func TestHTTPClient_ListEvents_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	events, err := fastClient().ListEvents(context.Background(),
+		testCreds(t, srv.URL, domain.AuthTypeBasic, "s"))
+
+	require.NoError(t, err)
+	assert.Empty(t, events)
+}
+
+func TestHTTPClient_ListEvents_RetriesThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	_, err := fastClient().ListEvents(context.Background(),
+		testCreds(t, srv.URL, domain.AuthTypeBasic, "s"))
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "transient 502 must be retried once")
+}
+
+func TestHTTPClient_ListEvents_4xxIsTerminal(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := fastClient().ListEvents(context.Background(),
+		testCreds(t, srv.URL, domain.AuthTypeBasic, "s"))
+
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "4xx must not be retried")
+}
+
+// Compile-time check that the HTTP client satisfies the reader port.
+var _ OneCReader = (*HTTPClient)(nil)

--- a/backend/internal/integrations/onec/outbound_repository.go
+++ b/backend/internal/integrations/onec/outbound_repository.go
@@ -52,6 +52,30 @@ func (r *Repository) UpsertOutboundRecord(ctx context.Context, rec *domain.SyncR
 	return err
 }
 
+// ActiveOnecUserIDs lists every tenant with a usable 1C connection (active +
+// non-empty base URL) — the targets reconciliation (#109) polls for missed
+// events. Ordered for deterministic iteration.
+func (r *Repository) ActiveOnecUserIDs(ctx context.Context) ([]uuid.UUID, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT user_id FROM onec_credentials
+		WHERE is_active = TRUE AND base_url <> ''
+		ORDER BY user_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // OutboundProcessedExists reports whether the object was already pushed to 1C
 // successfully (a 'processed' record for the dedup key). The outbound flow uses
 // it to skip re-creating a counterparty; an 'error' record does NOT count, so a

--- a/backend/internal/integrations/onec/outbound_repository_integration_test.go
+++ b/backend/internal/integrations/onec/outbound_repository_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/daniil/floq/internal/integrations/onec"
 	"github.com/daniil/floq/internal/integrations/onec/domain"
 	"github.com/daniil/floq/internal/testutil"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -60,6 +61,33 @@ func TestRepository_GetOutboundCredentials(t *testing.T) {
 		_, err = repo.GetOutboundCredentials(ctx, user)
 		assert.True(t, errors.Is(err, onec.ErrOutboundNotConfigured), "empty base_url is not usable; got %v", err)
 	})
+}
+
+func TestRepository_ActiveOnecUserIDs(t *testing.T) {
+	pool := testutil.TestDB(t)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+
+	active := testutil.SeedUser(t, pool)
+	inactive := testutil.SeedUser(t, pool)
+	noURL := testutil.SeedUser(t, pool)
+
+	_, err := pool.Exec(ctx, `INSERT INTO onec_credentials (user_id, base_url, auth_type, is_active) VALUES
+		($1, 'https://1c.example', 'basic', TRUE),
+		($2, 'https://1c.example', 'basic', FALSE),
+		($3, '', 'basic', TRUE)`, active, inactive, noURL)
+	require.NoError(t, err)
+
+	ids, err := repo.ActiveOnecUserIDs(ctx)
+	require.NoError(t, err)
+
+	set := map[uuid.UUID]bool{}
+	for _, id := range ids {
+		set[id] = true
+	}
+	assert.True(t, set[active], "active + base_url must be listed")
+	assert.False(t, set[inactive], "inactive must be excluded")
+	assert.False(t, set[noURL], "active but empty base_url must be excluded")
 }
 
 func TestRepository_OutboundRecord_UpsertAndExists(t *testing.T) {

--- a/backend/internal/integrations/onec/ports.go
+++ b/backend/internal/integrations/onec/ports.go
@@ -42,6 +42,14 @@ type MappingStore interface {
 	GetActiveMappingConfig(ctx context.Context, userID uuid.UUID) (*domain.MappingConfig, error)
 }
 
+// OneCReader reads recent events back from a tenant's 1C endpoint, used by
+// reconciliation (#109) to re-apply events whose webhook was lost. The
+// HTTP/OData implementation satisfies it. Kind may be empty per event — it is
+// resolved from the mapping downstream, same as the webhook path.
+type OneCReader interface {
+	ListEvents(ctx context.Context, creds *domain.OutboundCredentials) ([]RawInboundEvent, error)
+}
+
 // OutboundStore resolves a tenant's outbound connection and persists the push
 // ledger. The postgres Repository satisfies it. GetOutboundCredentials returns
 // ErrOutboundNotConfigured when the tenant has no usable 1C endpoint.

--- a/backend/internal/integrations/onec/ports.go
+++ b/backend/internal/integrations/onec/ports.go
@@ -16,6 +16,10 @@ type InsertOutcome struct {
 	// content changed. The caller decides what to do (we log it); a silent
 	// drop would lose a real update.
 	PayloadDrifted bool
+	// AlreadyProcessed is true when a dedup hit found a record whose domain
+	// action already succeeded (status 'processed'). When false on a dedup hit,
+	// the event was recorded but never applied — reconciliation must re-apply it.
+	AlreadyProcessed bool
 }
 
 // SyncStore persists ledger entries. Declared in the consumer package
@@ -24,6 +28,9 @@ type SyncStore interface {
 	// InsertSyncRecord saves rec idempotently: a replayed dedup key yields
 	// Inserted=false, and PayloadDrifted=true if the stored payload differs.
 	InsertSyncRecord(ctx context.Context, rec *domain.SyncRecord) (InsertOutcome, error)
+	// MarkProcessed flips the record's status to 'processed' once its domain
+	// action has succeeded, so a later replay/reconciliation does not re-apply it.
+	MarkProcessed(ctx context.Context, rec *domain.SyncRecord) error
 }
 
 // SecretResolver maps an inbound webhook secret to its owning user. The

--- a/backend/internal/integrations/onec/reconcile.go
+++ b/backend/internal/integrations/onec/reconcile.go
@@ -91,16 +91,21 @@ func (u *ReconcileUseCase) ReconcileUser(ctx context.Context, userID uuid.UUID) 
 
 	stats := ReconcileStats{Fetched: len(events)}
 	for _, ev := range events {
+		// Stop promptly on shutdown rather than hammering a cancelled context and
+		// inflating Failed with context.Canceled for every remaining event.
+		if ctx.Err() != nil {
+			return stats, ctx.Err()
+		}
 		res, err := u.processor.ProcessInboundEvent(ctx, userID, ev)
 		switch {
 		case err != nil:
 			stats.Failed++
 			u.logger.Warn("onec: reconcile event failed",
 				"user_id", userID, "external_id", ev.ExternalID, "external_type", ev.ExternalType, "err", err)
-		case res.Deduped:
-			stats.Deduped++
+		case res.Applied:
+			stats.Applied++ // missed/unprocessed event recovered
 		default:
-			stats.Applied++
+			stats.Deduped++ // already processed (or no actionable rule) — no-op
 		}
 	}
 	return stats, nil

--- a/backend/internal/integrations/onec/reconcile.go
+++ b/backend/internal/integrations/onec/reconcile.go
@@ -1,0 +1,107 @@
+package onec
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/google/uuid"
+)
+
+// InboundProcessor applies one inbound 1C event idempotently. The inbound
+// UseCase satisfies it; reconciliation reuses that exact path so a re-fed event
+// dedups (already seen) or applies (webhook was missed) with no extra logic.
+type InboundProcessor interface {
+	ProcessInboundEvent(ctx context.Context, userID uuid.UUID, in RawInboundEvent) (ProcessResult, error)
+}
+
+// ReconcileStore lists tenants to reconcile and resolves their read credentials.
+// The postgres Repository satisfies it.
+type ReconcileStore interface {
+	ActiveOnecUserIDs(ctx context.Context) ([]uuid.UUID, error)
+	GetOutboundCredentials(ctx context.Context, userID uuid.UUID) (*domain.OutboundCredentials, error)
+}
+
+// ReconcileStats summarises one reconciliation pass for a user.
+type ReconcileStats struct {
+	Fetched int // events read back from 1C
+	Applied int // events that were missing locally and got applied (recovered)
+	Deduped int // events already in the ledger — no-op
+	Failed  int // events that errored during processing (skipped, batch continues)
+}
+
+// ReconcileUseCase is the safety net for lost webhooks (#109): it periodically
+// reads recent events back from 1C and re-feeds them through the inbound path,
+// which idempotently applies anything missed and ignores anything already seen.
+type ReconcileUseCase struct {
+	store     ReconcileStore
+	reader    OneCReader
+	processor InboundProcessor
+	logger    *slog.Logger
+}
+
+// NewReconcileUseCase wires the reconciliation use case. A nil logger falls back
+// to the default.
+func NewReconcileUseCase(store ReconcileStore, reader OneCReader, processor InboundProcessor, logger *slog.Logger) *ReconcileUseCase {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ReconcileUseCase{store: store, reader: reader, processor: processor, logger: logger}
+}
+
+// ReconcileAll reconciles every tenant with a usable 1C connection. A failure
+// for one tenant is logged and does not stop the others.
+func (u *ReconcileUseCase) ReconcileAll(ctx context.Context) error {
+	ids, err := u.store.ActiveOnecUserIDs(ctx)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		stats, err := u.ReconcileUser(ctx, id)
+		if err != nil {
+			u.logger.Warn("onec: reconcile failed for user", "user_id", id, "err", err)
+			continue
+		}
+		if stats.Applied > 0 || stats.Failed > 0 {
+			u.logger.Info("onec: reconciled user",
+				"user_id", id, "fetched", stats.Fetched, "applied", stats.Applied,
+				"deduped", stats.Deduped, "failed", stats.Failed)
+		}
+	}
+	return nil
+}
+
+// ReconcileUser reads a tenant's recent 1C events and re-feeds each through the
+// inbound path. An unconfigured tenant is a silent no-op. A per-event failure is
+// counted and skipped so one bad document never blocks the rest of the batch.
+func (u *ReconcileUseCase) ReconcileUser(ctx context.Context, userID uuid.UUID) (ReconcileStats, error) {
+	creds, err := u.store.GetOutboundCredentials(ctx, userID)
+	if errors.Is(err, ErrOutboundNotConfigured) {
+		return ReconcileStats{}, nil
+	}
+	if err != nil {
+		return ReconcileStats{}, err
+	}
+
+	events, err := u.reader.ListEvents(ctx, creds)
+	if err != nil {
+		return ReconcileStats{}, err
+	}
+
+	stats := ReconcileStats{Fetched: len(events)}
+	for _, ev := range events {
+		res, err := u.processor.ProcessInboundEvent(ctx, userID, ev)
+		switch {
+		case err != nil:
+			stats.Failed++
+			u.logger.Warn("onec: reconcile event failed",
+				"user_id", userID, "external_id", ev.ExternalID, "external_type", ev.ExternalType, "err", err)
+		case res.Deduped:
+			stats.Deduped++
+		default:
+			stats.Applied++
+		}
+	}
+	return stats, nil
+}

--- a/backend/internal/integrations/onec/reconcile_cron.go
+++ b/backend/internal/integrations/onec/reconcile_cron.go
@@ -1,0 +1,56 @@
+package onec
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// reconciler is the slice of ReconcileUseCase the cron drives. An interface so
+// the cron's loop is unit-testable with a fake.
+type reconciler interface {
+	ReconcileAll(ctx context.Context) error
+}
+
+// ReconcileCron periodically runs the 1C reconciliation safety net (#109). It
+// mirrors reminders.Cron: a ticker loop that runs once on startup and stops when
+// its context is cancelled, so it shuts down gracefully with the server.
+type ReconcileCron struct {
+	uc       reconciler
+	interval time.Duration
+	logger   *slog.Logger
+}
+
+// NewReconcileCron builds the cron. A nil logger falls back to the default.
+func NewReconcileCron(uc reconciler, interval time.Duration, logger *slog.Logger) *ReconcileCron {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ReconcileCron{uc: uc, interval: interval, logger: logger}
+}
+
+// Start runs the reconciliation loop until ctx is cancelled. It runs once
+// immediately so a freshly started server closes any gap that accrued while it
+// was down, then on each interval tick.
+func (c *ReconcileCron) Start(ctx context.Context) {
+	c.logger.Info("onec: reconcile cron started", "interval", c.interval)
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	c.runOnce(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("onec: reconcile cron shutting down")
+			return
+		case <-ticker.C:
+			c.runOnce(ctx)
+		}
+	}
+}
+
+func (c *ReconcileCron) runOnce(ctx context.Context) {
+	if err := c.uc.ReconcileAll(ctx); err != nil {
+		c.logger.Warn("onec: reconcile pass failed", "err", err)
+	}
+}

--- a/backend/internal/integrations/onec/reconcile_cron_test.go
+++ b/backend/internal/integrations/onec/reconcile_cron_test.go
@@ -1,0 +1,54 @@
+package onec
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakeReconciler struct {
+	calls int32
+	fn    func()
+}
+
+func (f *fakeReconciler) ReconcileAll(_ context.Context) error {
+	atomic.AddInt32(&f.calls, 1)
+	if f.fn != nil {
+		f.fn()
+	}
+	return nil
+}
+
+func TestReconcileCron_RunsOnStartupThenStopsOnCancel(t *testing.T) {
+	ran := make(chan struct{}, 1)
+	rec := &fakeReconciler{fn: func() {
+		select {
+		case ran <- struct{}{}:
+		default:
+		}
+	}}
+	cron := NewReconcileCron(rec, time.Hour, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { cron.Start(ctx); close(done) }()
+
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReconcileAll must run once on startup")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cron must stop when ctx is cancelled")
+	}
+	if atomic.LoadInt32(&rec.calls) < 1 {
+		t.Fatal("expected at least one reconcile pass")
+	}
+}

--- a/backend/internal/integrations/onec/reconcile_test.go
+++ b/backend/internal/integrations/onec/reconcile_test.go
@@ -57,7 +57,7 @@ func TestReconcileUser_AppliesMissedEvent(t *testing.T) {
 	store := &fakeReconcileStore{creds: reconcileCreds(t)}
 	reader := &fakeReader{events: []RawInboundEvent{{ExternalID: "doc-1", ExternalType: "X", Kind: "payment"}}}
 	proc := &fakeProcessor{fn: func(RawInboundEvent) (ProcessResult, error) {
-		return ProcessResult{Deduped: false}, nil // was missing → freshly applied
+		return ProcessResult{Applied: true}, nil // was missing → freshly applied
 	}}
 	uc := NewReconcileUseCase(store, reader, proc, nil)
 
@@ -107,7 +107,7 @@ func TestReconcileUser_OneBadEventDoesNotStopBatch(t *testing.T) {
 		if in.ExternalID == "bad" {
 			return ProcessResult{}, errors.New("unresolvable")
 		}
-		return ProcessResult{Deduped: false}, nil
+		return ProcessResult{Applied: true}, nil
 	}}
 	uc := NewReconcileUseCase(store, reader, proc, nil)
 
@@ -134,4 +134,44 @@ func TestReconcileAll_IteratesActiveUsers(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, 2, reader.calls, "each active user must be reconciled")
+}
+
+func TestReconcileUser_ListEventsError_Propagates(t *testing.T) {
+	store := &fakeReconcileStore{creds: reconcileCreds(t)}
+	reader := &fakeReader{err: errors.New("1C unreachable")}
+	proc := &fakeProcessor{fn: func(RawInboundEvent) (ProcessResult, error) { return ProcessResult{}, nil }}
+	uc := NewReconcileUseCase(store, reader, proc, nil)
+
+	_, err := uc.ReconcileUser(context.Background(), uuid.New())
+
+	require.Error(t, err, "a read failure must surface so the pass is not silently empty")
+	assert.Equal(t, 0, proc.calls)
+}
+
+func TestReconcileAll_ActiveUsersError_Propagates(t *testing.T) {
+	store := &fakeReconcileStore{activeErr: errors.New("db down")}
+	reader := &fakeReader{}
+	proc := &fakeProcessor{fn: func(RawInboundEvent) (ProcessResult, error) { return ProcessResult{}, nil }}
+	uc := NewReconcileUseCase(store, reader, proc, nil)
+
+	err := uc.ReconcileAll(context.Background())
+
+	require.Error(t, err)
+	assert.Equal(t, 0, reader.calls)
+}
+
+func TestReconcileAll_OneTenantFailureDoesNotStopOthers(t *testing.T) {
+	// First user's read fails; ReconcileAll must still reconcile the second.
+	store := &fakeReconcileStore{
+		activeIDs: []uuid.UUID{uuid.New(), uuid.New()},
+		creds:     reconcileCreds(t),
+	}
+	reader := &fakeReader{err: errors.New("1C unreachable")}
+	proc := &fakeProcessor{fn: func(RawInboundEvent) (ProcessResult, error) { return ProcessResult{}, nil }}
+	uc := NewReconcileUseCase(store, reader, proc, nil)
+
+	err := uc.ReconcileAll(context.Background())
+
+	require.NoError(t, err, "a per-tenant failure is logged, not fatal to the pass")
+	assert.Equal(t, 2, reader.calls, "both tenants attempted despite the first failing")
 }

--- a/backend/internal/integrations/onec/reconcile_test.go
+++ b/backend/internal/integrations/onec/reconcile_test.go
@@ -1,0 +1,137 @@
+package onec
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeReconcileStore struct {
+	activeIDs []uuid.UUID
+	activeErr error
+	creds     *domain.OutboundCredentials
+	credsErr  error
+}
+
+func (f *fakeReconcileStore) ActiveOnecUserIDs(_ context.Context) ([]uuid.UUID, error) {
+	return f.activeIDs, f.activeErr
+}
+func (f *fakeReconcileStore) GetOutboundCredentials(_ context.Context, _ uuid.UUID) (*domain.OutboundCredentials, error) {
+	return f.creds, f.credsErr
+}
+
+type fakeReader struct {
+	events []RawInboundEvent
+	err    error
+	calls  int
+}
+
+func (f *fakeReader) ListEvents(_ context.Context, _ *domain.OutboundCredentials) ([]RawInboundEvent, error) {
+	f.calls++
+	return f.events, f.err
+}
+
+type fakeProcessor struct {
+	calls int
+	fn    func(RawInboundEvent) (ProcessResult, error)
+}
+
+func (f *fakeProcessor) ProcessInboundEvent(_ context.Context, _ uuid.UUID, in RawInboundEvent) (ProcessResult, error) {
+	f.calls++
+	return f.fn(in)
+}
+
+func reconcileCreds(t *testing.T) *domain.OutboundCredentials {
+	t.Helper()
+	c, err := domain.NewOutboundCredentials("https://1c.example", domain.AuthTypeBasic, "s")
+	require.NoError(t, err)
+	return c
+}
+
+func TestReconcileUser_AppliesMissedEvent(t *testing.T) {
+	store := &fakeReconcileStore{creds: reconcileCreds(t)}
+	reader := &fakeReader{events: []RawInboundEvent{{ExternalID: "doc-1", ExternalType: "X", Kind: "payment"}}}
+	proc := &fakeProcessor{fn: func(RawInboundEvent) (ProcessResult, error) {
+		return ProcessResult{Deduped: false}, nil // was missing → freshly applied
+	}}
+	uc := NewReconcileUseCase(store, reader, proc, nil)
+
+	stats, err := uc.ReconcileUser(context.Background(), uuid.New())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Fetched)
+	assert.Equal(t, 1, stats.Applied, "a missed event must be applied")
+	assert.Equal(t, 0, stats.Deduped)
+}
+
+func TestReconcileUser_SkipsAlreadyProcessed(t *testing.T) {
+	store := &fakeReconcileStore{creds: reconcileCreds(t)}
+	reader := &fakeReader{events: []RawInboundEvent{{ExternalID: "doc-1", ExternalType: "X", Kind: "payment"}}}
+	proc := &fakeProcessor{fn: func(RawInboundEvent) (ProcessResult, error) {
+		return ProcessResult{Deduped: true}, nil // already in ledger → no-op
+	}}
+	uc := NewReconcileUseCase(store, reader, proc, nil)
+
+	stats, err := uc.ReconcileUser(context.Background(), uuid.New())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Deduped)
+	assert.Equal(t, 0, stats.Applied, "already-processed event must not be re-applied")
+}
+
+func TestReconcileUser_UnconfiguredSkips(t *testing.T) {
+	store := &fakeReconcileStore{credsErr: ErrOutboundNotConfigured}
+	reader := &fakeReader{}
+	proc := &fakeProcessor{fn: func(RawInboundEvent) (ProcessResult, error) { return ProcessResult{}, nil }}
+	uc := NewReconcileUseCase(store, reader, proc, nil)
+
+	stats, err := uc.ReconcileUser(context.Background(), uuid.New())
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, reader.calls, "must not read 1C when unconfigured")
+	assert.Equal(t, 0, stats.Fetched)
+}
+
+func TestReconcileUser_OneBadEventDoesNotStopBatch(t *testing.T) {
+	store := &fakeReconcileStore{creds: reconcileCreds(t)}
+	reader := &fakeReader{events: []RawInboundEvent{
+		{ExternalID: "bad", ExternalType: "X"},
+		{ExternalID: "good", ExternalType: "X", Kind: "payment"},
+	}}
+	proc := &fakeProcessor{fn: func(in RawInboundEvent) (ProcessResult, error) {
+		if in.ExternalID == "bad" {
+			return ProcessResult{}, errors.New("unresolvable")
+		}
+		return ProcessResult{Deduped: false}, nil
+	}}
+	uc := NewReconcileUseCase(store, reader, proc, nil)
+
+	stats, err := uc.ReconcileUser(context.Background(), uuid.New())
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, stats.Fetched)
+	assert.Equal(t, 1, stats.Failed)
+	assert.Equal(t, 1, stats.Applied, "a later good event still applies after an earlier failure")
+}
+
+func TestReconcileAll_IteratesActiveUsers(t *testing.T) {
+	store := &fakeReconcileStore{
+		activeIDs: []uuid.UUID{uuid.New(), uuid.New()},
+		creds:     reconcileCreds(t),
+	}
+	reader := &fakeReader{events: []RawInboundEvent{{ExternalID: "d", ExternalType: "X", Kind: "payment"}}}
+	proc := &fakeProcessor{fn: func(RawInboundEvent) (ProcessResult, error) {
+		return ProcessResult{Deduped: true}, nil
+	}}
+	uc := NewReconcileUseCase(store, reader, proc, nil)
+
+	err := uc.ReconcileAll(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, reader.calls, "each active user must be reconciled")
+}

--- a/backend/internal/integrations/onec/repository.go
+++ b/backend/internal/integrations/onec/repository.go
@@ -40,16 +40,32 @@ func (r *Repository) InsertSyncRecord(ctx context.Context, rec *domain.SyncRecor
 		return InsertOutcome{Inserted: true}, nil
 	}
 
-	// Dedup hit: check whether the replayed payload differs from the stored one.
-	var storedHash string
+	// Dedup hit: read the stored payload hash (drift) and status (whether the
+	// domain action already succeeded — drives whether reconciliation re-applies).
+	var storedHash, storedStatus string
 	err = r.pool.QueryRow(ctx, `
-		SELECT payload_hash FROM onec_sync_records
+		SELECT payload_hash, status FROM onec_sync_records
 		WHERE user_id = $1 AND external_id = $2 AND external_type = $3`,
-		rec.UserID, rec.ExternalID, rec.ExternalType).Scan(&storedHash)
+		rec.UserID, rec.ExternalID, rec.ExternalType).Scan(&storedHash, &storedStatus)
 	if err != nil {
 		return InsertOutcome{}, err
 	}
-	return InsertOutcome{Inserted: false, PayloadDrifted: storedHash != rec.PayloadHash}, nil
+	return InsertOutcome{
+		Inserted:         false,
+		PayloadDrifted:   storedHash != rec.PayloadHash,
+		AlreadyProcessed: storedStatus == string(domain.SyncStatusProcessed),
+	}, nil
+}
+
+// MarkProcessed flips an inbound ledger entry to 'processed' after its domain
+// action succeeded. Keyed on the dedup tuple so it targets the row InsertSyncRecord
+// wrote. Idempotent — re-marking an already-processed row is a no-op.
+func (r *Repository) MarkProcessed(ctx context.Context, rec *domain.SyncRecord) error {
+	_, err := r.pool.Exec(ctx, `
+		UPDATE onec_sync_records SET status = $4
+		WHERE user_id = $1 AND external_id = $2 AND external_type = $3`,
+		rec.UserID, rec.ExternalID, rec.ExternalType, string(domain.SyncStatusProcessed))
+	return err
 }
 
 // UserIDByWebhookSecret resolves the owning user from a webhook secret. Only

--- a/backend/internal/integrations/onec/repository.go
+++ b/backend/internal/integrations/onec/repository.go
@@ -58,12 +58,16 @@ func (r *Repository) InsertSyncRecord(ctx context.Context, rec *domain.SyncRecor
 }
 
 // MarkProcessed flips an inbound ledger entry to 'processed' after its domain
-// action succeeded. Keyed on the dedup tuple so it targets the row InsertSyncRecord
-// wrote. Idempotent — re-marking an already-processed row is a no-op.
+// action succeeded. Keyed on the dedup tuple so it targets the row
+// InsertSyncRecord wrote, and scoped to direction='inbound' so it can never
+// touch an outbound push record that happens to share an (external_id,
+// external_type) — the dedup constraint is direction-agnostic, so this scope is
+// the explicit guard. Idempotent — re-marking an already-processed row is a no-op.
 func (r *Repository) MarkProcessed(ctx context.Context, rec *domain.SyncRecord) error {
 	_, err := r.pool.Exec(ctx, `
 		UPDATE onec_sync_records SET status = $4
-		WHERE user_id = $1 AND external_id = $2 AND external_type = $3`,
+		WHERE user_id = $1 AND external_id = $2 AND external_type = $3
+		  AND direction = 'inbound'`,
 		rec.UserID, rec.ExternalID, rec.ExternalType, string(domain.SyncStatusProcessed))
 	return err
 }

--- a/backend/internal/integrations/onec/repository_integration_test.go
+++ b/backend/internal/integrations/onec/repository_integration_test.go
@@ -139,3 +139,33 @@ func TestRepository_UserIDByWebhookSecret(t *testing.T) {
 		require.False(t, found, "inactive credentials must not authenticate")
 	})
 }
+
+func TestRepository_InsertSyncRecord_AlreadyProcessedAndMark(t *testing.T) {
+	pool := testutil.TestDB(t)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+	user := testutil.SeedUser(t, pool)
+
+	rec, err := domain.NewSyncRecord(user, newEvent(t, "ОП-9001"), domain.DirectionInbound)
+	require.NoError(t, err)
+
+	out, err := repo.InsertSyncRecord(ctx, rec)
+	require.NoError(t, err)
+	require.True(t, out.Inserted)
+	require.False(t, out.AlreadyProcessed, "a fresh record starts unprocessed")
+
+	// Replay before processing → dedup, still not processed (reconciliation must re-apply).
+	out, err = repo.InsertSyncRecord(ctx, rec)
+	require.NoError(t, err)
+	require.False(t, out.Inserted)
+	require.False(t, out.AlreadyProcessed, "recorded-but-unapplied must read as not-processed")
+
+	// Apply succeeded → mark processed.
+	require.NoError(t, repo.MarkProcessed(ctx, rec))
+
+	// Replay after processing → dedup AND already-processed (no re-apply).
+	out, err = repo.InsertSyncRecord(ctx, rec)
+	require.NoError(t, err)
+	require.False(t, out.Inserted)
+	require.True(t, out.AlreadyProcessed, "a processed record must read as already-processed")
+}

--- a/backend/internal/integrations/onec/usecase.go
+++ b/backend/internal/integrations/onec/usecase.go
@@ -62,6 +62,10 @@ type ProcessResult struct {
 	Deduped bool
 	// PayloadDrifted is true when a replay arrived with changed content.
 	PayloadDrifted bool
+	// Applied is true when this call ran the mapped domain action and it
+	// succeeded — either a fresh event or the recovery of a recorded-but-unapplied
+	// one. Reconciliation counts this to know what it recovered.
+	Applied bool
 }
 
 // ProcessInboundEvent resolves, records, and applies one 1C event for a user.
@@ -97,13 +101,24 @@ func (u *UseCase) ProcessInboundEvent(ctx context.Context, userID uuid.UUID, in 
 			"user_id", userID, "external_id", ev.ExternalID, "external_type", ev.ExternalType, "kind", kind.String())
 	}
 
-	// Apply only on a fresh insert, and only when a rule exists (we need its
-	// fields to extract the counterparty). Replays are not re-applied.
-	if out.Inserted && hasRule && u.applier != nil {
-		u.apply(ctx, userID, kind, rule, in.Payload)
+	// Apply when the action hasn't yet succeeded and a rule exists (we need its
+	// fields to extract the counterparty). That covers a fresh insert AND a
+	// replay of a recorded-but-unapplied event — the reconciliation recovery
+	// path. A replay of an already-processed event is skipped.
+	applied := false
+	if hasRule && u.applier != nil && !out.AlreadyProcessed {
+		if applyErr := u.apply(ctx, userID, kind, rule, in.Payload); applyErr == nil {
+			applied = true
+			// Domain actions are idempotent, so a missed mark only risks a
+			// harmless re-apply on the next pass — log, don't fail.
+			if mErr := u.store.MarkProcessed(ctx, rec); mErr != nil {
+				u.logger.Warn("onec: action applied but marking processed failed; may re-apply",
+					"user_id", userID, "external_id", ev.ExternalID, "err", mErr)
+			}
+		}
 	}
 
-	return ProcessResult{Deduped: !out.Inserted, PayloadDrifted: out.PayloadDrifted}, nil
+	return ProcessResult{Deduped: !out.Inserted, PayloadDrifted: out.PayloadDrifted, Applied: applied}, nil
 }
 
 // lookupRule resolves the mapping rule for an external type. A missing active
@@ -142,9 +157,10 @@ func resolveKind(explicit string, rule domain.MappingRule, hasRule bool, lookupE
 	return "", ErrUnresolvableKind
 }
 
-// apply routes a recorded event to its domain action. Apply failures are logged,
-// not returned — the event is already persisted.
-func (u *UseCase) apply(ctx context.Context, userID uuid.UUID, kind domain.EventKind, rule domain.MappingRule, payload []byte) {
+// apply routes a recorded event to its domain action and returns the action's
+// error. A failure is logged here and returned so the caller leaves the record
+// unprocessed (reconciliation will retry); the event itself stays persisted.
+func (u *UseCase) apply(ctx context.Context, userID uuid.UUID, kind domain.EventKind, rule domain.MappingRule, payload []byte) error {
 	fields := parseStringFields(payload)
 	email := fields[rule.EmailField]
 	var err error
@@ -159,9 +175,10 @@ func (u *UseCase) apply(ctx context.Context, userID uuid.UUID, kind domain.Event
 		err = u.applier.HandleShipment(ctx, userID, email)
 	}
 	if err != nil {
-		u.logger.Warn("onec: applying event failed; recorded but not applied",
+		u.logger.Warn("onec: applying event failed; recorded but left unprocessed for reconciliation",
 			"user_id", userID, "kind", kind.String(), "err", err)
 	}
+	return err
 }
 
 // parseStringFields flattens a raw JSON object's string-valued top-level keys

--- a/backend/internal/integrations/onec/usecase_test.go
+++ b/backend/internal/integrations/onec/usecase_test.go
@@ -12,17 +12,25 @@ import (
 
 // fakeStore is an in-memory SyncStore for unit tests.
 type fakeStore struct {
-	inserted bool  // InsertOutcome.Inserted to return
-	drifted  bool  // InsertOutcome.PayloadDrifted to return
-	err      error // error to return
-	calls    int   // how many times InsertSyncRecord was called
-	last     *domain.SyncRecord
+	inserted         bool  // InsertOutcome.Inserted to return
+	drifted          bool  // InsertOutcome.PayloadDrifted to return
+	alreadyProcessed bool  // InsertOutcome.AlreadyProcessed to return (dedup of a processed record)
+	err              error // error to return
+	calls            int   // how many times InsertSyncRecord was called
+	last             *domain.SyncRecord
+	markedProcessed  bool
+	markErr          error
 }
 
 func (f *fakeStore) InsertSyncRecord(_ context.Context, rec *domain.SyncRecord) (onec.InsertOutcome, error) {
 	f.calls++
 	f.last = rec
-	return onec.InsertOutcome{Inserted: f.inserted, PayloadDrifted: f.drifted}, f.err
+	return onec.InsertOutcome{Inserted: f.inserted, PayloadDrifted: f.drifted, AlreadyProcessed: f.alreadyProcessed}, f.err
+}
+
+func (f *fakeStore) MarkProcessed(_ context.Context, _ *domain.SyncRecord) error {
+	f.markedProcessed = true
+	return f.markErr
 }
 
 // fakeMapping is an in-memory MappingStore.
@@ -250,7 +258,7 @@ func TestProcessInbound_ExtractionEdgeCases(t *testing.T) {
 }
 
 func TestProcessInbound_DedupSkipsApply(t *testing.T) {
-	store := &fakeStore{inserted: false} // dedup hit
+	store := &fakeStore{inserted: false, alreadyProcessed: true} // dedup hit of an already-applied event
 	mapping := activeMapping(t, "Документ.Оплата", domain.EventKindPayment)
 	applier := &fakeApplier{}
 	uc := onec.NewUseCase(store, onec.WithMapping(mapping), onec.WithApplier(applier))
@@ -263,7 +271,66 @@ func TestProcessInbound_DedupSkipsApply(t *testing.T) {
 		t.Error("expected deduped")
 	}
 	if applier.action != "" {
-		t.Errorf("deduped replay must not re-apply, got %q", applier.action)
+		t.Errorf("replay of an already-processed event must not re-apply, got %q", applier.action)
+	}
+	if res.Applied {
+		t.Error("already-processed replay is not a fresh apply")
+	}
+}
+
+func TestProcessInbound_MarksProcessedOnApplySuccess(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	mapping := activeMapping(t, "Документ.Оплата", domain.EventKindPayment)
+	applier := &fakeApplier{}
+	uc := onec.NewUseCase(store, onec.WithMapping(mapping), onec.WithApplier(applier))
+
+	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), raw(""))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !res.Applied {
+		t.Error("a fresh successful apply must report Applied")
+	}
+	if !store.markedProcessed {
+		t.Error("a successful apply must mark the record processed")
+	}
+}
+
+func TestProcessInbound_DoesNotMarkProcessedOnApplyFailure(t *testing.T) {
+	store := &fakeStore{inserted: true}
+	mapping := activeMapping(t, "Документ.Оплата", domain.EventKindPayment)
+	applier := &fakeApplier{err: errors.New("downstream boom")}
+	uc := onec.NewUseCase(store, onec.WithMapping(mapping), onec.WithApplier(applier))
+
+	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), raw(""))
+	if err != nil {
+		t.Fatalf("apply failure must not fail the webhook: %v", err)
+	}
+	if res.Applied {
+		t.Error("a failed apply must not report Applied")
+	}
+	if store.markedProcessed {
+		t.Error("a failed apply must leave the record un-processed so reconciliation retries it")
+	}
+}
+
+func TestProcessInbound_ReappliesRecordedButUnprocessed(t *testing.T) {
+	// Dedup hit (record exists) but it was never successfully applied — the
+	// safety-net case: reconciliation re-feeds it and apply runs again.
+	store := &fakeStore{inserted: false, alreadyProcessed: false}
+	mapping := activeMapping(t, "Документ.Оплата", domain.EventKindPayment)
+	applier := &fakeApplier{}
+	uc := onec.NewUseCase(store, onec.WithMapping(mapping), onec.WithApplier(applier))
+
+	res, err := uc.ProcessInboundEvent(context.Background(), uuid.New(), raw(""))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if applier.action != "payment" {
+		t.Errorf("a recorded-but-unapplied event must be re-applied, got %q", applier.action)
+	}
+	if !res.Applied || !store.markedProcessed {
+		t.Error("recovery apply must report Applied and mark processed")
 	}
 }
 


### PR DESCRIPTION
Четвёртый PR серии интеграции с 1С. Регламентная **сверка дельты** — safety-net на случай потерянных webhook: периодически перечитывает недавние события из 1С и идемпотентно до-применяет пропущенное.

## Что сделано
- **Read-порт `OneCReader.ListEvents`** + HTTP/OData GET (`/floq_events?$format=json&$top=500`): ограниченное окно, ретраи 5xx/transport, 4xx терминально. Общий `doRetrying`-хелпер (GET+POST), на него же переведён `CreateCounterparty` (#108).
- **`ReconcileUseCase`**: `ReconcileUser` (creds → ListEvents → каждое событие через существующий inbound `ProcessInboundEvent`), `ReconcileAll` (по всем активным тенантам, сбой одного не валит остальных). Переиспользует идемпотентный inbound-путь #106/#107.
- **`ReconcileCron`** (как `reminders.Cron`): тикер 15м, прогон при старте, graceful shutdown через `context.Context`.
- **Repo `ActiveOnecUserIDs`** — тенанты с активными creds + непустым base_url.
- **Wiring** в `cmd/server`: один shared HTTP-клиент на read+write, cron стартует с app-lifecycle ctx.

## Apply-фаза под safety-net (закрытый ревью-blocker)
Раньше inbound `apply` был fire-and-forget: транзиентный сбой оставлял событие записанным, но непринятым, а повторная сверка дедупила запись → действие терялось навсегда. Теперь:
- `InsertOutcome.AlreadyProcessed` (по stored `status`); `MarkProcessed` помечает запись `processed` после успешного apply (scoped `direction='inbound'`).
- `ProcessInboundEvent` переприменяет **recorded-but-unprocessed** событие (recovery), пропускает уже `processed`. `ProcessResult.Applied` честно отражает выполненное действие.
- Доменные действия идемпотентны (`CanTransitionTo`, prospect upsert) → повторное применение безопасно. Webhook-семантика (`Deduped=!Inserted`, 200 на реплей) не изменилась.

## Тесты (TDD, RED→GREEN)
- Reader (httptest): success/empty/retry/4xx + проверка `$top` окна.
- ReconcileUseCase (unit): applied/deduped/unconfigured-skip/one-bad-event/ListEvents-error/activeErr/one-tenant-fails.
- Apply-status (unit + integration): mark-on-success, no-mark-on-failure, re-apply-unprocessed, AlreadyProcessed lifecycle против Postgres.
- Cron: run-on-startup + stop-on-cancel.
- `-race` чисто. onec coverage 69.7%.

## Ревью
Два прохода независимого ревью. BLOCKER (apply-recovery) + 2 IMPORTANT (ctx-cancel в цикле, окно батча) + suggestions устранены. Финал: TDD 9 / DDD 9 / CA 9.

Closes #109
Refs #105
