### PR TITLE
feat(audit): audit_log retention rollup + purge cron (#101)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,12 @@ AUTH_REGISTER_RATE_LIMIT=3
 # front of the app — otherwise the per-IP rate limit is spoofable.
 TRUST_PROXY=false
 
+# Audit-log retention. Per-call rows older than AUDIT_RETENTION_DAYS are
+# rolled up into audit_log_daily and deleted; the cron runs every
+# AUDIT_RETENTION_INTERVAL.
+AUDIT_RETENTION_DAYS=30
+AUDIT_RETENTION_INTERVAL=24h
+
 # AI Provider: claude | openai | groq | ollama
 AI_PROVIDER=claude
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -330,6 +330,12 @@ func main() {
 	// 1C reconciliation cron — recovers lost webhooks every 15 minutes, stops on ctx.
 	go onec.NewReconcileCron(onecReconcileUC, 15*time.Minute, slog.Default()).Start(ctx)
 
+	// Audit-log retention cron (#101) — rolls per-call rows older than the
+	// retention window into audit_log_daily and purges them, bounding
+	// unbounded growth of the cost ledger. Stops on ctx.
+	auditRetentionUC := audit.NewRetentionUseCase(auditRepo, cfg.AuditRetentionDays)
+	go audit.NewRetentionCron(auditRetentionUC, cfg.AuditRetentionInterval, slog.Default()).Start(ctx)
+
 	// 8. Optional: Telegram inbox bot
 	// Read token from DB first, fall back to .env
 	prospectAdapter := newProspectRepoAdapter(prospectsRepo, txManager)

--- a/backend/internal/audit/cost_summary_integration_test.go
+++ b/backend/internal/audit/cost_summary_integration_test.go
@@ -97,6 +97,43 @@ func TestRepository_CostSummary_IncludesAggregatedHistory(t *testing.T) {
 	assert.Equal(t, 2, byModel["m2"].Calls)
 }
 
+// TestRepository_CostSummary_SplitDayNoLossNoDoubleCount pins the
+// tightest invariant of the union: a SINGLE calendar day whose rows are
+// split between audit_log (afternoon, not yet purged) and
+// audit_log_daily (morning, already rolled up by the cron) must sum to
+// the day's true total — neither dropping the detailed tail nor
+// double-counting the rolled-up head. The two sides hold different
+// physical rows, so the outer SUM is exact.
+func TestRepository_CostSummary_SplitDayNoLossNoDoubleCount(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := audit.NewRepository(pool)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	// A day near the retention boundary, split across both tables.
+	splitDay := now.AddDate(0, 0, -30)
+	splitDayAfternoon := time.Date(splitDay.Year(), splitDay.Month(), splitDay.Day(), 18, 0, 0, 0, time.UTC)
+
+	// Morning of splitDay: already purged → lives only in the rollup.
+	seedDailyRollup(t, pool, userID, splitDay, "test-provider", "m1", "qualification", 3, 3_000_000, 300, 150)
+	// Afternoon of the SAME day: still detailed in audit_log.
+	seedAuditEntry(t, pool, userID, "qualification", "m1", 1_000_000, 100, 50, splitDayAfternoon)
+
+	from := now.AddDate(0, 0, -60)
+	to := now.Add(time.Hour)
+	got, err := repo.CostSummary(ctx, userID, from, to)
+	require.NoError(t, err)
+
+	assert.Equal(t, 4, got.TotalCalls, "morning rollup (3) + afternoon detail (1), no loss/no double-count")
+	assert.EqualValues(t, 4_000_000, got.TotalUSDMicro)
+	require.Len(t, got.ByRequestType, 1)
+	assert.Equal(t, "qualification", got.ByRequestType[0].RequestType)
+	assert.Equal(t, 4, got.ByRequestType[0].Calls)
+	assert.EqualValues(t, 400, got.ByRequestType[0].InputTokens)
+	assert.EqualValues(t, 200, got.ByRequestType[0].OutputTokens)
+}
+
 func TestRepository_CostSummary_DailyRollupScopedByUserAndRange(t *testing.T) {
 	pool := testutil.TestDB(t)
 	userA := testutil.SeedUser(t, pool)

--- a/backend/internal/audit/cost_summary_integration_test.go
+++ b/backend/internal/audit/cost_summary_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/daniil/floq/internal/audit"
+	"github.com/daniil/floq/internal/audit/domain"
 	"github.com/daniil/floq/internal/testutil"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -30,6 +31,92 @@ func seedAuditEntry(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID, requestT
 		 VALUES ($1, $2, $3, 'test-provider', $4, $5, $6, $7, $8, 100, 'success', $9)`,
 		id, userID, requestType, model, inTokens, outTokens, totalTokens, costMicro, createdAt)
 	require.NoError(t, err, "seed audit entry")
+}
+
+// seedDailyRollup inserts one pre-aggregated audit_log_daily bucket —
+// the shape the retention cron leaves behind after purging old per-call
+// rows. Used to assert the cost summary stitches recent detail together
+// with aggregated history.
+func seedDailyRollup(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID, day time.Time, provider, model, reqType string, calls, costMicro, inTok, outTok int64) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO audit_log_daily
+			(day, user_id, provider, model, request_type,
+			 total_calls, total_cost_usd_micro, total_input_tokens, total_output_tokens)
+		 VALUES ($1::date, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		day, userID, provider, model, reqType, calls, costMicro, inTok, outTok)
+	require.NoError(t, err, "seed daily rollup")
+}
+
+func TestRepository_CostSummary_IncludesAggregatedHistory(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := audit.NewRepository(pool)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	// One recent detailed row still in audit_log.
+	seedAuditEntry(t, pool, userID, "qualification", "m1", 1_000_000, 100, 50, now)
+	// Aggregated history in the daily rollup: same request_type+model so
+	// the breakdowns must MERGE detail and rollup, not list them twice.
+	oldDay := now.AddDate(0, 0, -40)
+	seedDailyRollup(t, pool, userID, oldDay, "test-provider", "m1", "qualification", 5, 5_000_000, 500, 250)
+	// A different model, only in history — must appear in by_model.
+	seedDailyRollup(t, pool, userID, oldDay, "test-provider", "m2", "draft_reply", 2, 2_000_000, 200, 100)
+
+	from := now.AddDate(0, 0, -60)
+	to := now.Add(time.Hour)
+	got, err := repo.CostSummary(ctx, userID, from, to)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	// Totals span detail + history: 1 + 5 + 2 = 8 calls, 8 USD micro.
+	assert.Equal(t, 8, got.TotalCalls)
+	assert.EqualValues(t, 8_000_000, got.TotalUSDMicro)
+
+	// by_request_type: qualification merges recent (1c) + history (5c) = 6c.
+	byType := map[string]domain.RequestTypeBreakdown{}
+	for _, b := range got.ByRequestType {
+		byType[b.RequestType] = b
+	}
+	require.Contains(t, byType, "qualification")
+	assert.Equal(t, 6, byType["qualification"].Calls, "recent detail + aggregated history merge")
+	assert.EqualValues(t, 6_000_000, byType["qualification"].USDMicro)
+	assert.EqualValues(t, 600, byType["qualification"].InputTokens)
+	assert.EqualValues(t, 300, byType["qualification"].OutputTokens)
+	require.Contains(t, byType, "draft_reply")
+	assert.Equal(t, 2, byType["draft_reply"].Calls)
+
+	// by_model: m1 merges detail+history (6c), m2 from history only (2c).
+	byModel := map[string]domain.ModelBreakdown{}
+	for _, b := range got.ByModel {
+		byModel[b.Model] = b
+	}
+	assert.Equal(t, 6, byModel["m1"].Calls)
+	assert.EqualValues(t, 6_000_000, byModel["m1"].USDMicro)
+	assert.Equal(t, 2, byModel["m2"].Calls)
+}
+
+func TestRepository_CostSummary_DailyRollupScopedByUserAndRange(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userA := testutil.SeedUser(t, pool)
+	userB := testutil.SeedUser(t, pool)
+	repo := audit.NewRepository(pool)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	// userB's history must never leak into userA's summary.
+	seedDailyRollup(t, pool, userB, now.AddDate(0, 0, -40), "test-provider", "m1", "qualification", 99, 99_000_000, 9, 9)
+	// userA history inside and outside the queried range.
+	seedDailyRollup(t, pool, userA, now.AddDate(0, 0, -40), "test-provider", "m1", "qualification", 5, 5_000_000, 50, 25)
+	seedDailyRollup(t, pool, userA, now.AddDate(0, 0, -400), "test-provider", "m1", "qualification", 7, 7_000_000, 70, 35)
+
+	from := now.AddDate(0, 0, -60)
+	to := now.Add(time.Hour)
+	got, err := repo.CostSummary(ctx, userA, from, to)
+	require.NoError(t, err)
+	assert.Equal(t, 5, got.TotalCalls, "only userA's in-range history counts")
+	assert.EqualValues(t, 5_000_000, got.TotalUSDMicro, "cross-tenant + out-of-range history excluded")
 }
 
 func TestRepository_CostSummary_AggregatesByRequestTypeAndModel(t *testing.T) {

--- a/backend/internal/audit/domain/ports.go
+++ b/backend/internal/audit/domain/ports.go
@@ -24,6 +24,20 @@ type AuditRepository interface {
 	CostSummary(ctx context.Context, userID uuid.UUID, from, to time.Time) (*CostSummary, error)
 }
 
+// RetentionRepository rolls audit_log rows older than a threshold into
+// the audit_log_daily aggregate and deletes them, in one atomic step.
+// Segregated from AuditRepository: its only consumer is the retention
+// cron, which has no business reaching the per-call write/read surface.
+type RetentionRepository interface {
+	// AggregateAndPurgeOlderThan aggregates every audit_log row with
+	// created_at < threshold into audit_log_daily (summing onto any
+	// existing bucket for the same day/user/provider/model/request_type)
+	// and deletes those rows, returning how many were purged. It is
+	// idempotent: a second call with the same threshold finds nothing to
+	// move and leaves the daily buckets unchanged.
+	AggregateAndPurgeOlderThan(ctx context.Context, threshold time.Time) (purged int, err error)
+}
+
 // Recorder is the port the RecordingProvider decorator uses to hand
 // finished call records off to background storage. Implementations are
 // expected to be non-blocking: a stuck or saturated recorder must NOT

--- a/backend/internal/audit/domain/ports.go
+++ b/backend/internal/audit/domain/ports.go
@@ -17,10 +17,11 @@ import (
 // pgx.CopyFrom. An empty slice is a no-op.
 type AuditRepository interface {
 	Save(ctx context.Context, entries []*Entry) error
-	// CostSummary aggregates audit_log rows for one user over a closed
-	// time range [from, to). Returns zero-valued breakdown slices (not
-	// nil) when nothing matches so JSON serialisation produces [] rather
-	// than null.
+	// CostSummary aggregates spend for one user over the half-open range
+	// [from, to), stitching the detailed audit_log together with the
+	// audit_log_daily rollup so reports survive the retention cron.
+	// Returns zero-valued breakdown slices (not nil) when nothing matches
+	// so JSON serialisation produces [] rather than null.
 	CostSummary(ctx context.Context, userID uuid.UUID, from, to time.Time) (*CostSummary, error)
 }
 

--- a/backend/internal/audit/repository.go
+++ b/backend/internal/audit/repository.go
@@ -80,11 +80,16 @@ func (r *Repository) Save(ctx context.Context, entries []*domain.Entry) error {
 // — so a UNION ALL summed in an outer GROUP BY cannot double-count.
 //
 // The daily side is filtered on its day column by the UTC calendar date
-// of the bounds. Aggregated history is therefore day-granular: a from/to
-// that lands mid-day on an already-rolled-up day pulls that whole day's
-// bucket. This is the accepted trade-off of aggregate-then-delete
-// (per-call precision is shed beyond the retention window); recent data,
-// where sub-day precision matters, is still served from audit_log.
+// of the bounds. Aggregated history is therefore day-granular: when
+// `from` lands mid-day on an already-rolled-up day, the whole day's
+// bucket is included — i.e. the result OVER-includes the part of that
+// edge day before `from` (it can never lose or double-count rows, only
+// pull in extra pre-`from` spend on the boundary day). This is the
+// accepted trade-off of aggregate-then-delete: per-call/sub-day
+// precision is shed beyond the retention window, while recent data —
+// where sub-day precision matters — is still served from audit_log. The
+// default lookback equals the retention window, so the boundary almost
+// always falls outside the rolled-up range.
 //
 // Two grouped queries (by request_type, by model); totals derive from
 // the request-type breakdown to avoid a third round-trip and stay

--- a/backend/internal/audit/repository.go
+++ b/backend/internal/audit/repository.go
@@ -12,8 +12,11 @@ import (
 	"github.com/daniil/floq/internal/audit/domain"
 )
 
-// Compile-time check: Repository satisfies the domain port.
-var _ domain.AuditRepository = (*Repository)(nil)
+// Compile-time check: Repository satisfies the domain ports.
+var (
+	_ domain.AuditRepository     = (*Repository)(nil)
+	_ domain.RetentionRepository = (*Repository)(nil)
+)
 
 // Repository persists audit_log rows via pgx. Bulk inserts use
 // pgx.CopyFrom so a buffered batch from the async recorder writes in
@@ -133,6 +136,59 @@ func (r *Repository) CostSummary(ctx context.Context, userID uuid.UUID, from, to
 		return nil, fmt.Errorf("audit cost-summary by model rows: %w", err)
 	}
 	return summary, nil
+}
+
+// AggregateAndPurgeOlderThan implements domain.RetentionRepository. The
+// roll-up and the delete run as ONE data-modifying CTE so they share a
+// single snapshot: the rows fed into the aggregate are exactly the rows
+// deleted, with no window in which a concurrent writer's row could be
+// purged-but-not-counted. (In practice the recorder always stamps
+// created_at=now(), so no fresh row is ever < threshold — but the CTE
+// makes that safety structural rather than incidental.)
+//
+// Day bucketing uses the UTC calendar date of created_at so the result
+// is independent of the connection's session timezone and lines up with
+// the day-range filter the cost-summary read path applies to this table.
+// ON CONFLICT accumulates onto an existing bucket, which keeps the
+// operation idempotent and correct when a day is purged across multiple
+// runs.
+func (r *Repository) AggregateAndPurgeOlderThan(ctx context.Context, threshold time.Time) (int, error) {
+	var purged int
+	err := r.pool.QueryRow(ctx, `
+WITH purged AS (
+    DELETE FROM audit_log
+    WHERE created_at < $1
+    RETURNING (created_at AT TIME ZONE 'UTC')::date AS day,
+              user_id, provider, model, request_type,
+              cost_usd_micro, input_tokens, output_tokens
+),
+agg AS (
+    SELECT day, user_id, provider, model, request_type,
+           COUNT(*)                        AS total_calls,
+           COALESCE(SUM(cost_usd_micro), 0) AS total_cost,
+           COALESCE(SUM(input_tokens), 0)   AS total_in,
+           COALESCE(SUM(output_tokens), 0)  AS total_out
+    FROM purged
+    GROUP BY day, user_id, provider, model, request_type
+),
+ins AS (
+    INSERT INTO audit_log_daily AS d
+        (day, user_id, provider, model, request_type,
+         total_calls, total_cost_usd_micro, total_input_tokens, total_output_tokens)
+    SELECT day, user_id, provider, model, request_type,
+           total_calls, total_cost, total_in, total_out
+    FROM agg
+    ON CONFLICT (day, user_id, provider, model, request_type) DO UPDATE SET
+        total_calls          = d.total_calls          + EXCLUDED.total_calls,
+        total_cost_usd_micro = d.total_cost_usd_micro + EXCLUDED.total_cost_usd_micro,
+        total_input_tokens   = d.total_input_tokens   + EXCLUDED.total_input_tokens,
+        total_output_tokens  = d.total_output_tokens  + EXCLUDED.total_output_tokens
+)
+SELECT COUNT(*) FROM purged`, threshold).Scan(&purged)
+	if err != nil {
+		return 0, fmt.Errorf("audit retention aggregate-and-purge: %w", err)
+	}
+	return purged, nil
 }
 
 // nullableUUID converts an optional UUID into the form pgx expects for

--- a/backend/internal/audit/repository.go
+++ b/backend/internal/audit/repository.go
@@ -71,14 +71,26 @@ func (r *Repository) Save(ctx context.Context, entries []*domain.Entry) error {
 	return nil
 }
 
-// CostSummary aggregates audit_log rows for one user over the half-
-// open interval [from, to). Two grouped queries (by request_type, by
-// model) — totals are derived from the request-type breakdown to
-// avoid a third round-trip and stay consistent by construction.
+// CostSummary aggregates spend for one user over the half-open interval
+// [from, to). It stitches together two sources so reports survive the
+// retention cron: the detailed per-call audit_log (recent rows) and the
+// audit_log_daily rollup (older rows the cron has already purged from
+// audit_log). The two are disjoint by construction — a row lives in
+// exactly one of them, since the cron deletes and aggregates atomically
+// — so a UNION ALL summed in an outer GROUP BY cannot double-count.
 //
-// Breakdowns are ordered by USDMicro DESC so the operator dashboard
-// shows the most expensive surface first. Empty slices are returned
-// instead of nil so the JSON wire-shape stays predictable.
+// The daily side is filtered on its day column by the UTC calendar date
+// of the bounds. Aggregated history is therefore day-granular: a from/to
+// that lands mid-day on an already-rolled-up day pulls that whole day's
+// bucket. This is the accepted trade-off of aggregate-then-delete
+// (per-call precision is shed beyond the retention window); recent data,
+// where sub-day precision matters, is still served from audit_log.
+//
+// Two grouped queries (by request_type, by model); totals derive from
+// the request-type breakdown to avoid a third round-trip and stay
+// consistent by construction. Breakdowns are ordered by USDMicro DESC so
+// the dashboard shows the most expensive surface first. Empty slices
+// (not nil) keep the JSON wire-shape predictable.
 func (r *Repository) CostSummary(ctx context.Context, userID uuid.UUID, from, to time.Time) (*domain.CostSummary, error) {
 	summary := &domain.CostSummary{
 		ByRequestType: []domain.RequestTypeBreakdown{},
@@ -88,12 +100,28 @@ func (r *Repository) CostSummary(ctx context.Context, userID uuid.UUID, from, to
 	}
 
 	rows, err := r.pool.Query(ctx,
-		`SELECT request_type, COUNT(*), COALESCE(SUM(cost_usd_micro), 0),
-		        COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0)
-		 FROM audit_log
-		 WHERE user_id = $1 AND created_at >= $2 AND created_at < $3
-		 GROUP BY request_type
-		 ORDER BY SUM(cost_usd_micro) DESC`,
+		`SELECT dim, SUM(calls), SUM(cost), SUM(in_tok), SUM(out_tok)
+		 FROM (
+		     SELECT request_type AS dim, COUNT(*) AS calls,
+		            COALESCE(SUM(cost_usd_micro), 0) AS cost,
+		            COALESCE(SUM(input_tokens), 0) AS in_tok,
+		            COALESCE(SUM(output_tokens), 0) AS out_tok
+		     FROM audit_log
+		     WHERE user_id = $1 AND created_at >= $2 AND created_at < $3
+		     GROUP BY request_type
+		     UNION ALL
+		     SELECT request_type AS dim, COALESCE(SUM(total_calls), 0),
+		            COALESCE(SUM(total_cost_usd_micro), 0),
+		            COALESCE(SUM(total_input_tokens), 0),
+		            COALESCE(SUM(total_output_tokens), 0)
+		     FROM audit_log_daily
+		     WHERE user_id = $1
+		       AND day >= ($2 AT TIME ZONE 'UTC')::date
+		       AND day <  ($3 AT TIME ZONE 'UTC')::date
+		     GROUP BY request_type
+		 ) u
+		 GROUP BY dim
+		 ORDER BY SUM(cost) DESC`,
 		userID, from, to)
 	if err != nil {
 		return nil, fmt.Errorf("audit cost-summary by request_type: %w", err)
@@ -114,12 +142,28 @@ func (r *Repository) CostSummary(ctx context.Context, userID uuid.UUID, from, to
 	}
 
 	rows, err = r.pool.Query(ctx,
-		`SELECT model, COUNT(*), COALESCE(SUM(cost_usd_micro), 0),
-		        COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0)
-		 FROM audit_log
-		 WHERE user_id = $1 AND created_at >= $2 AND created_at < $3
-		 GROUP BY model
-		 ORDER BY SUM(cost_usd_micro) DESC`,
+		`SELECT dim, SUM(calls), SUM(cost), SUM(in_tok), SUM(out_tok)
+		 FROM (
+		     SELECT model AS dim, COUNT(*) AS calls,
+		            COALESCE(SUM(cost_usd_micro), 0) AS cost,
+		            COALESCE(SUM(input_tokens), 0) AS in_tok,
+		            COALESCE(SUM(output_tokens), 0) AS out_tok
+		     FROM audit_log
+		     WHERE user_id = $1 AND created_at >= $2 AND created_at < $3
+		     GROUP BY model
+		     UNION ALL
+		     SELECT model AS dim, COALESCE(SUM(total_calls), 0),
+		            COALESCE(SUM(total_cost_usd_micro), 0),
+		            COALESCE(SUM(total_input_tokens), 0),
+		            COALESCE(SUM(total_output_tokens), 0)
+		     FROM audit_log_daily
+		     WHERE user_id = $1
+		       AND day >= ($2 AT TIME ZONE 'UTC')::date
+		       AND day <  ($3 AT TIME ZONE 'UTC')::date
+		     GROUP BY model
+		 ) u
+		 GROUP BY dim
+		 ORDER BY SUM(cost) DESC`,
 		userID, from, to)
 	if err != nil {
 		return nil, fmt.Errorf("audit cost-summary by model: %w", err)

--- a/backend/internal/audit/retention_cron.go
+++ b/backend/internal/audit/retention_cron.go
@@ -1,0 +1,63 @@
+package audit
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// purger is the slice of RetentionUseCase the cron drives. An interface
+// so the loop is unit-testable with a fake.
+type purger interface {
+	Purge(ctx context.Context) (int, error)
+}
+
+// RetentionCron periodically rolls audit_log rows older than the
+// retention window into the daily aggregate and deletes them (#101). It
+// mirrors onec.ReconcileCron / reminders.Cron: a ticker loop that runs
+// once on startup and stops when its context is cancelled, so it shuts
+// down gracefully with the server.
+type RetentionCron struct {
+	uc       purger
+	interval time.Duration
+	logger   *slog.Logger
+}
+
+// NewRetentionCron builds the cron. A nil logger falls back to default.
+func NewRetentionCron(uc purger, interval time.Duration, logger *slog.Logger) *RetentionCron {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &RetentionCron{uc: uc, interval: interval, logger: logger}
+}
+
+// Start runs the retention loop until ctx is cancelled. It runs once
+// immediately so a freshly started server reclaims any backlog that
+// accrued while it was down, then on each interval tick.
+func (c *RetentionCron) Start(ctx context.Context) {
+	c.logger.Info("audit: retention cron started", "interval", c.interval)
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	c.runOnce(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("audit: retention cron shutting down")
+			return
+		case <-ticker.C:
+			c.runOnce(ctx)
+		}
+	}
+}
+
+func (c *RetentionCron) runOnce(ctx context.Context) {
+	purged, err := c.uc.Purge(ctx)
+	if err != nil {
+		c.logger.Warn("audit: retention pass failed", "err", err)
+		return
+	}
+	if purged > 0 {
+		c.logger.Info("audit: retention pass complete", "purged", purged)
+	}
+}

--- a/backend/internal/audit/retention_cron_test.go
+++ b/backend/internal/audit/retention_cron_test.go
@@ -1,0 +1,76 @@
+package audit
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakePurger struct {
+	calls int32
+	fn    func()
+}
+
+func (f *fakePurger) Purge(_ context.Context) (int, error) {
+	atomic.AddInt32(&f.calls, 1)
+	if f.fn != nil {
+		f.fn()
+	}
+	return 0, nil
+}
+
+func TestRetentionCron_RunsOnStartupThenStopsOnCancel(t *testing.T) {
+	ran := make(chan struct{}, 1)
+	p := &fakePurger{fn: func() {
+		select {
+		case ran <- struct{}{}:
+		default:
+		}
+	}}
+	cron := NewRetentionCron(p, time.Hour, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { cron.Start(ctx); close(done) }()
+
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Purge must run once on startup")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cron must stop when ctx is cancelled")
+	}
+	if atomic.LoadInt32(&p.calls) < 1 {
+		t.Fatal("expected at least one purge pass")
+	}
+}
+
+func TestRetentionCron_RunsAgainOnTick(t *testing.T) {
+	p := &fakePurger{}
+	cron := NewRetentionCron(p, 20*time.Millisecond, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go cron.Start(ctx)
+
+	// Startup pass + at least one tick within the budget.
+	deadline := time.After(2 * time.Second)
+	for {
+		if atomic.LoadInt32(&p.calls) >= 2 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("expected >=2 purge passes (startup + tick), got %d", atomic.LoadInt32(&p.calls))
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}

--- a/backend/internal/audit/retention_integration_test.go
+++ b/backend/internal/audit/retention_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package audit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/daniil/floq/internal/audit"
+	"github.com/daniil/floq/internal/testutil"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dailyRow mirrors one audit_log_daily row for assertions.
+type dailyRow struct {
+	day        time.Time
+	calls      int64
+	costMicro  int64
+	inTokens   int64
+	outTokens  int64
+}
+
+func readDailyRows(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID) []dailyRow {
+	t.Helper()
+	rows, err := pool.Query(context.Background(),
+		`SELECT day, total_calls, total_cost_usd_micro, total_input_tokens, total_output_tokens
+		 FROM audit_log_daily WHERE user_id = $1 ORDER BY day`, userID)
+	require.NoError(t, err)
+	defer rows.Close()
+	var out []dailyRow
+	for rows.Next() {
+		var r dailyRow
+		require.NoError(t, rows.Scan(&r.day, &r.calls, &r.costMicro, &r.inTokens, &r.outTokens))
+		out = append(out, r)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+func countAuditLog(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID) int {
+	t.Helper()
+	var n int
+	require.NoError(t, pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM audit_log WHERE user_id = $1`, userID).Scan(&n))
+	return n
+}
+
+func TestRepository_AggregateAndPurge_RollsUpOldRowsAndDeletesThem(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := audit.NewRepository(pool)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	threshold := now.AddDate(0, 0, -30)
+	oldDay := now.AddDate(0, 0, -40)
+
+	// Two old rows on the same (day, provider, model, request_type) must
+	// collapse into a single daily bucket with summed counts.
+	seedAuditEntry(t, pool, userID, "qualification", "m1", 1_000_000, 100, 50, oldDay)
+	seedAuditEntry(t, pool, userID, "qualification", "m1", 2_000_000, 200, 100, oldDay)
+	// A recent row (newer than the threshold) must be left untouched.
+	seedAuditEntry(t, pool, userID, "qualification", "m1", 9_000_000, 900, 450, now)
+
+	purged, err := repo.AggregateAndPurgeOlderThan(ctx, threshold)
+	require.NoError(t, err)
+	assert.Equal(t, 2, purged, "two rows older than threshold purged")
+
+	// Only the recent row survives in audit_log.
+	assert.Equal(t, 1, countAuditLog(t, pool, userID))
+
+	daily := readDailyRows(t, pool, userID)
+	require.Len(t, daily, 1, "two old rows of same key collapse to one daily bucket")
+	assert.EqualValues(t, 2, daily[0].calls)
+	assert.EqualValues(t, 3_000_000, daily[0].costMicro)
+	assert.EqualValues(t, 300, daily[0].inTokens)
+	assert.EqualValues(t, 150, daily[0].outTokens)
+	assert.Equal(t, oldDay.Format("2006-01-02"), daily[0].day.Format("2006-01-02"), "bucketed by calendar day of created_at")
+}
+
+func TestRepository_AggregateAndPurge_SkipsRecentRows(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := audit.NewRepository(pool)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	threshold := now.AddDate(0, 0, -30)
+
+	// All rows are recent — nothing to purge.
+	seedAuditEntry(t, pool, userID, "qualification", "m1", 1_000_000, 10, 5, now)
+	seedAuditEntry(t, pool, userID, "draft_reply", "m2", 2_000_000, 20, 10, now.AddDate(0, 0, -5))
+
+	purged, err := repo.AggregateAndPurgeOlderThan(ctx, threshold)
+	require.NoError(t, err)
+	assert.Equal(t, 0, purged, "no row older than threshold")
+	assert.Equal(t, 2, countAuditLog(t, pool, userID), "recent rows untouched")
+	assert.Empty(t, readDailyRows(t, pool, userID), "nothing rolled up")
+}
+
+func TestRepository_AggregateAndPurge_IsIdempotent(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := audit.NewRepository(pool)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	threshold := now.AddDate(0, 0, -30)
+	oldDay := now.AddDate(0, 0, -40)
+
+	seedAuditEntry(t, pool, userID, "qualification", "m1", 4_000_000, 400, 200, oldDay)
+
+	purged1, err := repo.AggregateAndPurgeOlderThan(ctx, threshold)
+	require.NoError(t, err)
+	assert.Equal(t, 1, purged1)
+
+	// Second run with the same threshold: the rows are already gone, so
+	// nothing is purged and the daily bucket must NOT be double-counted.
+	purged2, err := repo.AggregateAndPurgeOlderThan(ctx, threshold)
+	require.NoError(t, err)
+	assert.Equal(t, 0, purged2, "idempotent: second pass purges nothing")
+
+	daily := readDailyRows(t, pool, userID)
+	require.Len(t, daily, 1)
+	assert.EqualValues(t, 1, daily[0].calls, "bucket not inflated by re-run")
+	assert.EqualValues(t, 4_000_000, daily[0].costMicro)
+}
+
+func TestRepository_AggregateAndPurge_AccumulatesAcrossRuns(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := audit.NewRepository(pool)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	oldDay := now.AddDate(0, 0, -40)
+
+	// First batch aged past the threshold and rolled up.
+	seedAuditEntry(t, pool, userID, "qualification", "m1", 1_000_000, 100, 50, oldDay)
+	purged1, err := repo.AggregateAndPurgeOlderThan(ctx, now.AddDate(0, 0, -30))
+	require.NoError(t, err)
+	require.Equal(t, 1, purged1)
+
+	// A second row on the SAME calendar day surfaces later (e.g. a
+	// delayed flush) and ages past a later threshold — it must ADD to
+	// the existing daily bucket, not create a duplicate PK row.
+	seedAuditEntry(t, pool, userID, "qualification", "m1", 3_000_000, 300, 150, oldDay)
+	purged2, err := repo.AggregateAndPurgeOlderThan(ctx, now.AddDate(0, 0, -30))
+	require.NoError(t, err)
+	require.Equal(t, 1, purged2)
+
+	daily := readDailyRows(t, pool, userID)
+	require.Len(t, daily, 1, "same key accumulates into one bucket via ON CONFLICT")
+	assert.EqualValues(t, 2, daily[0].calls)
+	assert.EqualValues(t, 4_000_000, daily[0].costMicro)
+	assert.EqualValues(t, 400, daily[0].inTokens)
+	assert.EqualValues(t, 200, daily[0].outTokens)
+}

--- a/backend/internal/audit/retention_usecase.go
+++ b/backend/internal/audit/retention_usecase.go
@@ -1,0 +1,37 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/daniil/floq/internal/audit/domain"
+)
+
+// RetentionUseCase turns a retention window (in days) into the concrete
+// cut-off timestamp and drives the repository roll-up-and-purge. It owns
+// the clock so the handler/cron stay free of time.Now — the retention
+// boundary is a policy decision, not a transport concern.
+type RetentionUseCase struct {
+	repo          domain.RetentionRepository
+	retentionDays int
+	now           func() time.Time
+}
+
+// NewRetentionUseCase builds the use case. retentionDays is how long the
+// per-call audit_log rows are kept before being aggregated into the
+// daily rollup and deleted.
+func NewRetentionUseCase(repo domain.RetentionRepository, retentionDays int) *RetentionUseCase {
+	return &RetentionUseCase{repo: repo, retentionDays: retentionDays, now: time.Now}
+}
+
+// Purge aggregates and deletes every audit_log row older than
+// now-retentionDays, returning how many rows were purged.
+func (uc *RetentionUseCase) Purge(ctx context.Context) (int, error) {
+	threshold := uc.now().AddDate(0, 0, -uc.retentionDays)
+	purged, err := uc.repo.AggregateAndPurgeOlderThan(ctx, threshold)
+	if err != nil {
+		return 0, fmt.Errorf("audit retention purge: %w", err)
+	}
+	return purged, nil
+}

--- a/backend/internal/audit/retention_usecase_test.go
+++ b/backend/internal/audit/retention_usecase_test.go
@@ -1,0 +1,45 @@
+package audit
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRetentionRepo struct {
+	gotThreshold time.Time
+	purged       int
+	err          error
+	calls        int
+}
+
+func (f *fakeRetentionRepo) AggregateAndPurgeOlderThan(_ context.Context, threshold time.Time) (int, error) {
+	f.calls++
+	f.gotThreshold = threshold
+	return f.purged, f.err
+}
+
+func TestRetentionUseCase_Purge_ThresholdIsNowMinusRetentionDays(t *testing.T) {
+	fixedNow := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	fake := &fakeRetentionRepo{purged: 7}
+	uc := NewRetentionUseCase(fake, 30)
+	uc.now = func() time.Time { return fixedNow }
+
+	n, err := uc.Purge(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 7, n, "returns the repo's purged count")
+	assert.Equal(t, fixedNow.AddDate(0, 0, -30), fake.gotThreshold, "threshold = now - retentionDays")
+	assert.Equal(t, 1, fake.calls)
+}
+
+func TestRetentionUseCase_Purge_PropagatesRepoError(t *testing.T) {
+	fake := &fakeRetentionRepo{err: errors.New("db down")}
+	uc := NewRetentionUseCase(fake, 30)
+
+	_, err := uc.Purge(context.Background())
+	require.Error(t, err, "a repo failure must surface so the cron logs it")
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"strconv"
+	"time"
 )
 
 // Config holds all application configuration read from environment variables.
@@ -62,6 +63,15 @@ type Config struct {
 	// dodge the cap. Set TRUST_PROXY=true only when a reverse proxy that
 	// overwrites these headers sits in front of the app.
 	TrustProxyHeaders bool
+	// AuditRetentionDays is how long per-call audit_log rows are kept
+	// before the retention cron aggregates them into audit_log_daily and
+	// deletes them. Default 30 — matches the cost-summary default
+	// lookback, so recent reports still hit the detailed table.
+	AuditRetentionDays int
+	// AuditRetentionInterval is how often the retention cron runs.
+	// Default 24h — the rollup is day-granular, so sub-daily passes
+	// would only add churn.
+	AuditRetentionInterval time.Duration
 }
 
 // Load reads configuration from environment variables and returns a Config.
@@ -104,6 +114,8 @@ func Load() *Config {
 		AuthLoginRateLimit:          getEnvInt("AUTH_LOGIN_RATE_LIMIT", 5),
 		AuthRegisterRateLimit:       getEnvInt("AUTH_REGISTER_RATE_LIMIT", 3),
 		TrustProxyHeaders:           getEnvBool("TRUST_PROXY", false),
+		AuditRetentionDays:          getEnvInt("AUDIT_RETENTION_DAYS", 30),
+		AuditRetentionInterval:      getEnvDuration("AUDIT_RETENTION_INTERVAL", 24*time.Hour),
 	}
 }
 
@@ -127,6 +139,15 @@ func getEnvBool(key string, fallback bool) bool {
 	if v := os.Getenv(key); v != "" {
 		if b, err := strconv.ParseBool(v); err == nil {
 			return b
+		}
+	}
+	return fallback
+}
+
+func getEnvDuration(key string, fallback time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
 		}
 	}
 	return fallback

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +17,7 @@ func TestLoad_Defaults(t *testing.T) {
 		"BOOKING_LINK", "SENDER_NAME", "SENDER_COMPANY", "STALE_DAYS",
 		"DATABASE_URL", "REDIS_URL", "JWT_SECRET",
 		"AUTH_LOGIN_RATE_LIMIT", "AUTH_REGISTER_RATE_LIMIT", "TRUST_PROXY",
+		"AUDIT_RETENTION_DAYS", "AUDIT_RETENTION_INTERVAL",
 	} {
 		t.Setenv(key, "")
 		os.Unsetenv(key)
@@ -39,6 +41,8 @@ func TestLoad_Defaults(t *testing.T) {
 	assert.Equal(t, 5, cfg.AuthLoginRateLimit)
 	assert.Equal(t, 3, cfg.AuthRegisterRateLimit)
 	assert.False(t, cfg.TrustProxyHeaders, "TRUST_PROXY must default to false — app is exposed directly")
+	assert.Equal(t, 30, cfg.AuditRetentionDays)
+	assert.Equal(t, 24*time.Hour, cfg.AuditRetentionInterval)
 	assert.Empty(t, cfg.DatabaseURL)
 	assert.Empty(t, cfg.JWTSecret)
 }
@@ -53,6 +57,8 @@ func TestLoad_CustomEnvVars(t *testing.T) {
 	t.Setenv("AUTH_LOGIN_RATE_LIMIT", "10")
 	t.Setenv("AUTH_REGISTER_RATE_LIMIT", "1")
 	t.Setenv("TRUST_PROXY", "true")
+	t.Setenv("AUDIT_RETENTION_DAYS", "90")
+	t.Setenv("AUDIT_RETENTION_INTERVAL", "6h")
 
 	cfg := Load()
 	require.NotNil(t, cfg)
@@ -66,6 +72,8 @@ func TestLoad_CustomEnvVars(t *testing.T) {
 	assert.Equal(t, 10, cfg.AuthLoginRateLimit)
 	assert.Equal(t, 1, cfg.AuthRegisterRateLimit)
 	assert.True(t, cfg.TrustProxyHeaders)
+	assert.Equal(t, 90, cfg.AuditRetentionDays)
+	assert.Equal(t, 6*time.Hour, cfg.AuditRetentionInterval)
 }
 
 func TestGetEnvInt_ValidInt(t *testing.T) {

--- a/backend/migrations/036_audit_log_daily.down.sql
+++ b/backend/migrations/036_audit_log_daily.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS audit_log_daily;

--- a/backend/migrations/036_audit_log_daily.up.sql
+++ b/backend/migrations/036_audit_log_daily.up.sql
@@ -1,0 +1,34 @@
+-- Retention rollup for audit_log (#101). The per-call ledger (one row
+-- per AI provider call) grows unbounded — ~200 bytes/row, 10k calls/day
+-- is ~730 MB/year. A daily cron aggregates rows older than the retention
+-- window into this table and deletes them from audit_log, preserving
+-- cost trends (for the cost-summary report) while shedding the
+-- high-cardinality per-call detail.
+--
+-- One row per (day, user_id, provider, model, request_type). Cost stays
+-- in int64 micro-USD, summed — integer arithmetic, no float drift, same
+-- convention as audit_log.cost_usd_micro.
+--
+-- user_id CASCADE mirrors audit_log: a deleted user's cost history goes
+-- with them (GDPR erasure), no orphaned attribution rows.
+--
+-- No CHECK on request_type: this is a rollup of already-validated source
+-- rows, and coupling it to the audit_log enum would force a constraint
+-- bump here on every migration that extends that enum (see 029).
+CREATE TABLE audit_log_daily (
+    day                   DATE   NOT NULL,
+    user_id               UUID   NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider              TEXT   NOT NULL,
+    model                 TEXT   NOT NULL,
+    request_type          TEXT   NOT NULL,
+    total_calls           BIGINT NOT NULL CHECK (total_calls          >= 0),
+    total_cost_usd_micro  BIGINT NOT NULL CHECK (total_cost_usd_micro >= 0),
+    total_input_tokens    BIGINT NOT NULL CHECK (total_input_tokens   >= 0),
+    total_output_tokens   BIGINT NOT NULL CHECK (total_output_tokens  >= 0),
+    PRIMARY KEY (day, user_id, provider, model, request_type)
+);
+
+-- Read path mirrors audit_log's cost-summary access pattern: per-user
+-- over a day range. The PK leads with `day`, so a user-scoped range scan
+-- cannot use the PK prefix — it needs its own (user_id, day) index.
+CREATE INDEX idx_audit_log_daily_user_day ON audit_log_daily (user_id, day);

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -149,6 +149,9 @@ Documented trade-off: observed-cost ledger, not financial truth.
   a user" access pattern; partial indexes per `lead_id` /
   `prospect_id` for per-entity drilldowns.
 
+`036_audit_log_daily.up.sql` adds the retention rollup table — see
+[Retention & rotation](#retention--rotation-audit_log_daily).
+
 ## Style-check sub-call attribution
 
 When `AIClient.GenerateColdMessage` (or the Telegram / followup variants)
@@ -225,6 +228,50 @@ this user's spend is the style critic vs. the actual draft."
   erasure). Lead / prospect deletion leaves the row with NULL FK so
   per-user totals stay correct. Locked by integration test
   `TestAcceptance_UserDeletionCascadesToAuditLog`.
+
+## Retention & rotation (audit_log_daily)
+
+The per-call ledger grows unbounded (~200 bytes/row; 10k calls/day ≈
+730 MB/year). Migration `036_audit_log_daily.up.sql` adds a day-granular
+rollup, and a daily cron (`audit.RetentionCron`) ages detail out of
+`audit_log` into it.
+
+**Strategy — aggregate-then-delete (#101).** Cost trends are preserved;
+per-call detail beyond the window is shed. Chosen over hard-delete
+(loses trends) and partitioning (operational complexity).
+
+- **Schema.** `audit_log_daily (day, user_id, provider, model,
+  request_type, total_calls, total_cost_usd_micro, total_input_tokens,
+  total_output_tokens)`, PK on the five dimensions. `user_id` FK
+  `ON DELETE CASCADE` mirrors `audit_log` (GDPR erasure pulls the
+  rollup too). No `request_type` CHECK — it is a rollup of
+  already-validated source rows, and coupling it to the enum would force
+  a constraint bump here on every extension (cf. migration 029). Extra
+  `(user_id, day)` index for the cost-summary read path (PK leads with
+  `day`).
+- **Cron.** `audit.RetentionCron` mirrors `onec.ReconcileCron`: runs once
+  on startup, then every `AUDIT_RETENTION_INTERVAL` (default `24h`),
+  stops on ctx cancel. `RetentionUseCase` turns `AUDIT_RETENTION_DAYS`
+  (default `30`) into the cut-off `now() - days`.
+- **Repository.** `AggregateAndPurgeOlderThan(ctx, threshold)` runs the
+  roll-up and delete as ONE data-modifying CTE
+  (`DELETE … RETURNING` → `GROUP BY` → `INSERT … ON CONFLICT DO UPDATE`
+  accumulate), so the aggregated rows are exactly the deleted rows — no
+  window where a row is purged-but-not-counted. Idempotent: a second run
+  finds nothing < threshold and leaves buckets untouched. Day bucket =
+  UTC calendar date of `created_at` (session-timezone independent).
+- **Cost summary.** `Repository.CostSummary` `UNION ALL`s `audit_log`
+  (recent detail) with `audit_log_daily` (aggregated history) and sums in
+  an outer `GROUP BY`. The two are disjoint (a row lives in exactly one),
+  so no double-count. The daily side is filtered by UTC day, so
+  aggregated history is **day-granular**: a from/to landing mid-day on an
+  already-rolled-up day pulls that whole day's bucket — the accepted
+  cost of shedding per-call precision past the window. Recent data, where
+  sub-day precision matters, is still served from `audit_log`.
+
+Tuning: `AUDIT_RETENTION_DAYS` (window), `AUDIT_RETENTION_INTERVAL` (cron
+cadence). Setting the window very low loses detail faster; the rollup
+keeps cost trends regardless.
 
 ## Phase 3 backlog
 


### PR DESCRIPTION
Closes #101 (sub-task C of #92). Завершает security-кластер #92 — после мёржа закрыть parent.

## Что
`audit_log` (per-call AI-ledger) рос неограниченно (~200 B/строка, 10k вызовов/день ≈ 730 MB/год). Стратегия **aggregate-then-delete** (Option 2 из issue): суточный cron сворачивает строки старше retention-окна в `audit_log_daily` и удаляет из `audit_log`. Cost-тренды сохраняются, per-call детализация за окном отбрасывается.

## Компоненты
- **Миграция 036** `audit_log_daily`: `(day, user_id, provider, model, request_type)` PK + `total_calls/total_cost_usd_micro/total_input_tokens/total_output_tokens`. `user_id` FK `ON DELETE CASCADE` (зеркалит audit_log, GDPR). Индекс `(user_id, day)` под read-path. Без CHECK на request_type (rollup уже-валидированных строк — иначе бамп constraint на каждом расширении enum, ср. 029). Обратима (down+up проверено).
- **Repository `AggregateAndPurgeOlderThan(ctx, threshold)`**: один атомарный CTE `DELETE…RETURNING → GROUP BY → INSERT…ON CONFLICT DO UPDATE` (accumulate). DELETE и INSERT в одном snapshot → нет гонки purged-but-not-counted, строка живёт ровно в одной таблице. Idempotent. Day-бакет = UTC-дата `created_at` (session-TZ-независимо).
- **`RetentionUseCase`**: threshold = `now − AuditRetentionDays` (часы инъектируются). **`RetentionCron`**: зеркало `onec.ReconcileCron` — runs-on-startup + tick, graceful shutdown по ctx, fail-soft (логирует, не паникует).
- **CostSummary UNION ALL** `audit_log` (свежий детальный) + `audit_log_daily` (свёрнутая история), суммирование в внешнем GROUP BY. Множества дизъюнктны → нет double-count. Cross-tenant-фильтр на обоих плечах. Свёрнутая история day-granular (документированный trade-off; over-inclusion только на `from`-кромке).
- **Config**: `AUDIT_RETENTION_DAYS=30`, `AUDIT_RETENTION_INTERVAL=24h` (+ `getEnvDuration`), задокументированы в `.env.example`.
- **Docs**: `docs/audit-log.md` — секция «Retention & rotation».

## TDD
14 коммитов, строгие RED→GREEN пары (repo purge / usecase / cron / config / cost-summary union). Integration-тесты: rollup+delete, skip-recent, idempotency, accumulate-across-runs, union-history, cross-tenant+range scoping, **split-day** (день, расщеплённый между обеими таблицами — no loss / no double-count).

## Проверка
- Unit: 34 пакета зелёные, 0 FAIL. Integration (`-tags=integration`, Postgres+Redis): 34 зелёные, 0 FAIL.
- Кросс-сборка `GOOS=linux GOARCH=arm64` OK, `go vet` чисто, миграция down+up обратима.
- Независимое ревью (TDD/DDD/CA): **9/9/9**, blocker/major нет. Все 3 minor follow-up закрыты (split-day тест, docstring, формулировка trade-off).

Refs #92