### PR TITLE
feat(security): per-route 50 MiB cap for CSV uploads, 413 on oversize (#99)

### DIFF
--- a/backend/internal/httputil/middleware.go
+++ b/backend/internal/httputil/middleware.go
@@ -12,6 +12,12 @@ import (
 // defence-in-depth stack with JSONBodyCap.
 const DefaultMaxBodyBytes int64 = 10 * 1024 * 1024
 
+// DefaultMaxUploadBytes is the ceiling for multipart CSV-import uploads
+// (prospects/leads). Higher than DefaultMaxBodyBytes because legitimate
+// enterprise imports can be large (≈50-100K rows); only the import routes get
+// this looser cap, selected by path in MaxBodyBytesWithUploads.
+const DefaultMaxUploadBytes int64 = 50 * 1024 * 1024
+
 // DefaultMaxJSONBodyBytes is the default cap applied by JSONBodyCap.
 // 1 MiB is far beyond any structured JSON payload Floq accepts and far
 // below the DoS threshold. The inner (tighter) layer in the
@@ -32,6 +38,32 @@ func MaxBodyBytes(maxBytes int64) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Body != nil {
 				r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// MaxBodyBytesWithUploads is the outer body ceiling that lets CSV-import
+// uploads exceed the general limit. It applies generalMax to every request,
+// except paths ending in "/import" (the multipart upload routes) which get
+// uploadMax.
+//
+// Why path-based and not a per-route middleware: http.MaxBytesReader is
+// smallest-wins, so a higher inner cap on the import route cannot loosen a lower
+// ancestor cap. The upload routes therefore must NOT sit under the general
+// ceiling at all — selecting the cap by path here keeps both limits in one
+// documented place instead of splitting the router. JSONBodyCap still composes
+// on top, so JSON traffic trips its tighter 1 MiB cap first.
+func MaxBodyBytesWithUploads(generalMax, uploadMax int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Body != nil {
+				limit := generalMax
+				if strings.HasSuffix(r.URL.Path, "/import") {
+					limit = uploadMax
+				}
+				r.Body = http.MaxBytesReader(w, r.Body, limit)
 			}
 			next.ServeHTTP(w, r)
 		})

--- a/backend/internal/httputil/middleware.go
+++ b/backend/internal/httputil/middleware.go
@@ -1,6 +1,7 @@
 package httputil
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 )
@@ -87,6 +88,15 @@ func JSONBodyCap(maxBytes int64) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// IsBodyTooLarge reports whether err is (or wraps) an *http.MaxBytesError — the
+// signal that a request body exceeded the cap set by a MaxBodyBytes* middleware.
+// Handlers that read bodies (multipart uploads, io.ReadAll) use it to answer 413
+// instead of a generic 400.
+func IsBodyTooLarge(err error) bool {
+	_, ok := errors.AsType[*http.MaxBytesError](err)
+	return ok
 }
 
 func isJSONContentType(ct string) bool {

--- a/backend/internal/httputil/middleware_test.go
+++ b/backend/internal/httputil/middleware_test.go
@@ -168,3 +168,44 @@ func TestMaxBodyBytes_StackedUnderJSONBodyCap(t *testing.T) {
 		t.Fatalf("expected inner JSON cap (10) to trip first, got Limit=%d", maxBytesErr.Limit)
 	}
 }
+
+func TestMaxBodyBytesWithUploads_PathSelectsCap(t *testing.T) {
+	// Small caps exercise the path-based selection without multi-MiB bodies:
+	// general=10, upload=50.
+	mw := MaxBodyBytesWithUploads(10, 50)
+
+	readErr := func(path string, n int) error {
+		var captured error
+		next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			_, captured = io.ReadAll(r.Body)
+		})
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(strings.Repeat("x", n)))
+		mw(next).ServeHTTP(httptest.NewRecorder(), req)
+		return captured
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		n       int
+		wantErr bool
+	}{
+		{"import under upload cap", "/api/prospects/import", 30, false},
+		{"import over upload cap", "/api/leads/import", 60, true},
+		{"non-import over general cap", "/api/prospects", 30, true},
+		{"non-import under general cap", "/api/leads", 5, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := readErr(tt.path, tt.n)
+			if tt.wantErr {
+				var maxErr *http.MaxBytesError
+				if !errors.As(err, &maxErr) {
+					t.Fatalf("expected *http.MaxBytesError, got %T (%v)", err, err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected read under cap to succeed, got %v", err)
+			}
+		})
+	}
+}

--- a/backend/internal/leads/handler.go
+++ b/backend/internal/leads/handler.go
@@ -292,6 +292,10 @@ func (h *Handler) importCSV() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		file, _, err := r.FormFile("file")
 		if err != nil {
+			if httputil.IsBodyTooLarge(err) {
+				httputil.WriteError(w, http.StatusRequestEntityTooLarge, "uploaded file too large")
+				return
+			}
 			httputil.WriteError(w, http.StatusBadRequest, "missing file field")
 			return
 		}
@@ -299,6 +303,10 @@ func (h *Handler) importCSV() http.HandlerFunc {
 
 		data, err := io.ReadAll(file)
 		if err != nil {
+			if httputil.IsBodyTooLarge(err) {
+				httputil.WriteError(w, http.StatusRequestEntityTooLarge, "uploaded file too large")
+				return
+			}
 			httputil.WriteError(w, http.StatusBadRequest, "failed to read file")
 			return
 		}

--- a/backend/internal/leads/handler_test.go
+++ b/backend/internal/leads/handler_test.go
@@ -465,6 +465,29 @@ func TestHandler_ImportCSV(t *testing.T) {
 	assert.Equal(t, 1, resp["imported"])
 }
 
+func TestHandler_ImportCSV_TooLarge(t *testing.T) {
+	repo := newMockRepo()
+	// Tiny caps exercise the 413 path without a real 50 MiB body: upload=50 bytes.
+	r := chi.NewRouter()
+	r.Use(httputil.MaxBodyBytesWithUploads(10, 50))
+	RegisterRoutes(r, NewUseCase(repo, &mockAI{}, nil))
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", "big.csv")
+	require.NoError(t, err)
+	_, err = fw.Write(bytes.Repeat([]byte("x"), 200)) // exceeds the 50-byte upload cap
+	require.NoError(t, err)
+	mw.Close()
+
+	w := httptest.NewRecorder()
+	req := reqWithUser("POST", "/api/leads/import", &buf, uuid.New())
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code, "oversized upload must be 413, not 400")
+}
+
 func TestHandler_ImportCSV_NoFile(t *testing.T) {
 	r := newTestRouter(NewUseCase(newMockRepo(), &mockAI{}, nil))
 	w := httptest.NewRecorder()

--- a/backend/internal/prospects/handler.go
+++ b/backend/internal/prospects/handler.go
@@ -95,6 +95,10 @@ func (h *Handler) importCSV() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		file, _, err := r.FormFile("file")
 		if err != nil {
+			if httputil.IsBodyTooLarge(err) {
+				httputil.WriteError(w, http.StatusRequestEntityTooLarge, "uploaded file too large")
+				return
+			}
 			httputil.WriteError(w, http.StatusBadRequest, "missing file field")
 			return
 		}
@@ -102,6 +106,10 @@ func (h *Handler) importCSV() http.HandlerFunc {
 
 		data, err := io.ReadAll(file)
 		if err != nil {
+			if httputil.IsBodyTooLarge(err) {
+				httputil.WriteError(w, http.StatusRequestEntityTooLarge, "uploaded file too large")
+				return
+			}
 			httputil.WriteError(w, http.StatusBadRequest, "failed to read file")
 			return
 		}

--- a/backend/internal/prospects/handler_test.go
+++ b/backend/internal/prospects/handler_test.go
@@ -295,6 +295,31 @@ func TestHandler_ImportCSV_OK(t *testing.T) {
 	assert.Empty(t, resp.Skipped)
 }
 
+func TestHandler_ImportCSV_TooLarge(t *testing.T) {
+	repo := newMockRepo()
+	uc := NewUseCase(repo, WithLeadChecker(&mockLeadChecker{}))
+	// Tiny caps exercise the 413 path without a real 50 MiB body: upload=50 bytes.
+	r := chi.NewRouter()
+	r.Use(httputil.MaxBodyBytesWithUploads(10, 50))
+	RegisterRoutes(r, uc)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", "big.csv")
+	require.NoError(t, err)
+	_, err = fw.Write(bytes.Repeat([]byte("x"), 200)) // exceeds the 50-byte upload cap
+	require.NoError(t, err)
+	mw.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/prospects/import", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req = authedRequest(req, uuid.New())
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code, "oversized upload must be 413, not 400")
+}
+
 func TestHandler_ImportCSV_MissingFile(t *testing.T) {
 	repo := newMockRepo()
 	uc := NewUseCase(repo)


### PR DESCRIPTION
Sub-issue A из security follow-ups #92. Поднимает лимит тела для multipart CSV-import маршрутов (`/api/prospects/import`, `/api/leads/import`) до 50 MiB, сохраняя общий 10 MiB-ceiling везде иначе.

## Важно: подход A1 из issue не работает
Issue предлагал `r.With(MaxBodyBytes(50MiB))` поверх глобального `MaxBodyBytes(10MiB)`. Это НЕ сработало бы: `http.MaxBytesReader` — smallest-wins, внутренний 50 MiB не переопределяет внешний 10 MiB (10 всё равно зарежет). Чтобы upload реально получил 50 MiB, у него не должно быть 10-MiB-предка.

## Решение
**Path-aware root-middleware** `httputil.MaxBodyBytesWithUploads(general, upload)` вместо router-split: применяет `general` (10 MiB) ко всем, кроме путей с суффиксом `/import` (multipart-маршруты), которым даёт `upload` (50 MiB). Один задокументированный middleware, без дробления API пакетов и ре-индента main.go.

- `httputil`: `MaxBodyBytesWithUploads` + `DefaultMaxUploadBytes=50 MiB` + shared `IsBodyTooLarge(err)` (Go 1.26 `errors.AsType[*http.MaxBytesError]`). onec-вебхук переведён на тот же helper (single source of truth).
- `prospects`/`leads` importCSV: oversized → **413** (а не generic 400), через `IsBodyTooLarge`.
- `main.go`: глобальный cap заменён на path-aware; `JSONBodyCap(1 MiB)` остаётся и composes (smallest-wins → JSON-роуты по-прежнему 1 MiB).

## Security
- 10 MiB-ceiling сохранён для всех не-import маршрутов, включая anti-spoofing: спуф `Content-Type` на JSON-хендлер всё равно упирается во внешний 10 MiB-reader.
- Только точный суффикс `/import` ослабляет лимит; `/import/`, `/IMPORT` падают на general (и 404 на роутере) — обход вниз невозможен (покрыто тестом).

## Тесты (TDD, RED→GREEN)
- `httputil`: path-selection table-driven (6 кейсов вкл. edge: trailing slash, uppercase).
- `prospects`/`leads`: 413 на oversized import (handler-level, малые cap'ы вместо реального 50 MiB).
- Регрессий нет: JSON/обычные роуты без изменений, build + все тесты зелёные.

## Ревью
Независимое ревью: TDD 9 / DDD 8 / CA 8 (все оси ≥8). Important (DRY с onec) + 2 minor (комментарий belt-and-suspenders, edge-кейсы пути) закрыты.

Closes #99
Refs #92
