### PR TITLE
fix(security): wire #99 upload cap + apply review follow-ups

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -203,16 +203,18 @@ func main() {
 	r.Use(middleware.Recoverer)
 	r.Use(corsMiddleware)
 	// Defence in depth on request body size:
-	//   1) MaxBodyBytes (outer, 10 MiB) — unconditional ceiling so a
-	//      client omitting or spoofing Content-Type cannot stream past
-	//      the cap into a handler. Multipart uploads (importCSV) are
-	//      bounded here as well.
+	//   1) MaxBodyBytesWithUploads (outer) — unconditional ceiling so a client
+	//      omitting or spoofing Content-Type cannot stream past the cap. General
+	//      routes get 10 MiB; the multipart CSV-import routes (/…/import) get
+	//      50 MiB so legitimate enterprise imports fit. Path-based rather than a
+	//      per-route override because MaxBytesReader is smallest-wins — a higher
+	//      inner cap cannot loosen a lower ancestor (#99).
 	//   2) JSONBodyCap (inner, 1 MiB) — tighter cap that fires only for
 	//      application/json bodies; MaxBytesReader composes downward so
 	//      JSON clients trip the inner cap first.
 	//   3) Handler-local caps (e.g. bulk endpoint's 256 KiB) still win
 	//      when wrapped after the middleware — smallest in chain wins.
-	r.Use(httputil.MaxBodyBytes(httputil.DefaultMaxBodyBytes))
+	r.Use(httputil.MaxBodyBytesWithUploads(httputil.DefaultMaxBodyBytes, httputil.DefaultMaxUploadBytes))
 	r.Use(httputil.JSONBodyCap(httputil.DefaultMaxJSONBodyBytes))
 
 	// Health (public)

--- a/backend/internal/httputil/middleware_test.go
+++ b/backend/internal/httputil/middleware_test.go
@@ -194,6 +194,11 @@ func TestMaxBodyBytesWithUploads_PathSelectsCap(t *testing.T) {
 		{"import over upload cap", "/api/leads/import", 60, true},
 		{"non-import over general cap", "/api/prospects", 30, true},
 		{"non-import under general cap", "/api/leads", 5, false},
+		// Only an exact "/import" suffix loosens the cap. Variants fall back to
+		// the general ceiling (and would 404 at the router anyway) — they must
+		// never be a way around the tighter limit.
+		{"trailing slash stays general", "/api/leads/import/", 30, true},
+		{"uppercase stays general", "/api/leads/IMPORT", 30, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/backend/internal/integrations/onec/handler.go
+++ b/backend/internal/integrations/onec/handler.go
@@ -56,7 +56,7 @@ func (h *Handler) Webhook(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		// A body that exceeds the JSONBodyCap is a size violation (413), not
 		// malformed JSON (400).
-		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+		if httputil.IsBodyTooLarge(err) {
 			http.Error(w, "payload too large", http.StatusRequestEntityTooLarge)
 			return
 		}

--- a/backend/internal/leads/handler.go
+++ b/backend/internal/leads/handler.go
@@ -303,6 +303,9 @@ func (h *Handler) importCSV() http.HandlerFunc {
 
 		data, err := io.ReadAll(file)
 		if err != nil {
+			// Belt-and-suspenders: an oversized body almost always trips the cap
+			// earlier in FormFile/ParseMultipartForm, but keep the 413 mapping
+			// here too so a streamed read can never surface as a generic 400.
 			if httputil.IsBodyTooLarge(err) {
 				httputil.WriteError(w, http.StatusRequestEntityTooLarge, "uploaded file too large")
 				return

--- a/backend/internal/prospects/handler.go
+++ b/backend/internal/prospects/handler.go
@@ -106,6 +106,9 @@ func (h *Handler) importCSV() http.HandlerFunc {
 
 		data, err := io.ReadAll(file)
 		if err != nil {
+			// Belt-and-suspenders: an oversized body almost always trips the cap
+			// earlier in FormFile/ParseMultipartForm, but keep the 413 mapping
+			// here too so a streamed read can never surface as a generic 400.
 			if httputil.IsBodyTooLarge(err) {
 				httputil.WriteError(w, http.StatusRequestEntityTooLarge, "uploaded file too large")
 				return


### PR DESCRIPTION
Долив к #99: завершает фичу per-route upload caps, которая в v0.33.0 уехала неполной из-за моей ошибки в процессе (wiring в main.go не был закоммичен перед мёржем #116, плюс review-followup коммит не дотолкнут).

## Что чинит
1. **Wiring (поведенческий баг)**: в v0.33.0 `MaxBodyBytesWithUploads` существовал, но main.go всё ещё звал старый `MaxBodyBytes(10 MiB)` на root → 50 MiB-cap на `/import` был инертен, импорт оставался зажат 10 MiB. Теперь wiring подключён — фича реально работает.
2. **Review-followups #99** (были закоммичены локально, но не попали в #116):
   - onec webhook 413-детект переведён на shared `httputil.IsBodyTooLarge` (DRY, single source of truth) — important из ревью.
   - комментарий на belt-and-suspenders ReadAll-ветку 413.
   - edge-кейсы пути (`/import/`, `/IMPORT`) в тесте middleware.

## Почему слип не поймался
Хендлер-тесты навешивают middleware вручную, а композитный root-роутер из main.go не покрыт интеграционным тестом — поэтому отсутствие wiring прошло зелёным. Зафиксировано как известный пробел.

Build + все тесты (httputil/prospects/leads/onec/cmd) зелёные.

Refs #99, #92
