### PR TITLE
feat(security): per-IP rate-limit on /api/auth/login + /register (#100)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,15 @@ JWT_SECRET=change-me
 JWT_EXPIRES_IN=15m
 JWT_REFRESH_EXPIRES_IN=7d
 
+# Auth rate limits (per client IP). Login: AUTH_LOGIN_RATE_LIMIT attempts
+# per 5 min. Register: AUTH_REGISTER_RATE_LIMIT sign-ups per hour.
+AUTH_LOGIN_RATE_LIMIT=5
+AUTH_REGISTER_RATE_LIMIT=3
+# Trust X-Forwarded-For / X-Real-IP when resolving the client IP. Leave
+# false unless a reverse proxy that OVERWRITES these headers sits in
+# front of the app — otherwise the per-IP rate limit is spoofable.
+TRUST_PROXY=false
+
 # AI Provider: claude | openai | groq | ollama
 AI_PROVIDER=claude
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -54,6 +54,16 @@ import (
 // comes from config so ops can tighten on demand without rebuild.
 const pendingReplyRateWindow = time.Minute
 
+// Auth rate-limit windows are fixed in the composition root; only the
+// per-window budgets come from config (cfg.AuthLoginRateLimit /
+// cfg.AuthRegisterRateLimit). Login: 5 attempts / 5 min — sane online
+// brute-force protection. Register: 3 / hour — anti-spam without
+// blocking a legitimate signup retry.
+const (
+	authLoginRateWindow    = 5 * time.Minute
+	authRegisterRateWindow = time.Hour
+)
+
 func main() {
 	// Load .env file (ignore error if missing — production uses real env vars).
 	_ = godotenv.Load()
@@ -147,29 +157,49 @@ func main() {
 	// bot -> usecase -> dispatcher -> bot cycle.
 	pendingReplyUC := inbox.NewPendingReplyUseCase(pendingReplyRepo, nil)
 
-	// Rate limiter for pending-reply approve/reject. Redis-backed when
-	// REDIS_URL is set (multi-instance safe); falls back to an in-
-	// process sliding-window for single-instance dev/test. Middleware
-	// fails open on Limiter errors so a Redis outage does not lock
-	// operators out of urgent approvals.
-	var pendingReplyLimiter ratelimit.Limiter
+	// Rate limiters. Redis-backed when REDIS_URL is set (multi-instance
+	// safe); falls back to an in-process sliding-window for single-
+	// instance dev/test. The Middleware fails open on Limiter errors so
+	// a Redis outage cannot lock legitimate users out. One Redis client
+	// is shared by every limiter so the connection pool is not
+	// duplicated per route.
+	var redisClient redis.UniversalClient
 	if cfg.RedisURL != "" {
 		redisOpt, err := redis.ParseURL(cfg.RedisURL)
 		if err != nil {
 			log.Fatalf("invalid REDIS_URL: %v", err)
 		}
-		redisClient := redis.NewClient(redisOpt)
+		rc := redis.NewClient(redisOpt)
 		pingCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		if err := redisClient.Ping(pingCtx).Err(); err != nil {
+		if err := rc.Ping(pingCtx).Err(); err != nil {
 			slog.Warn("redis ping failed at startup; rate limiter will fail-open until reachable", "err", err)
 		}
 		cancel()
-		pendingReplyLimiter = ratelimit.NewRedisLimiter(redisClient, cfg.PendingReplyRateLimitPerMin, pendingReplyRateWindow)
+		redisClient = rc
 	} else {
 		slog.Warn("REDIS_URL not set; using in-process rate limiter (single-instance only)")
-		pendingReplyLimiter = ratelimit.NewInMemoryLimiter(cfg.PendingReplyRateLimitPerMin, pendingReplyRateWindow)
 	}
-	pendingReplyDecideMW := ratelimit.Middleware(pendingReplyLimiter, pendingReplyKeyFn, slog.Default())
+	newLimiter := func(limit int, window time.Duration) ratelimit.Limiter {
+		if redisClient != nil {
+			return ratelimit.NewRedisLimiter(redisClient, limit, window)
+		}
+		return ratelimit.NewInMemoryLimiter(limit, window)
+	}
+
+	// HITL approve/reject — keyed per authenticated user_id.
+	pendingReplyDecideMW := ratelimit.Middleware(
+		newLimiter(cfg.PendingReplyRateLimitPerMin, pendingReplyRateWindow),
+		pendingReplyKeyFn, slog.Default())
+
+	// Public auth endpoints — keyed per client IP (caller is not yet
+	// authenticated). Separate key prefixes keep login and register
+	// buckets from colliding in the shared Redis keyspace.
+	authLoginMW := ratelimit.Middleware(
+		newLimiter(cfg.AuthLoginRateLimit, authLoginRateWindow),
+		ratelimit.IPKeyFunc("ratelimit:auth-login:"), slog.Default())
+	authRegisterMW := ratelimit.Middleware(
+		newLimiter(cfg.AuthRegisterRateLimit, authRegisterRateWindow),
+		ratelimit.IPKeyFunc("ratelimit:auth-register:"), slog.Default())
 
 	// 4. Adapters
 	leadsAI := leads.NewAIAdapter(aiClient)
@@ -227,8 +257,8 @@ func main() {
 	// Tracking pixel (public, no auth — loaded by email clients)
 	sequences.RegisterPublicRoutes(r, sequencesUC)
 
-	// Auth (public)
-	auth.RegisterRoutes(r, authHandler)
+	// Auth (public) — login/register rate-limited per client IP.
+	auth.RegisterRoutes(r, authHandler, authLoginMW, authRegisterMW)
 
 	// 1C inbound webhook (public — authenticated by per-user secret, not JWT).
 	// Mapping resolves event kinds + counterparty fields; the applier routes

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -196,10 +196,10 @@ func main() {
 	// buckets from colliding in the shared Redis keyspace.
 	authLoginMW := ratelimit.Middleware(
 		newLimiter(cfg.AuthLoginRateLimit, authLoginRateWindow),
-		ratelimit.IPKeyFunc("ratelimit:auth-login:"), slog.Default())
+		ratelimit.IPKeyFunc("ratelimit:auth-login:", cfg.TrustProxyHeaders), slog.Default())
 	authRegisterMW := ratelimit.Middleware(
 		newLimiter(cfg.AuthRegisterRateLimit, authRegisterRateWindow),
-		ratelimit.IPKeyFunc("ratelimit:auth-register:"), slog.Default())
+		ratelimit.IPKeyFunc("ratelimit:auth-register:", cfg.TrustProxyHeaders), slog.Default())
 
 	// 4. Adapters
 	leadsAI := leads.NewAIAdapter(aiClient)

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -27,8 +27,21 @@ func NewHandler(repo UserRepository, jwtSecret string) *Handler {
 // not in this package. Either may be nil (e.g. in tests), in which case
 // that route is mounted without a limiter.
 func RegisterRoutes(r chi.Router, h *Handler, loginMW, registerMW func(http.Handler) http.Handler) {
-	r.Post("/api/auth/register", h.Register)
-	r.Post("/api/auth/login", h.Login)
+	register := http.HandlerFunc(h.Register)
+	login := http.HandlerFunc(h.Login)
+	if registerMW != nil {
+		r.Method(http.MethodPost, "/api/auth/register", registerMW(register))
+	} else {
+		r.Method(http.MethodPost, "/api/auth/register", register)
+	}
+	if loginMW != nil {
+		r.Method(http.MethodPost, "/api/auth/login", loginMW(login))
+	} else {
+		r.Method(http.MethodPost, "/api/auth/login", login)
+	}
+	// Refresh is intentionally not rate-limited: it requires a valid
+	// signed refresh token, which is not brute-forceable, so a per-IP
+	// cap would only risk throttling legitimate token rotation.
 	r.Post("/api/auth/refresh", h.Refresh)
 }
 

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -21,7 +21,12 @@ func NewHandler(repo UserRepository, jwtSecret string) *Handler {
 	return &Handler{repo: repo, jwtSecret: []byte(jwtSecret)}
 }
 
-func RegisterRoutes(r chi.Router, h *Handler) {
+// RegisterRoutes mounts the public auth endpoints. loginMW and
+// registerMW are per-route rate-limit middlewares supplied by the
+// composition root (DI) — the limits and storage backend live there,
+// not in this package. Either may be nil (e.g. in tests), in which case
+// that route is mounted without a limiter.
+func RegisterRoutes(r chi.Router, h *Handler, loginMW, registerMW func(http.Handler) http.Handler) {
 	r.Post("/api/auth/register", h.Register)
 	r.Post("/api/auth/login", h.Login)
 	r.Post("/api/auth/refresh", h.Refresh)

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -434,7 +434,7 @@ func TestRegisterRoutes(t *testing.T) {
 	repo := newMockUserRepo()
 	h := newTestHandlerWithRepo(repo)
 	r := chi.NewRouter()
-	RegisterRoutes(r, h)
+	RegisterRoutes(r, h, nil, nil)
 
 	// Test that register endpoint is routed
 	body, _ := json.Marshal(registerRequest{Email: "route@test.com", Password: "secure123", FullName: "Route Test"})

--- a/backend/internal/auth/ratelimit_test.go
+++ b/backend/internal/auth/ratelimit_test.go
@@ -19,7 +19,7 @@ import (
 // these tests exercise the real KeyFunc + Middleware path.
 func limitMW(prefix string, limit int) func(http.Handler) http.Handler {
 	l := ratelimit.NewInMemoryLimiter(limit, time.Minute)
-	return ratelimit.Middleware(l, ratelimit.IPKeyFunc(prefix), nil)
+	return ratelimit.Middleware(l, ratelimit.IPKeyFunc(prefix, false), nil)
 }
 
 func postJSON(t *testing.T, r chi.Router, path string, v any) *httptest.ResponseRecorder {

--- a/backend/internal/auth/ratelimit_test.go
+++ b/backend/internal/auth/ratelimit_test.go
@@ -1,0 +1,103 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/daniil/floq/internal/ratelimit"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// limitMW builds a per-IP rate-limit middleware backed by an in-memory
+// sliding window — the same wiring shape the composition root uses, so
+// these tests exercise the real KeyFunc + Middleware path.
+func limitMW(prefix string, limit int) func(http.Handler) http.Handler {
+	l := ratelimit.NewInMemoryLimiter(limit, time.Minute)
+	return ratelimit.Middleware(l, ratelimit.IPKeyFunc(prefix), nil)
+}
+
+func postJSON(t *testing.T, r chi.Router, path string, v any) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(v)
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestRegisterRoutes_LoginRateLimited(t *testing.T) {
+	repo := newMockUserRepo()
+	h := newTestHandlerWithRepo(repo)
+	r := chi.NewRouter()
+	RegisterRoutes(r, h, limitMW("ratelimit:test-login:", 2), nil)
+
+	// Seed a real user so wrong-password attempts hit the bcrypt path.
+	rec := postJSON(t, r, "/api/auth/register", registerRequest{
+		Email: "victim@example.com", Password: "correct-horse", FullName: "Victim",
+	})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	bad := loginRequest{Email: "victim@example.com", Password: "wrong"}
+
+	// First two brute-force attempts are answered normally (401).
+	for i := 1; i <= 2; i++ {
+		rec := postJSON(t, r, "/api/auth/login", bad)
+		require.Equalf(t, http.StatusUnauthorized, rec.Code, "attempt %d", i)
+	}
+
+	// Third attempt from the same IP must be rate-limited.
+	rec = postJSON(t, r, "/api/auth/login", bad)
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code, "3rd attempt must be 429")
+
+	// Security: a rate-limited response must NOT leak credential state —
+	// the attacker should see the generic limit message, not "invalid
+	// credentials" (which distinguishes wrong-password from rate-limit).
+	assert.NotContains(t, rec.Body.String(), "invalid credentials")
+	assert.Contains(t, rec.Body.String(), "rate limit exceeded")
+	assert.NotEmpty(t, rec.Header().Get("Retry-After"))
+}
+
+func TestRegisterRoutes_RegisterRateLimited(t *testing.T) {
+	repo := newMockUserRepo()
+	h := newTestHandlerWithRepo(repo)
+	r := chi.NewRouter()
+	RegisterRoutes(r, h, nil, limitMW("ratelimit:test-register:", 2))
+
+	// Two distinct sign-ups succeed.
+	for i, email := range []string{"a@example.com", "b@example.com"} {
+		rec := postJSON(t, r, "/api/auth/register", registerRequest{
+			Email: email, Password: "secure123", FullName: "User",
+		})
+		require.Equalf(t, http.StatusCreated, rec.Code, "signup %d", i+1)
+	}
+
+	// Third signup from the same IP is throttled (anti-spam).
+	rec := postJSON(t, r, "/api/auth/register", registerRequest{
+		Email: "c@example.com", Password: "secure123", FullName: "User",
+	})
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code, "3rd signup must be 429")
+}
+
+func TestRegisterRoutes_LimitersDoNotCrossContaminate(t *testing.T) {
+	repo := newMockUserRepo()
+	h := newTestHandlerWithRepo(repo)
+	r := chi.NewRouter()
+	RegisterRoutes(r, h, limitMW("ratelimit:test-login:", 1), limitMW("ratelimit:test-register:", 5))
+
+	// Exhaust the login limiter.
+	bad := loginRequest{Email: "nobody@example.com", Password: "x"}
+	require.Equal(t, http.StatusUnauthorized, postJSON(t, r, "/api/auth/login", bad).Code)
+	require.Equal(t, http.StatusTooManyRequests, postJSON(t, r, "/api/auth/login", bad).Code)
+
+	// Register must be unaffected by the exhausted login bucket.
+	rec := postJSON(t, r, "/api/auth/register", registerRequest{
+		Email: "fresh@example.com", Password: "secure123", FullName: "Fresh",
+	})
+	assert.Equal(t, http.StatusCreated, rec.Code, "register bucket must be independent of login bucket")
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -45,6 +45,15 @@ type Config struct {
 	// order of magnitude above any legitimate human cadence, still
 	// capped enough to bound abuse from a compromised JWT.
 	PendingReplyRateLimitPerMin int
+	// AuthLoginRateLimit caps login attempts per client IP within the
+	// login window (5 minutes, fixed in the composition root). Default 5
+	// — enough headroom for a fat-fingered human, tight enough to make
+	// online brute-force / credential-stuffing impractical.
+	AuthLoginRateLimit int
+	// AuthRegisterRateLimit caps sign-ups per client IP within the
+	// register window (1 hour, fixed in the composition root). Default 3
+	// — anti-spam without blocking a legitimate signup retry.
+	AuthRegisterRateLimit int
 }
 
 // Load reads configuration from environment variables and returns a Config.
@@ -84,6 +93,8 @@ func Load() *Config {
 		StaleDays:       getEnvInt("STALE_DAYS", 2),
 		ProxyURL:        os.Getenv("PROXY_URL"),
 		PendingReplyRateLimitPerMin: getEnvInt("RATE_LIMIT_PENDING_REPLIES_PER_MIN", 30),
+		AuthLoginRateLimit:          getEnvInt("AUTH_LOGIN_RATE_LIMIT", 5),
+		AuthRegisterRateLimit:       getEnvInt("AUTH_REGISTER_RATE_LIMIT", 3),
 	}
 }
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -54,6 +54,14 @@ type Config struct {
 	// register window (1 hour, fixed in the composition root). Default 3
 	// — anti-spam without blocking a legitimate signup retry.
 	AuthRegisterRateLimit int
+	// TrustProxyHeaders decides whether X-Forwarded-For / X-Real-IP are
+	// believed when resolving the client IP for per-IP rate limits.
+	// Default false: the committed deploy binds the backend directly
+	// (no reverse proxy), where those headers are attacker-controlled
+	// and trusting them would let a single host rotate the header to
+	// dodge the cap. Set TRUST_PROXY=true only when a reverse proxy that
+	// overwrites these headers sits in front of the app.
+	TrustProxyHeaders bool
 }
 
 // Load reads configuration from environment variables and returns a Config.
@@ -95,6 +103,7 @@ func Load() *Config {
 		PendingReplyRateLimitPerMin: getEnvInt("RATE_LIMIT_PENDING_REPLIES_PER_MIN", 30),
 		AuthLoginRateLimit:          getEnvInt("AUTH_LOGIN_RATE_LIMIT", 5),
 		AuthRegisterRateLimit:       getEnvInt("AUTH_REGISTER_RATE_LIMIT", 3),
+		TrustProxyHeaders:           getEnvBool("TRUST_PROXY", false),
 	}
 }
 
@@ -109,6 +118,15 @@ func getEnvInt(key string, fallback int) int {
 	if v := os.Getenv(key); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			return n
+		}
+	}
+	return fallback
+}
+
+func getEnvBool(key string, fallback bool) bool {
+	if v := os.Getenv(key); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			return b
 		}
 	}
 	return fallback

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -15,6 +15,7 @@ func TestLoad_Defaults(t *testing.T) {
 		"OLLAMA_MODEL", "GROQ_MODEL", "IMAP_PORT", "OWNER_USER_ID",
 		"BOOKING_LINK", "SENDER_NAME", "SENDER_COMPANY", "STALE_DAYS",
 		"DATABASE_URL", "REDIS_URL", "JWT_SECRET",
+		"AUTH_LOGIN_RATE_LIMIT", "AUTH_REGISTER_RATE_LIMIT",
 	} {
 		t.Setenv(key, "")
 		os.Unsetenv(key)
@@ -35,6 +36,8 @@ func TestLoad_Defaults(t *testing.T) {
 	assert.Equal(t, "Дмитрий", cfg.SenderName)
 	assert.Equal(t, "dev-bot.su", cfg.SenderCompany)
 	assert.Equal(t, 2, cfg.StaleDays)
+	assert.Equal(t, 5, cfg.AuthLoginRateLimit)
+	assert.Equal(t, 3, cfg.AuthRegisterRateLimit)
 	assert.Empty(t, cfg.DatabaseURL)
 	assert.Empty(t, cfg.JWTSecret)
 }
@@ -46,6 +49,8 @@ func TestLoad_CustomEnvVars(t *testing.T) {
 	t.Setenv("AI_PROVIDER", "openai")
 	t.Setenv("STALE_DAYS", "7")
 	t.Setenv("SENDER_NAME", "Иван")
+	t.Setenv("AUTH_LOGIN_RATE_LIMIT", "10")
+	t.Setenv("AUTH_REGISTER_RATE_LIMIT", "1")
 
 	cfg := Load()
 	require.NotNil(t, cfg)
@@ -56,6 +61,8 @@ func TestLoad_CustomEnvVars(t *testing.T) {
 	assert.Equal(t, "openai", cfg.AIProvider)
 	assert.Equal(t, 7, cfg.StaleDays)
 	assert.Equal(t, "Иван", cfg.SenderName)
+	assert.Equal(t, 10, cfg.AuthLoginRateLimit)
+	assert.Equal(t, 1, cfg.AuthRegisterRateLimit)
 }
 
 func TestGetEnvInt_ValidInt(t *testing.T) {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -15,7 +15,7 @@ func TestLoad_Defaults(t *testing.T) {
 		"OLLAMA_MODEL", "GROQ_MODEL", "IMAP_PORT", "OWNER_USER_ID",
 		"BOOKING_LINK", "SENDER_NAME", "SENDER_COMPANY", "STALE_DAYS",
 		"DATABASE_URL", "REDIS_URL", "JWT_SECRET",
-		"AUTH_LOGIN_RATE_LIMIT", "AUTH_REGISTER_RATE_LIMIT",
+		"AUTH_LOGIN_RATE_LIMIT", "AUTH_REGISTER_RATE_LIMIT", "TRUST_PROXY",
 	} {
 		t.Setenv(key, "")
 		os.Unsetenv(key)
@@ -38,6 +38,7 @@ func TestLoad_Defaults(t *testing.T) {
 	assert.Equal(t, 2, cfg.StaleDays)
 	assert.Equal(t, 5, cfg.AuthLoginRateLimit)
 	assert.Equal(t, 3, cfg.AuthRegisterRateLimit)
+	assert.False(t, cfg.TrustProxyHeaders, "TRUST_PROXY must default to false — app is exposed directly")
 	assert.Empty(t, cfg.DatabaseURL)
 	assert.Empty(t, cfg.JWTSecret)
 }
@@ -51,6 +52,7 @@ func TestLoad_CustomEnvVars(t *testing.T) {
 	t.Setenv("SENDER_NAME", "Иван")
 	t.Setenv("AUTH_LOGIN_RATE_LIMIT", "10")
 	t.Setenv("AUTH_REGISTER_RATE_LIMIT", "1")
+	t.Setenv("TRUST_PROXY", "true")
 
 	cfg := Load()
 	require.NotNil(t, cfg)
@@ -63,6 +65,7 @@ func TestLoad_CustomEnvVars(t *testing.T) {
 	assert.Equal(t, "Иван", cfg.SenderName)
 	assert.Equal(t, 10, cfg.AuthLoginRateLimit)
 	assert.Equal(t, 1, cfg.AuthRegisterRateLimit)
+	assert.True(t, cfg.TrustProxyHeaders)
 }
 
 func TestGetEnvInt_ValidInt(t *testing.T) {

--- a/backend/internal/ratelimit/key.go
+++ b/backend/internal/ratelimit/key.go
@@ -1,0 +1,64 @@
+package ratelimit
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// IPFromRequest resolves the client IP of an unauthenticated request so
+// public endpoints (login, register) can be bucketed per source address.
+// Precedence: X-Forwarded-For (first hop) → X-Real-IP → RemoteAddr. It
+// returns ok=false when no usable IP can be extracted, which the
+// middleware treats as "do not rate-limit" (fail-open) rather than
+// hashing every unresolvable request into one shared bucket.
+//
+// SECURITY: X-Forwarded-For / X-Real-IP are client-supplied and trivially
+// spoofable. Trusting them is only safe when the app sits behind a
+// reverse proxy that OVERWRITES these headers with the real peer address
+// (the deploy topology here — chi behind a proxy). If the app is ever
+// exposed directly, an attacker can rotate the header to dodge the
+// per-IP cap; in that topology this resolver should be gated behind a
+// trust-proxy switch. Documented rather than silently assumed.
+func IPFromRequest(r *http.Request) (string, bool) {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// First hop is the originating client; the rest are proxies.
+		first := strings.TrimSpace(strings.SplitN(xff, ",", 2)[0])
+		if first != "" {
+			return first, true
+		}
+	}
+	if xr := strings.TrimSpace(r.Header.Get("X-Real-IP")); xr != "" {
+		return xr, true
+	}
+	if r.RemoteAddr == "" {
+		return "", false
+	}
+	// RemoteAddr is normally host:port; tolerate a bare IP too.
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		if host != "" {
+			return host, true
+		}
+		return "", false
+	}
+	if ip := net.ParseIP(r.RemoteAddr); ip != nil {
+		return r.RemoteAddr, true
+	}
+	return "", false
+}
+
+// IPKeyFunc returns a KeyFunc that buckets requests by client IP under
+// the given namespace prefix. The prefix keeps separate limiters (e.g.
+// login vs register) from colliding in a shared Redis keyspace, where a
+// bare IP key would otherwise mix attempts across both endpoints. When
+// the IP cannot be resolved it returns ok=false so the middleware
+// fails open.
+func IPKeyFunc(prefix string) KeyFunc {
+	return func(r *http.Request) (string, bool) {
+		ip, ok := IPFromRequest(r)
+		if !ok {
+			return "", false
+		}
+		return prefix + ip, true
+	}
+}

--- a/backend/internal/ratelimit/key.go
+++ b/backend/internal/ratelimit/key.go
@@ -8,40 +8,50 @@ import (
 
 // IPFromRequest resolves the client IP of an unauthenticated request so
 // public endpoints (login, register) can be bucketed per source address.
-// Precedence: X-Forwarded-For (first hop) → X-Real-IP → RemoteAddr. It
-// returns ok=false when no usable IP can be extracted, which the
+// It returns ok=false when no usable IP can be extracted, which the
 // middleware treats as "do not rate-limit" (fail-open) rather than
 // hashing every unresolvable request into one shared bucket.
 //
-// SECURITY: X-Forwarded-For / X-Real-IP are client-supplied and trivially
-// spoofable. Trusting them is only safe when the app sits behind a
-// reverse proxy that OVERWRITES these headers with the real peer address
-// (the deploy topology here — chi behind a proxy). If the app is ever
-// exposed directly, an attacker can rotate the header to dodge the
-// per-IP cap; in that topology this resolver should be gated behind a
-// trust-proxy switch. Documented rather than silently assumed.
-func IPFromRequest(r *http.Request) (string, bool) {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// First hop is the originating client; the rest are proxies.
-		first := strings.TrimSpace(strings.SplitN(xff, ",", 2)[0])
-		if first != "" {
-			return first, true
+// trustProxy decides whether forwarded headers are believed:
+//
+//   - false (default): use only RemoteAddr — the real TCP peer. This is
+//     correct when the app is exposed directly (the committed
+//     docker-compose binds backend :8080 with no reverse proxy). X-
+//     Forwarded-For / X-Real-IP are client-supplied and trivially
+//     spoofable, so a different value per request would let an attacker
+//     dodge the per-IP cap entirely — exactly the brute-force the limit
+//     exists to stop. Ignoring them closes that bypass.
+//   - true: honor X-Forwarded-For (first hop) → X-Real-IP → RemoteAddr.
+//     Only safe behind a reverse proxy that OVERWRITES these headers
+//     with the real peer address. Enable via TRUST_PROXY once such a
+//     proxy is in front of the app.
+//
+// Header values are validated with net.ParseIP; a malformed entry falls
+// through to the next source rather than becoming a bogus bucket key.
+func IPFromRequest(r *http.Request, trustProxy bool) (string, bool) {
+	if trustProxy {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			// First hop is the originating client; the rest are proxies.
+			first := strings.TrimSpace(strings.SplitN(xff, ",", 2)[0])
+			if net.ParseIP(first) != nil {
+				return first, true
+			}
 		}
-	}
-	if xr := strings.TrimSpace(r.Header.Get("X-Real-IP")); xr != "" {
-		return xr, true
+		if xr := strings.TrimSpace(r.Header.Get("X-Real-IP")); net.ParseIP(xr) != nil {
+			return xr, true
+		}
 	}
 	if r.RemoteAddr == "" {
 		return "", false
 	}
 	// RemoteAddr is normally host:port; tolerate a bare IP too.
 	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
-		if host != "" {
+		if net.ParseIP(host) != nil {
 			return host, true
 		}
 		return "", false
 	}
-	if ip := net.ParseIP(r.RemoteAddr); ip != nil {
+	if net.ParseIP(r.RemoteAddr) != nil {
 		return r.RemoteAddr, true
 	}
 	return "", false
@@ -50,12 +60,12 @@ func IPFromRequest(r *http.Request) (string, bool) {
 // IPKeyFunc returns a KeyFunc that buckets requests by client IP under
 // the given namespace prefix. The prefix keeps separate limiters (e.g.
 // login vs register) from colliding in a shared Redis keyspace, where a
-// bare IP key would otherwise mix attempts across both endpoints. When
-// the IP cannot be resolved it returns ok=false so the middleware
-// fails open.
-func IPKeyFunc(prefix string) KeyFunc {
+// bare IP key would otherwise mix attempts across both endpoints.
+// trustProxy is threaded to IPFromRequest. When the IP cannot be
+// resolved it returns ok=false so the middleware fails open.
+func IPKeyFunc(prefix string, trustProxy bool) KeyFunc {
 	return func(r *http.Request) (string, bool) {
-		ip, ok := IPFromRequest(r)
+		ip, ok := IPFromRequest(r, trustProxy)
 		if !ok {
 			return "", false
 		}

--- a/backend/internal/ratelimit/key_test.go
+++ b/backend/internal/ratelimit/key_test.go
@@ -1,0 +1,150 @@
+package ratelimit_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daniil/floq/internal/ratelimit"
+)
+
+func TestIPFromRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		headers    map[string]string
+		wantIP     string
+		wantOK     bool
+	}{
+		{
+			name:       "remote addr host:port strips port",
+			remoteAddr: "203.0.113.7:54321",
+			wantIP:     "203.0.113.7",
+			wantOK:     true,
+		},
+		{
+			name:       "remote addr already bare ip",
+			remoteAddr: "203.0.113.7",
+			wantIP:     "203.0.113.7",
+			wantOK:     true,
+		},
+		{
+			name:       "x-forwarded-for takes precedence over remote addr",
+			remoteAddr: "10.0.0.1:9999",
+			headers:    map[string]string{"X-Forwarded-For": "198.51.100.23"},
+			wantIP:     "198.51.100.23",
+			wantOK:     true,
+		},
+		{
+			name:       "x-forwarded-for uses first ip in chain",
+			remoteAddr: "10.0.0.1:9999",
+			headers:    map[string]string{"X-Forwarded-For": "198.51.100.23, 70.41.3.18, 150.172.238.178"},
+			wantIP:     "198.51.100.23",
+			wantOK:     true,
+		},
+		{
+			name:       "x-forwarded-for trims surrounding whitespace",
+			remoteAddr: "10.0.0.1:9999",
+			headers:    map[string]string{"X-Forwarded-For": "  198.51.100.23  ,70.41.3.18"},
+			wantIP:     "198.51.100.23",
+			wantOK:     true,
+		},
+		{
+			name:       "x-real-ip used when no forwarded-for",
+			remoteAddr: "10.0.0.1:9999",
+			headers:    map[string]string{"X-Real-IP": "192.0.2.44"},
+			wantIP:     "192.0.2.44",
+			wantOK:     true,
+		},
+		{
+			name:       "forwarded-for wins over real-ip",
+			remoteAddr: "10.0.0.1:9999",
+			headers:    map[string]string{"X-Forwarded-For": "198.51.100.23", "X-Real-IP": "192.0.2.44"},
+			wantIP:     "198.51.100.23",
+			wantOK:     true,
+		},
+		{
+			name:       "ipv6 remote addr strips port",
+			remoteAddr: "[2001:db8::1]:443",
+			wantIP:     "2001:db8::1",
+			wantOK:     true,
+		},
+		{
+			name:       "empty forwarded-for falls back to remote addr",
+			remoteAddr: "203.0.113.7:54321",
+			headers:    map[string]string{"X-Forwarded-For": "   "},
+			wantIP:     "203.0.113.7",
+			wantOK:     true,
+		},
+		{
+			name:       "unparseable remote addr fails open",
+			remoteAddr: "garbage",
+			wantIP:     "",
+			wantOK:     false,
+		},
+		{
+			name:       "empty remote addr and no headers fails open",
+			remoteAddr: "",
+			wantIP:     "",
+			wantOK:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+			req.RemoteAddr = tc.remoteAddr
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+
+			ip, ok := ratelimit.IPFromRequest(req)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (ip=%q)", ok, tc.wantOK, ip)
+			}
+			if ip != tc.wantIP {
+				t.Errorf("ip = %q, want %q", ip, tc.wantIP)
+			}
+		})
+	}
+}
+
+func TestIPKeyFunc(t *testing.T) {
+	keyFn := ratelimit.IPKeyFunc("ratelimit:auth-login:")
+
+	t.Run("prefixes the resolved ip", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+		req.RemoteAddr = "203.0.113.7:54321"
+
+		key, ok := keyFn(req)
+		if !ok {
+			t.Fatal("expected ok=true for a resolvable ip")
+		}
+		if key != "ratelimit:auth-login:203.0.113.7" {
+			t.Errorf("key = %q, want %q", key, "ratelimit:auth-login:203.0.113.7")
+		}
+	})
+
+	t.Run("unresolvable ip bypasses (ok=false)", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+		req.RemoteAddr = "garbage"
+
+		key, ok := keyFn(req)
+		if ok {
+			t.Errorf("expected ok=false when ip cannot be resolved, got key=%q", key)
+		}
+	})
+
+	t.Run("distinct ips map to distinct keys", func(t *testing.T) {
+		reqA := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+		reqA.RemoteAddr = "203.0.113.7:1111"
+		reqB := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+		reqB.RemoteAddr = "203.0.113.8:2222"
+
+		keyA, _ := keyFn(reqA)
+		keyB, _ := keyFn(reqB)
+		if keyA == keyB {
+			t.Errorf("distinct ips produced identical keys %q", keyA)
+		}
+	})
+}

--- a/backend/internal/ratelimit/key_test.go
+++ b/backend/internal/ratelimit/key_test.go
@@ -12,6 +12,7 @@ func TestIPFromRequest(t *testing.T) {
 	tests := []struct {
 		name       string
 		remoteAddr string
+		trustProxy bool
 		headers    map[string]string
 		wantIP     string
 		wantOK     bool
@@ -29,51 +30,9 @@ func TestIPFromRequest(t *testing.T) {
 			wantOK:     true,
 		},
 		{
-			name:       "x-forwarded-for takes precedence over remote addr",
-			remoteAddr: "10.0.0.1:9999",
-			headers:    map[string]string{"X-Forwarded-For": "198.51.100.23"},
-			wantIP:     "198.51.100.23",
-			wantOK:     true,
-		},
-		{
-			name:       "x-forwarded-for uses first ip in chain",
-			remoteAddr: "10.0.0.1:9999",
-			headers:    map[string]string{"X-Forwarded-For": "198.51.100.23, 70.41.3.18, 150.172.238.178"},
-			wantIP:     "198.51.100.23",
-			wantOK:     true,
-		},
-		{
-			name:       "x-forwarded-for trims surrounding whitespace",
-			remoteAddr: "10.0.0.1:9999",
-			headers:    map[string]string{"X-Forwarded-For": "  198.51.100.23  ,70.41.3.18"},
-			wantIP:     "198.51.100.23",
-			wantOK:     true,
-		},
-		{
-			name:       "x-real-ip used when no forwarded-for",
-			remoteAddr: "10.0.0.1:9999",
-			headers:    map[string]string{"X-Real-IP": "192.0.2.44"},
-			wantIP:     "192.0.2.44",
-			wantOK:     true,
-		},
-		{
-			name:       "forwarded-for wins over real-ip",
-			remoteAddr: "10.0.0.1:9999",
-			headers:    map[string]string{"X-Forwarded-For": "198.51.100.23", "X-Real-IP": "192.0.2.44"},
-			wantIP:     "198.51.100.23",
-			wantOK:     true,
-		},
-		{
 			name:       "ipv6 remote addr strips port",
 			remoteAddr: "[2001:db8::1]:443",
 			wantIP:     "2001:db8::1",
-			wantOK:     true,
-		},
-		{
-			name:       "empty forwarded-for falls back to remote addr",
-			remoteAddr: "203.0.113.7:54321",
-			headers:    map[string]string{"X-Forwarded-For": "   "},
-			wantIP:     "203.0.113.7",
 			wantOK:     true,
 		},
 		{
@@ -88,6 +47,101 @@ func TestIPFromRequest(t *testing.T) {
 			wantIP:     "",
 			wantOK:     false,
 		},
+
+		// --- trustProxy=false: forwarded headers MUST be ignored
+		// (otherwise a directly-exposed app lets an attacker rotate
+		// X-Forwarded-For to dodge the per-IP cap). ---
+		{
+			name:       "untrusted proxy ignores x-forwarded-for, uses remote addr",
+			remoteAddr: "203.0.113.7:54321",
+			trustProxy: false,
+			headers:    map[string]string{"X-Forwarded-For": "198.51.100.23"},
+			wantIP:     "203.0.113.7",
+			wantOK:     true,
+		},
+		{
+			name:       "untrusted proxy ignores x-real-ip, uses remote addr",
+			remoteAddr: "203.0.113.7:54321",
+			trustProxy: false,
+			headers:    map[string]string{"X-Real-IP": "198.51.100.23"},
+			wantIP:     "203.0.113.7",
+			wantOK:     true,
+		},
+		{
+			name:       "untrusted proxy does not fall back to spoofable header",
+			remoteAddr: "garbage",
+			trustProxy: false,
+			headers:    map[string]string{"X-Forwarded-For": "198.51.100.23"},
+			wantIP:     "",
+			wantOK:     false,
+		},
+
+		// --- trustProxy=true: honor headers, client is behind a proxy
+		// that overwrites them with the real peer address. ---
+		{
+			name:       "trusted proxy: x-forwarded-for takes precedence",
+			remoteAddr: "10.0.0.1:9999",
+			trustProxy: true,
+			headers:    map[string]string{"X-Forwarded-For": "198.51.100.23"},
+			wantIP:     "198.51.100.23",
+			wantOK:     true,
+		},
+		{
+			name:       "trusted proxy: x-forwarded-for uses first ip in chain",
+			remoteAddr: "10.0.0.1:9999",
+			trustProxy: true,
+			headers:    map[string]string{"X-Forwarded-For": "198.51.100.23, 70.41.3.18, 150.172.238.178"},
+			wantIP:     "198.51.100.23",
+			wantOK:     true,
+		},
+		{
+			name:       "trusted proxy: trims surrounding whitespace",
+			remoteAddr: "10.0.0.1:9999",
+			trustProxy: true,
+			headers:    map[string]string{"X-Forwarded-For": "  198.51.100.23  ,70.41.3.18"},
+			wantIP:     "198.51.100.23",
+			wantOK:     true,
+		},
+		{
+			name:       "trusted proxy: x-real-ip used when no forwarded-for",
+			remoteAddr: "10.0.0.1:9999",
+			trustProxy: true,
+			headers:    map[string]string{"X-Real-IP": "192.0.2.44"},
+			wantIP:     "192.0.2.44",
+			wantOK:     true,
+		},
+		{
+			name:       "trusted proxy: forwarded-for wins over real-ip",
+			remoteAddr: "10.0.0.1:9999",
+			trustProxy: true,
+			headers:    map[string]string{"X-Forwarded-For": "198.51.100.23", "X-Real-IP": "192.0.2.44"},
+			wantIP:     "198.51.100.23",
+			wantOK:     true,
+		},
+		{
+			name:       "trusted proxy: empty forwarded-for falls back to remote addr",
+			remoteAddr: "203.0.113.7:54321",
+			trustProxy: true,
+			headers:    map[string]string{"X-Forwarded-For": "   "},
+			wantIP:     "203.0.113.7",
+			wantOK:     true,
+		},
+		{
+			name:       "trusted proxy: non-ip forwarded-for falls through to real-ip",
+			remoteAddr: "10.0.0.1:9999",
+			trustProxy: true,
+			headers:    map[string]string{"X-Forwarded-For": "not-an-ip", "X-Real-IP": "192.0.2.44"},
+			wantIP:     "192.0.2.44",
+			wantOK:     true,
+		},
+		{
+			name:       "trusted proxy: non-ip headers fall through to remote addr",
+			remoteAddr: "203.0.113.7:54321",
+			trustProxy: true,
+			headers:    map[string]string{"X-Forwarded-For": "not-an-ip", "X-Real-IP": "also-bad"},
+			wantIP:     "203.0.113.7",
+			wantOK:     true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -98,7 +152,7 @@ func TestIPFromRequest(t *testing.T) {
 				req.Header.Set(k, v)
 			}
 
-			ip, ok := ratelimit.IPFromRequest(req)
+			ip, ok := ratelimit.IPFromRequest(req, tc.trustProxy)
 			if ok != tc.wantOK {
 				t.Fatalf("ok = %v, want %v (ip=%q)", ok, tc.wantOK, ip)
 			}
@@ -110,7 +164,7 @@ func TestIPFromRequest(t *testing.T) {
 }
 
 func TestIPKeyFunc(t *testing.T) {
-	keyFn := ratelimit.IPKeyFunc("ratelimit:auth-login:")
+	keyFn := ratelimit.IPKeyFunc("ratelimit:auth-login:", false)
 
 	t.Run("prefixes the resolved ip", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
@@ -122,6 +176,23 @@ func TestIPKeyFunc(t *testing.T) {
 		}
 		if key != "ratelimit:auth-login:203.0.113.7" {
 			t.Errorf("key = %q, want %q", key, "ratelimit:auth-login:203.0.113.7")
+		}
+	})
+
+	t.Run("untrusted proxy ignores spoofed x-forwarded-for", func(t *testing.T) {
+		// Two requests with the SAME peer but DIFFERENT spoofed XFF must
+		// map to the SAME key — otherwise the per-IP cap is bypassable.
+		reqA := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+		reqA.RemoteAddr = "203.0.113.7:1111"
+		reqA.Header.Set("X-Forwarded-For", "1.1.1.1")
+		reqB := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+		reqB.RemoteAddr = "203.0.113.7:2222"
+		reqB.Header.Set("X-Forwarded-For", "2.2.2.2")
+
+		keyA, _ := keyFn(reqA)
+		keyB, _ := keyFn(reqB)
+		if keyA != keyB {
+			t.Errorf("spoofed XFF produced distinct keys %q vs %q — per-IP cap bypassable", keyA, keyB)
 		}
 	})
 
@@ -145,6 +216,18 @@ func TestIPKeyFunc(t *testing.T) {
 		keyB, _ := keyFn(reqB)
 		if keyA == keyB {
 			t.Errorf("distinct ips produced identical keys %q", keyA)
+		}
+	})
+
+	t.Run("trusted proxy honors x-forwarded-for", func(t *testing.T) {
+		trusted := ratelimit.IPKeyFunc("ratelimit:auth-login:", true)
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+		req.RemoteAddr = "10.0.0.1:9999"
+		req.Header.Set("X-Forwarded-For", "198.51.100.23")
+
+		key, ok := trusted(req)
+		if !ok || key != "ratelimit:auth-login:198.51.100.23" {
+			t.Errorf("trusted proxy key = %q ok=%v, want ...198.51.100.23", key, ok)
 		}
 	})
 }


### PR DESCRIPTION
Closes #100 (sub-task B of #92).

## Что
Публичные auth-эндпоинты (`/api/auth/login`, `/api/auth/register`) теперь под per-IP rate-limit — защита от brute-force / credential-stuffing на login и spam-регистрации.

- **login**: 5 попыток / IP / 5 мин (`AUTH_LOGIN_RATE_LIMIT`)
- **register**: 3 / IP / час (`AUTH_REGISTER_RATE_LIMIT`)
- **429**, не 401 — rate-limited ответ не отличить от «wrong password» (нет information leak).
- **refresh** намеренно не лимитируется (требует подписанный токен, не брутфорсится).

Переиспользует существующий `ratelimit.Middleware` (fail-open на сбое Redis, Retry-After) и Redis-or-inmemory паттерн от pending-replies. Один Redis-клиент шарится всеми лимитерами.

## IP-резолв и анти-спуфинг
`ratelimit.IPKeyFunc(prefix, trustProxy)` + `IPFromRequest`:
- **`TRUST_PROXY=false` (default)** — ключ строится ТОЛЬКО из `RemoteAddr` (реальный TCP-peer). Текущий деплой биндит backend напрямую (`docker-compose` `8080:8080`, без reverse-proxy), поэтому `X-Forwarded-For`/`X-Real-IP` атакующий-контролируемы; доверять им = дать обойти лимит ротацией заголовка. Игнорируем.
- **`TRUST_PROXY=true`** — `XFF (first hop) → X-Real-IP → RemoteAddr`, включать только за прокси, который ПЕРЕЗАПИСЫВАЕТ эти заголовки.
- Все источники валидируются через `net.ParseIP`; мусорный токен проваливается дальше по цепочке.
- Префиксы ключей (`ratelimit:auth-login:` / `ratelimit:auth-register:`) разводят бакеты login/register в общем Redis-keyspace.

## Конфиг (новые env, см. `.env.example`)
`AUTH_LOGIN_RATE_LIMIT=5`, `AUTH_REGISTER_RATE_LIMIT=3`, `TRUST_PROXY=false`. Окна (5 мин / 1 час) фиксированы в composition root.

## TDD
12 коммитов, строгие RED→GREEN пары (IP KeyFunc, route-wiring, config vars, trust-proxy gate). Table-driven `IPFromRequest` (16 кейсов). Тест на information-leak (429 не содержит «invalid credentials»), на bypass-resistance (один peer + разные спуфнутые XFF → один key), на изоляцию login/register бакетов.

## Проверка
- `go test ./...` — 34 пакета зелёные, 0 FAIL.
- Кросс-сборка `GOOS=linux GOARCH=arm64` — OK.
- Двойной проход независимого ревью (TDD/DDD/CA): первый нашёл XFF-spoofing (MAJOR) + отсутствие ParseIP (MINOR) — оба исправлены; повторное ревью подтвердило все оси ≥8/10, blocker/major нет.

Миграций нет, repo-слой не затронут (integration-сёрфейс без изменений).