### PR TITLE
feat(observability): AI-cost Prometheus metrics (#94 PR B)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -130,7 +130,12 @@ func main() {
 	auditRecorder := audit.NewAsyncRecorder(auditRepo,
 		audit.WithLogger(slog.Default()))
 	auditRecorder.Start()
-	wrappedProvider := audit.NewRecordingProvider(aiProvider, auditRecorder, slog.Default())
+	// Prometheus metrics. Built here so the RecordingProvider can feed
+	// AI-cost metrics through the observer hook; the HTTP middleware and
+	// /metrics endpoint are wired into the router below.
+	appMetrics := metrics.New()
+	wrappedProvider := audit.NewRecordingProvider(aiProvider, auditRecorder, slog.Default(),
+		audit.WithObserver(appMetrics.OnAuditEntry))
 
 	// Read the owner's style-check preference once at boot. We don't
 	// propagate runtime changes — switching the toggle in the UI requires
@@ -229,7 +234,6 @@ func main() {
 	authHandler := auth.NewHandler(auth.NewRepository(pool), cfg.JWTSecret)
 
 	// 6. Router
-	appMetrics := metrics.New()
 	r := chi.NewRouter()
 	// Metrics middleware is outermost so it observes the FINAL status,
 	// including the 500 the Recoverer writes for a panicked handler.

--- a/backend/internal/audit/recording_provider.go
+++ b/backend/internal/audit/recording_provider.go
@@ -26,6 +26,20 @@ type RecordingProvider struct {
 	inner    ai.Provider
 	recorder domain.Recorder
 	logger   *slog.Logger
+	observe  func(*domain.Entry)
+}
+
+// RecordingOption configures a RecordingProvider at construction.
+type RecordingOption func(*RecordingProvider)
+
+// WithObserver registers a side-channel callback invoked with every
+// successfully-constructed Entry, just before it is handed to the
+// Recorder. Used to feed real-time metrics (Prometheus) without coupling
+// the audit layer to the metrics package — the observer fires for both
+// success and error outcomes, and regardless of whether the async
+// recorder later persists or drops the row. It must be non-blocking.
+func WithObserver(fn func(*domain.Entry)) RecordingOption {
+	return func(r *RecordingProvider) { r.observe = fn }
 }
 
 // Compile-time assertions: RecordingProvider always satisfies Provider;
@@ -39,11 +53,15 @@ var (
 // NewRecordingProvider wires the decorator. Pass nil logger to use
 // slog.Default(). The recorder is mandatory — there is no sensible
 // "no-op" mode for the audit layer.
-func NewRecordingProvider(inner ai.Provider, recorder domain.Recorder, logger *slog.Logger) *RecordingProvider {
+func NewRecordingProvider(inner ai.Provider, recorder domain.Recorder, logger *slog.Logger, opts ...RecordingOption) *RecordingProvider {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &RecordingProvider{inner: inner, recorder: recorder, logger: logger}
+	rp := &RecordingProvider{inner: inner, recorder: recorder, logger: logger}
+	for _, opt := range opts {
+		opt(rp)
+	}
+	return rp
 }
 
 func (r *RecordingProvider) Name() string { return r.inner.Name() }
@@ -133,6 +151,12 @@ func (r *RecordingProvider) record(ctx context.Context, resp *ai.CompletionResul
 		r.logger.WarnContext(ctx, "audit: entry construction failed, skipping row",
 			"err", entryErr, "provider", r.inner.Name(), "model", model)
 		return
+	}
+	if r.observe != nil {
+		// Real-time metrics hook — fires for every real call (success or
+		// error), before the async Record so a saturated recorder cannot
+		// suppress the "call happened" signal.
+		r.observe(entry)
 	}
 	r.recorder.Record(ctx, entry)
 }

--- a/backend/internal/audit/recording_provider.go
+++ b/backend/internal/audit/recording_provider.go
@@ -155,8 +155,19 @@ func (r *RecordingProvider) record(ctx context.Context, resp *ai.CompletionResul
 	if r.observe != nil {
 		// Real-time metrics hook — fires for every real call (success or
 		// error), before the async Record so a saturated recorder cannot
-		// suppress the "call happened" signal.
-		r.observe(entry)
+		// suppress the "call happened" signal. Wrapped in recover: an
+		// observer must never panic the AI hot path (same contract as
+		// the rest of record()), and the audit Record below must still
+		// run even if a misbehaving observer blows up.
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					r.logger.WarnContext(ctx, "audit: metrics observer panicked, ignoring",
+						"recover", rec, "provider", r.inner.Name())
+				}
+			}()
+			r.observe(entry)
+		}()
 	}
 	r.recorder.Record(ctx, entry)
 }

--- a/backend/internal/audit/recording_provider_test.go
+++ b/backend/internal/audit/recording_provider_test.go
@@ -212,3 +212,63 @@ func TestRecordingProvider_PassThroughName(t *testing.T) {
 	rp := audit.NewRecordingProvider(&stubProvider{name: "claude"}, &fakeRecorder{}, silentDiscardLogger())
 	assert.Equal(t, "claude", rp.Name())
 }
+
+func TestRecordingProvider_ObserverFiresOnSuccess(t *testing.T) {
+	t.Parallel()
+	inner := &stubProvider{
+		name: "openai",
+		result: &ai.CompletionResult{
+			Usage: ai.TokenUsage{InputTokens: 100, OutputTokens: 50},
+			Model: "gpt-4o-mini",
+		},
+	}
+	var observed []*domain.Entry
+	rp := audit.NewRecordingProvider(inner, &fakeRecorder{}, silentDiscardLogger(),
+		audit.WithObserver(func(e *domain.Entry) { observed = append(observed, e) }))
+
+	ctx := domain.ContextWithCallMeta(context.Background(), domain.CallMeta{
+		UserID:      uuid.New(),
+		RequestType: domain.RequestTypeQualification,
+	})
+	_, err := rp.Complete(ctx, ai.CompletionRequest{})
+	require.NoError(t, err)
+
+	require.Len(t, observed, 1, "observer must fire once per constructed entry")
+	assert.Equal(t, "openai", observed[0].Provider)
+	assert.Equal(t, domain.RequestTypeQualification, observed[0].RequestType)
+}
+
+func TestRecordingProvider_ObserverFiresOnError(t *testing.T) {
+	t.Parallel()
+	inner := &stubProvider{name: "openai", err: errors.New("rate limited")}
+	var observed []*domain.Entry
+	rp := audit.NewRecordingProvider(inner, &fakeRecorder{}, silentDiscardLogger(),
+		audit.WithObserver(func(e *domain.Entry) { observed = append(observed, e) }))
+
+	ctx := domain.ContextWithCallMeta(context.Background(), domain.CallMeta{
+		UserID:      uuid.New(),
+		RequestType: domain.RequestTypeDraftReply,
+	})
+	_, err := rp.Complete(ctx, ai.CompletionRequest{})
+	require.Error(t, err)
+
+	// Failed-but-billed calls are real spend signal — observe them too.
+	require.Len(t, observed, 1)
+	assert.Equal(t, domain.StatusError, observed[0].Status)
+}
+
+func TestRecordingProvider_ObserverSkippedWhenNoMeta(t *testing.T) {
+	t.Parallel()
+	inner := &stubProvider{
+		name:   "openai",
+		result: &ai.CompletionResult{Model: "gpt-4o-mini"},
+	}
+	called := 0
+	rp := audit.NewRecordingProvider(inner, &fakeRecorder{}, silentDiscardLogger(),
+		audit.WithObserver(func(_ *domain.Entry) { called++ }))
+
+	// No CallMeta in ctx → no entry constructed → observer must not fire.
+	_, err := rp.Complete(context.Background(), ai.CompletionRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, called)
+}

--- a/backend/internal/audit/recording_provider_test.go
+++ b/backend/internal/audit/recording_provider_test.go
@@ -257,6 +257,31 @@ func TestRecordingProvider_ObserverFiresOnError(t *testing.T) {
 	assert.Equal(t, domain.StatusError, observed[0].Status)
 }
 
+func TestRecordingProvider_ObserverPanicDoesNotCrashCall(t *testing.T) {
+	t.Parallel()
+	inner := &stubProvider{
+		name:   "openai",
+		result: &ai.CompletionResult{Model: "gpt-4o-mini"},
+	}
+	rec := &fakeRecorder{}
+	rp := audit.NewRecordingProvider(inner, rec, silentDiscardLogger(),
+		audit.WithObserver(func(_ *domain.Entry) { panic("observer boom") }))
+
+	ctx := domain.ContextWithCallMeta(context.Background(), domain.CallMeta{
+		UserID:      uuid.New(),
+		RequestType: domain.RequestTypeQualification,
+	})
+
+	// A panicking observer must NOT take down the AI hot path — record()
+	// promises never to panic the call on an audit/metrics problem.
+	require.NotPanics(t, func() {
+		_, err := rp.Complete(ctx, ai.CompletionRequest{})
+		require.NoError(t, err)
+	})
+	// The audit row must still be recorded despite the observer panic.
+	assert.Len(t, rec.Entries(), 1, "recorder still runs after observer panic")
+}
+
 func TestRecordingProvider_ObserverSkippedWhenNoMeta(t *testing.T) {
 	t.Parallel()
 	inner := &stubProvider{

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -51,9 +51,13 @@ func New() *Metrics {
 			Help: "Cumulative AI spend in micro-USD by provider, model and request type.",
 		}, aiLabels),
 		aiDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "ai_call_duration_seconds",
-			Help:    "AI provider call latency by provider, model and request type.",
-			Buckets: prometheus.DefBuckets,
+			Name: "ai_call_duration_seconds",
+			Help: "AI provider call latency by provider, model and request type.",
+			// AI calls routinely run for tens of seconds (reasoning
+			// models, image analysis, long drafts), so the default
+			// buckets (cap 10s) would collapse the tail into +Inf and
+			// make p95/p99 useless. Buckets extend to 2 minutes.
+			Buckets: []float64{0.5, 1, 2.5, 5, 10, 20, 30, 60, 120},
 		}, aiLabels),
 	}
 	reg.MustRegister(

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -8,6 +8,7 @@ package metrics
 import (
 	"net/http"
 
+	"github.com/daniil/floq/internal/audit/domain"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -21,6 +22,9 @@ type Metrics struct {
 	registry     *prometheus.Registry
 	httpRequests *prometheus.CounterVec
 	httpDuration *prometheus.HistogramVec
+	aiCalls      *prometheus.CounterVec
+	aiCost       *prometheus.CounterVec
+	aiDuration   *prometheus.HistogramVec
 }
 
 // New builds the registry, registers the HTTP collectors plus the Go
@@ -38,14 +42,50 @@ func New() *Metrics {
 			Help:    "HTTP request latency by matched route pattern, method and status code.",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"route", "method", "status"}),
+		aiCalls: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "ai_calls_total",
+			Help: "Total AI provider calls by provider, model and request type.",
+		}, aiLabels),
+		aiCost: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "ai_cost_micro_usd_total",
+			Help: "Cumulative AI spend in micro-USD by provider, model and request type.",
+		}, aiLabels),
+		aiDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "ai_call_duration_seconds",
+			Help:    "AI provider call latency by provider, model and request type.",
+			Buckets: prometheus.DefBuckets,
+		}, aiLabels),
 	}
 	reg.MustRegister(
 		m.httpRequests,
 		m.httpDuration,
+		m.aiCalls,
+		m.aiCost,
+		m.aiDuration,
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
 	return m
+}
+
+// aiLabels are intentionally limited to bounded, non-tenant dimensions.
+// user_id is DELIBERATELY excluded: /metrics is public (no auth), so a
+// per-user label would leak tenant activity and explode cardinality.
+var aiLabels = []string{"provider", "model", "request_type"}
+
+// OnAuditEntry records AI-call metrics from a constructed audit Entry.
+// Wired as the RecordingProvider observer so it fires on every provider
+// call (success or error), independent of whether the async recorder
+// later persists or drops the row — this is the "calls made" signal.
+func (m *Metrics) OnAuditEntry(e *domain.Entry) {
+	labels := prometheus.Labels{
+		"provider":     e.Provider,
+		"model":        e.Model,
+		"request_type": string(e.RequestType),
+	}
+	m.aiCalls.With(labels).Inc()
+	m.aiCost.With(labels).Add(float64(e.CostUSDMicro))
+	m.aiDuration.With(labels).Observe(float64(e.LatencyMS) / 1000.0)
 }
 
 // Handler serves the registry in the Prometheus text exposition format.

--- a/backend/internal/metrics/metrics_test.go
+++ b/backend/internal/metrics/metrics_test.go
@@ -7,10 +7,24 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/daniil/floq/internal/audit/domain"
 	"github.com/daniil/floq/internal/metrics"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// scrape renders the registry in the Prometheus text exposition format
+// so tests can assert on exact metric+label lines.
+func scrape(t *testing.T, m *metrics.Metrics) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	m.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body, err := io.ReadAll(rec.Body)
+	require.NoError(t, err)
+	return string(body)
+}
 
 func TestHandler_ExposesGoAndProcessCollectors(t *testing.T) {
 	m := metrics.New()
@@ -26,4 +40,43 @@ func TestHandler_ExposesGoAndProcessCollectors(t *testing.T) {
 	// Runtime + process collectors must be wired into the same registry.
 	assert.True(t, strings.Contains(out, "go_goroutines"), "Go runtime collector must be registered")
 	assert.True(t, strings.Contains(out, "process_"), "process collector must be registered")
+}
+
+func TestOnAuditEntry_RecordsCostCallsAndDuration(t *testing.T) {
+	m := metrics.New()
+	entry := &domain.Entry{
+		UserID:       uuid.New(),
+		Provider:     "openai",
+		Model:        "gpt-4o-mini",
+		RequestType:  domain.RequestTypeQualification,
+		CostUSDMicro: 45,
+		LatencyMS:    1200,
+		Status:       domain.StatusSuccess,
+	}
+	m.OnAuditEntry(entry)
+	m.OnAuditEntry(entry)
+
+	body := scrape(t, m)
+	// Prometheus sorts label names alphabetically: model, provider, request_type.
+	assert.Contains(t, body, `ai_calls_total{model="gpt-4o-mini",provider="openai",request_type="qualification"} 2`)
+	assert.Contains(t, body, `ai_cost_micro_usd_total{model="gpt-4o-mini",provider="openai",request_type="qualification"} 90`)
+	assert.Contains(t, body, `ai_call_duration_seconds_count{model="gpt-4o-mini",provider="openai",request_type="qualification"} 2`)
+}
+
+func TestOnAuditEntry_NeverLabelsByUserID(t *testing.T) {
+	m := metrics.New()
+	userID := uuid.New()
+	m.OnAuditEntry(&domain.Entry{
+		UserID:      userID,
+		Provider:    "anthropic",
+		Model:       "claude-haiku-4-5",
+		RequestType: domain.RequestTypeColdMessage,
+		LatencyMS:   10,
+		Status:      domain.StatusSuccess,
+	})
+
+	body := scrape(t, m)
+	// /metrics is public (no auth) — a per-user label would leak tenant
+	// activity to anyone who can reach the scrape endpoint.
+	assert.NotContains(t, body, userID.String(), "user_id must never appear as a label")
 }

--- a/backend/internal/metrics/metrics_test.go
+++ b/backend/internal/metrics/metrics_test.go
@@ -63,6 +63,24 @@ func TestOnAuditEntry_RecordsCostCallsAndDuration(t *testing.T) {
 	assert.Contains(t, body, `ai_call_duration_seconds_count{model="gpt-4o-mini",provider="openai",request_type="qualification"} 2`)
 }
 
+func TestOnAuditEntry_LatencyHistogramCapturesSlowCalls(t *testing.T) {
+	m := metrics.New()
+	m.OnAuditEntry(&domain.Entry{
+		UserID:      uuid.New(),
+		Provider:    "openai",
+		Model:       "o1",
+		RequestType: domain.RequestTypeQualification,
+		LatencyMS:   30_000, // 30s — realistic for reasoning / image analysis
+		Status:      domain.StatusSuccess,
+	})
+
+	body := scrape(t, m)
+	// A 30s call must land in a FINITE bucket, not only +Inf. The default
+	// Prometheus buckets cap at 10s, which would collapse the AI latency
+	// tail (exactly where p95/p99 matter) — so a >10s bucket must exist.
+	assert.Contains(t, body, `ai_call_duration_seconds_bucket{model="o1",provider="openai",request_type="qualification",le="60"} 1`)
+}
+
 func TestOnAuditEntry_NeverLabelsByUserID(t *testing.T) {
 	m := metrics.New()
 	userID := uuid.New()


### PR DESCRIPTION
Refs #94 — **PR B (AI-cost metrics)** из разбивки A/B/C. НЕ закрывает #94: остаётся срез C (drops gauge + queue-depth scanner). Срез A (/metrics + HTTP middleware) — в main (v0.36.0).

## Что
AI-cost метрики в реальном времени через observer-hook в `audit.RecordingProvider`.

- **`metrics.OnAuditEntry(*domain.Entry)`**: `ai_calls_total`, `ai_cost_micro_usd_total` (Counters), `ai_call_duration_seconds` (Histogram). Labels `{provider, model, request_type}`.
- **`audit.WithObserver(func(*domain.Entry))`** — functional-option DI: RecordingProvider зовёт observer в `record()` после успешной конструкции Entry, ДО `recorder.Record` (считает все реальные вызовы независимо от drop'ов async-recorder'а; success И error — failed-but-billed это реальный spend).
- Wiring: `appMetrics` создан до RecordingProvider, `WithObserver(appMetrics.OnAuditEntry)`.

## Security / cardinality
- **НЕТ `user_id` в labels** — `/metrics` публичный без auth, per-user label = tenant-утечка. Покрыто negative-тестом `NeverLabelsByUserID`. Все три label bounded (provider ~4, model ~10, request_type — domain enum 10).
- coupling metrics→audit/domain (инфра→domain, направление корректное, цикла нет).

## Ревью-фиксы (оба minor, исправлены)
- **M1**: `ai_call_duration_seconds` buckets DefBuckets (cap 10s) → теряли хвост (AI-вызовы regularly >10s). Custom buckets до 120s (тест на захват 30s-вызова в конечный bucket).
- **M2**: паника observer роняла AI hot-path → обёрнута в recover (контракт record() «never panic the hot path»); recorder.Record выполняется даже при панике observer. Тест `ObserverPanicDoesNotCrashCall`.

## TDD / проверка
9 коммитов, строгие RED→GREEN (OnAuditEntry, observer-hook, M1 buckets, M2 panic-isolation). Unit 35/0, integration (audit+metrics) зелёные, кросс-сборка OK. Ревью TDD/DDD/CA 9/9/9, compliance PASS; оба minor закрыты.

Refs #94