### PR TITLE
feat(analytics): hot-leads list — View 4 (#98)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -310,7 +310,8 @@ func main() {
 		inbox.RegisterPendingReplyRoutes(r, pendingReplyUC, leadsUC, pendingReplyDecideMW)
 		audit.RegisterRoutes(r, audit.NewHandler(audit.NewUseCase(auditRepo)))
 		analyticsRepo := analytics.NewRepository(pool)
-		analytics.RegisterRoutes(r, analytics.NewUseCase(analyticsRepo, analyticsRepo))
+		analytics.RegisterRoutes(r, analytics.NewUseCase(analyticsRepo, analyticsRepo,
+			analytics.WithHotLeadsReader(analyticsRepo)))
 		tgOpts := []tgclient.Option{}
 		if proxyDialer != nil {
 			tgOpts = append(tgOpts, tgclient.WithDialer(proxyDialer))

--- a/backend/internal/analytics/handler.go
+++ b/backend/internal/analytics/handler.go
@@ -4,10 +4,18 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/daniil/floq/internal/httputil"
 	"github.com/go-chi/chi/v5"
+)
+
+// Hot-leads limit bounds: default page size and the hard cap that
+// prevents an enormous ?limit from sweeping the whole table.
+const (
+	defaultHotLeadsLimit = 20
+	maxHotLeadsLimit     = 100
 )
 
 // RegisterRoutes mounts the analytics endpoints onto the chi router.
@@ -17,6 +25,7 @@ func RegisterRoutes(r chi.Router, uc *UseCase) {
 	h := &handler{uc: uc}
 	r.Get("/api/analytics/sequences", h.getSequenceStats)
 	r.Get("/api/analytics/cost-ratios", h.getCostRatios)
+	r.Get("/api/analytics/hot-leads", h.getHotLeads)
 }
 
 type handler struct {
@@ -91,6 +100,103 @@ func (h *handler) getSequenceStats(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJSON(w, http.StatusOK, sequenceStatsResponse{
 		Sequences: wire,
 		Period:    string(period),
+	})
+}
+
+// hotLeadWire mirrors HotLeadDTO onto the JSON surface. Score and
+// QualifiedAt are pointers so an unqualified lead serialises them as
+// null rather than a misleading zero / zero-time.
+type hotLeadWire struct {
+	ID             string  `json:"id"`
+	ContactName    string  `json:"contact_name"`
+	Channel        string  `json:"channel"`
+	Status         string  `json:"status"`
+	Score          *int    `json:"score"`
+	ScoreReason    string  `json:"score_reason"`
+	LastActivityAt string  `json:"last_activity_at"`
+	QualifiedAt    *string `json:"qualified_at"`
+}
+
+type hotLeadsResponse struct {
+	Leads         []hotLeadWire `json:"leads"`
+	TotalMatching int           `json:"total_matching"`
+	LimitApplied  int           `json:"limit_applied"`
+}
+
+// parseHotLeadsLimit clamps the ?limit query value into [1, max],
+// defaulting on missing/garbage/non-positive input. Clamps rather than
+// 400s — a silly limit is a UI nicety, not a client error worth failing.
+func parseHotLeadsLimit(raw string) int {
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return defaultHotLeadsLimit
+	}
+	if n > maxHotLeadsLimit {
+		return maxHotLeadsLimit
+	}
+	return n
+}
+
+func (h *handler) getHotLeads(w http.ResponseWriter, r *http.Request) {
+	userID, ok := httputil.UserIDFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	period, err := ParsePeriod(r.URL.Query().Get("period"))
+	if err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "period must be one of: week, month, all")
+		return
+	}
+	status, err := ParseStatusFilter(r.URL.Query().Get("status"))
+	if err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "status must be one of: any, new, qualified, in_conversation, followup, closed")
+		return
+	}
+	channel, err := ParseChannelFilter(r.URL.Query().Get("channel"))
+	if err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "channel must be one of: any, telegram, email")
+		return
+	}
+	limit := parseHotLeadsLimit(r.URL.Query().Get("limit"))
+
+	dto, err := h.uc.GetHotLeads(r.Context(), userID, HotLeadsFilter{
+		Period:  period,
+		Status:  status,
+		Channel: channel,
+		Limit:   limit,
+	})
+	if err != nil {
+		slog.ErrorContext(r.Context(), "analytics: get hot leads failed",
+			slog.String("user_id", userID.String()),
+			slog.Any("err", err))
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to load hot leads")
+		return
+	}
+
+	wire := make([]hotLeadWire, 0, len(dto.Leads))
+	for _, l := range dto.Leads {
+		row := hotLeadWire{
+			ID:             l.ID.String(),
+			ContactName:    l.ContactName,
+			Channel:        l.Channel,
+			Status:         l.Status,
+			Score:          l.Score,
+			ScoreReason:    l.ScoreReason,
+			LastActivityAt: l.LastActivityAt.UTC().Format(time.RFC3339),
+		}
+		if l.QualifiedAt != nil {
+			qa := l.QualifiedAt.UTC().Format(time.RFC3339)
+			row.QualifiedAt = &qa
+		}
+		wire = append(wire, row)
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, hotLeadsResponse{
+		Leads:         wire,
+		TotalMatching: dto.TotalMatching,
+		LimitApplied:  limit,
 	})
 }
 

--- a/backend/internal/analytics/handler.go
+++ b/backend/internal/analytics/handler.go
@@ -196,7 +196,7 @@ func (h *handler) getHotLeads(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJSON(w, http.StatusOK, hotLeadsResponse{
 		Leads:         wire,
 		TotalMatching: dto.TotalMatching,
-		LimitApplied:  limit,
+		LimitApplied:  dto.LimitApplied,
 	})
 }
 

--- a/backend/internal/analytics/hot_leads.go
+++ b/backend/internal/analytics/hot_leads.go
@@ -1,0 +1,88 @@
+package analytics
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Sentinel errors for the hot-leads query-param validators, so the
+// handler can errors.Is them for the 400 mapping (mirrors
+// ErrInvalidPeriod).
+var (
+	ErrInvalidStatusFilter  = errors.New("invalid lead status filter")
+	ErrInvalidChannelFilter = errors.New("invalid lead channel filter")
+)
+
+// FilterAny is the sentinel meaning "no constraint on this dimension".
+const FilterAny = "any"
+
+// ParseStatusFilter normalises the ?status query value. Empty or "any"
+// means no status constraint; otherwise the value must be a member of
+// the lead_status enum (migration 002). Returns ErrInvalidStatusFilter
+// for anything else.
+func ParseStatusFilter(s string) (string, error) {
+	switch s {
+	case "", FilterAny:
+		return FilterAny, nil
+	case "new", "qualified", "in_conversation", "followup", "closed":
+		return s, nil
+	default:
+		return "", ErrInvalidStatusFilter
+	}
+}
+
+// ParseChannelFilter normalises the ?channel query value against the
+// lead_channel enum. Empty or "any" means no channel constraint.
+func ParseChannelFilter(s string) (string, error) {
+	switch s {
+	case "", FilterAny:
+		return FilterAny, nil
+	case "telegram", "email":
+		return s, nil
+	default:
+		return "", ErrInvalidChannelFilter
+	}
+}
+
+// HotLeadsFilter is the validated query input for the hot-leads view.
+// Status/Channel are either FilterAny or a valid enum member; Limit is
+// already clamped to a sane range by the handler.
+type HotLeadsFilter struct {
+	Period  Period
+	Status  string
+	Channel string
+	Limit   int
+}
+
+// HotLeadDTO is one row of the hot-leads read model. Public fields, no
+// invariants — a projection over leads LEFT JOIN qualifications, not a
+// domain entity. Score/ScoreReason/QualifiedAt are pointers because a
+// lead may not have been qualified yet (the LEFT JOIN yields NULLs).
+type HotLeadDTO struct {
+	ID             uuid.UUID
+	ContactName    string
+	Channel        string
+	Status         string
+	Score          *int
+	ScoreReason    string
+	LastActivityAt time.Time
+	QualifiedAt    *time.Time
+}
+
+// HotLeadsDTO wraps the page of rows with the total number of matching
+// leads (before LIMIT) and the limit actually applied, so the UI can
+// show "showing 20 of 45".
+type HotLeadsDTO struct {
+	Leads         []HotLeadDTO
+	TotalMatching int
+	LimitApplied  int
+}
+
+// HotLeadsReader is the port the usecase depends on for View 4. The pg
+// implementation lives in repository.go; tests stub it directly.
+type HotLeadsReader interface {
+	GetHotLeads(ctx context.Context, userID uuid.UUID, filter HotLeadsFilter) (*HotLeadsDTO, error)
+}

--- a/backend/internal/analytics/hot_leads_integration_test.go
+++ b/backend/internal/analytics/hot_leads_integration_test.go
@@ -1,0 +1,147 @@
+//go:build integration
+
+package analytics_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/daniil/floq/internal/analytics"
+	"github.com/daniil/floq/internal/testutil"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedHLLead(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID, channel, status, name string, createdAt, updatedAt time.Time) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO leads (id, user_id, channel, contact_name, first_message, status, created_at, updated_at)
+		 VALUES ($1, $2, $3::lead_channel, $4, 'hi', $5::lead_status, $6, $7)`,
+		id, userID, channel, name, status, createdAt, updatedAt)
+	require.NoError(t, err, "seed lead")
+	return id
+}
+
+func seedHLQual(t *testing.T, pool *pgxpool.Pool, leadID uuid.UUID, score int, reason string, genAt time.Time) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO qualifications (id, lead_id, score, score_reason, generated_at)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		uuid.New(), leadID, score, reason, genAt)
+	require.NoError(t, err, "seed qualification")
+}
+
+func anyFilter() analytics.HotLeadsFilter {
+	return analytics.HotLeadsFilter{Period: analytics.PeriodAll, Status: analytics.FilterAny, Channel: analytics.FilterAny, Limit: 20}
+}
+
+func TestRepository_GetHotLeads_SortsByScoreThenActivityNullsLast(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+	now := time.Now().UTC()
+
+	hi := seedHLLead(t, pool, userID, "telegram", "qualified", "High", now.Add(-3*time.Hour), now.Add(-1*time.Hour))
+	seedHLQual(t, pool, hi, 90, "strong fit", now)
+	mid := seedHLLead(t, pool, userID, "email", "qualified", "Mid", now.Add(-2*time.Hour), now.Add(-30*time.Minute))
+	seedHLQual(t, pool, mid, 50, "maybe", now)
+	noqual := seedHLLead(t, pool, userID, "telegram", "new", "Unqualified", now.Add(-1*time.Hour), now)
+
+	dto, err := repo.GetHotLeads(context.Background(), userID, anyFilter())
+	require.NoError(t, err)
+	require.Len(t, dto.Leads, 3)
+
+	assert.Equal(t, hi, dto.Leads[0].ID, "highest score first")
+	require.NotNil(t, dto.Leads[0].Score)
+	assert.Equal(t, 90, *dto.Leads[0].Score)
+	assert.Equal(t, "strong fit", dto.Leads[0].ScoreReason)
+	require.NotNil(t, dto.Leads[0].QualifiedAt)
+
+	assert.Equal(t, mid, dto.Leads[1].ID)
+	assert.Equal(t, noqual, dto.Leads[2].ID, "unqualified (NULL score) sorts last")
+	assert.Nil(t, dto.Leads[2].Score, "no qualification → nil score")
+	assert.Nil(t, dto.Leads[2].QualifiedAt)
+	assert.Equal(t, 3, dto.TotalMatching)
+}
+
+func TestRepository_GetHotLeads_StatusAndChannelFilters(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+	now := time.Now().UTC()
+
+	seedHLLead(t, pool, userID, "telegram", "qualified", "Q-tg", now, now)
+	seedHLLead(t, pool, userID, "email", "new", "N-em", now, now)
+	seedHLLead(t, pool, userID, "telegram", "closed", "C-tg", now, now)
+
+	// status=any excludes terminal 'closed' by default.
+	all, err := repo.GetHotLeads(context.Background(), userID, anyFilter())
+	require.NoError(t, err)
+	assert.Equal(t, 2, all.TotalMatching, "default any excludes closed")
+	for _, l := range all.Leads {
+		assert.NotEqual(t, "closed", l.Status)
+	}
+
+	// Explicit status=closed returns only the closed lead.
+	f := anyFilter()
+	f.Status = "closed"
+	closed, err := repo.GetHotLeads(context.Background(), userID, f)
+	require.NoError(t, err)
+	require.Len(t, closed.Leads, 1)
+	assert.Equal(t, "closed", closed.Leads[0].Status)
+
+	// channel=email returns only email leads (and still excludes closed).
+	f = anyFilter()
+	f.Channel = "email"
+	em, err := repo.GetHotLeads(context.Background(), userID, f)
+	require.NoError(t, err)
+	require.Len(t, em.Leads, 1)
+	assert.Equal(t, "email", em.Leads[0].Channel)
+}
+
+func TestRepository_GetHotLeads_TenantScopedAndLimited(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userA := testutil.SeedUser(t, pool)
+	userB := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+	now := time.Now().UTC()
+
+	for i := 0; i < 3; i++ {
+		l := seedHLLead(t, pool, userA, "telegram", "qualified", "A", now, now.Add(-time.Duration(i)*time.Hour))
+		seedHLQual(t, pool, l, 90-i, "r", now)
+	}
+	lb := seedHLLead(t, pool, userB, "telegram", "qualified", "B", now, now)
+	seedHLQual(t, pool, lb, 99, "r", now)
+
+	f := anyFilter()
+	f.Limit = 2
+	dto, err := repo.GetHotLeads(context.Background(), userA, f)
+	require.NoError(t, err)
+	assert.Len(t, dto.Leads, 2, "limit applied to page")
+	assert.Equal(t, 3, dto.TotalMatching, "total counts all matching pre-limit, userA only")
+	for _, l := range dto.Leads {
+		assert.NotEqual(t, lb, l.ID, "userB lead must never appear")
+	}
+}
+
+func TestRepository_GetHotLeads_PeriodFiltersByCreatedAt(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+	now := time.Now().UTC()
+
+	recent := seedHLLead(t, pool, userID, "telegram", "qualified", "recent", now.Add(-2*24*time.Hour), now)
+	seedHLQual(t, pool, recent, 80, "r", now)
+	seedHLLead(t, pool, userID, "telegram", "qualified", "old", now.Add(-60*24*time.Hour), now)
+
+	f := anyFilter()
+	f.Period = analytics.PeriodWeek
+	dto, err := repo.GetHotLeads(context.Background(), userID, f)
+	require.NoError(t, err)
+	require.Len(t, dto.Leads, 1, "only leads created within the week")
+	assert.Equal(t, recent, dto.Leads[0].ID)
+}

--- a/backend/internal/analytics/hot_leads_test.go
+++ b/backend/internal/analytics/hot_leads_test.go
@@ -1,0 +1,67 @@
+package analytics_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/daniil/floq/internal/analytics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseStatusFilter(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", "any", false},
+		{"any", "any", false},
+		{"new", "new", false},
+		{"qualified", "qualified", false},
+		{"in_conversation", "in_conversation", false},
+		{"followup", "followup", false},
+		{"closed", "closed", false},
+		{"lost", "", true},      // not in this schema's lead_status enum
+		{"garbage", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := analytics.ParseStatusFilter(tc.in)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, analytics.ErrInvalidStatusFilter))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseChannelFilter(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", "any", false},
+		{"any", "any", false},
+		{"telegram", "telegram", false},
+		{"email", "email", false},
+		{"sms", "", true},
+		{"garbage", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := analytics.ParseChannelFilter(tc.in)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, analytics.ErrInvalidChannelFilter))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/backend/internal/analytics/hot_leads_test.go
+++ b/backend/internal/analytics/hot_leads_test.go
@@ -1,13 +1,143 @@
 package analytics_test
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/daniil/floq/internal/analytics"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stubHotLeadsReader records the filter it was called with and returns
+// canned rows — keeps the handler test DB-free.
+type stubHotLeadsReader struct {
+	dto       *analytics.HotLeadsDTO
+	err       error
+	gotUserID uuid.UUID
+	gotFilter analytics.HotLeadsFilter
+	calls     int
+}
+
+func (s *stubHotLeadsReader) GetHotLeads(_ context.Context, userID uuid.UUID, f analytics.HotLeadsFilter) (*analytics.HotLeadsDTO, error) {
+	s.calls++
+	s.gotUserID = userID
+	s.gotFilter = f
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.dto, nil
+}
+
+func hotLeadsRouter(reader analytics.HotLeadsReader) chi.Router {
+	r := chi.NewRouter()
+	analytics.RegisterRoutes(r, analytics.NewUseCase(nil, nil, analytics.WithHotLeadsReader(reader)))
+	return r
+}
+
+func TestHandler_GetHotLeads_ReturnsRowsAndPassesFilter(t *testing.T) {
+	userID := uuid.New()
+	leadID := uuid.New()
+	score := 87
+	qAt := time.Date(2026, 5, 19, 14, 23, 0, 0, time.UTC)
+	reader := &stubHotLeadsReader{dto: &analytics.HotLeadsDTO{
+		Leads: []analytics.HotLeadDTO{{
+			ID: leadID, ContactName: "Acme Corp", Channel: "telegram",
+			Status: "qualified", Score: &score, ScoreReason: "strong fit",
+			LastActivityAt: qAt, QualifiedAt: &qAt,
+		}},
+		TotalMatching: 45,
+		LimitApplied:  20,
+	}}
+
+	w := httptest.NewRecorder()
+	req := newAuthedRequest(t, "/api/analytics/hot-leads?status=qualified&channel=telegram&period=month&limit=20", userID)
+	hotLeadsRouter(reader).ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, userID, reader.gotUserID)
+	assert.Equal(t, analytics.PeriodMonth, reader.gotFilter.Period)
+	assert.Equal(t, "qualified", reader.gotFilter.Status)
+	assert.Equal(t, "telegram", reader.gotFilter.Channel)
+	assert.Equal(t, 20, reader.gotFilter.Limit)
+
+	var got struct {
+		Leads []struct {
+			ID             string `json:"id"`
+			ContactName    string `json:"contact_name"`
+			Channel        string `json:"channel"`
+			Status         string `json:"status"`
+			Score          *int   `json:"score"`
+			ScoreReason    string `json:"score_reason"`
+			LastActivityAt string `json:"last_activity_at"`
+			QualifiedAt    string `json:"qualified_at"`
+		} `json:"leads"`
+		TotalMatching int `json:"total_matching"`
+		LimitApplied  int `json:"limit_applied"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	require.Len(t, got.Leads, 1)
+	assert.Equal(t, leadID.String(), got.Leads[0].ID)
+	assert.Equal(t, "Acme Corp", got.Leads[0].ContactName)
+	require.NotNil(t, got.Leads[0].Score)
+	assert.Equal(t, 87, *got.Leads[0].Score)
+	assert.Equal(t, 45, got.TotalMatching)
+	assert.Equal(t, 20, got.LimitApplied)
+}
+
+func TestHandler_GetHotLeads_Defaults(t *testing.T) {
+	reader := &stubHotLeadsReader{dto: &analytics.HotLeadsDTO{Leads: []analytics.HotLeadDTO{}, LimitApplied: 20}}
+	w := httptest.NewRecorder()
+	hotLeadsRouter(reader).ServeHTTP(w, newAuthedRequest(t, "/api/analytics/hot-leads", uuid.New()))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, analytics.PeriodAll, reader.gotFilter.Period, "missing period defaults to all")
+	assert.Equal(t, analytics.FilterAny, reader.gotFilter.Status, "missing status defaults to any")
+	assert.Equal(t, analytics.FilterAny, reader.gotFilter.Channel)
+	assert.Equal(t, 20, reader.gotFilter.Limit, "missing limit defaults to 20")
+}
+
+func TestHandler_GetHotLeads_ClampsLimit(t *testing.T) {
+	reader := &stubHotLeadsReader{dto: &analytics.HotLeadsDTO{Leads: []analytics.HotLeadDTO{}}}
+	cases := map[string]int{"0": 20, "-5": 20, "9999": 100, "abc": 20, "50": 50}
+	for raw, want := range cases {
+		t.Run(raw, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			hotLeadsRouter(reader).ServeHTTP(w, newAuthedRequest(t, "/api/analytics/hot-leads?limit="+raw, uuid.New()))
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, want, reader.gotFilter.Limit)
+		})
+	}
+}
+
+func TestHandler_GetHotLeads_InvalidFilters(t *testing.T) {
+	reader := &stubHotLeadsReader{dto: &analytics.HotLeadsDTO{}}
+	for _, target := range []string{
+		"/api/analytics/hot-leads?status=lost",
+		"/api/analytics/hot-leads?channel=sms",
+		"/api/analytics/hot-leads?period=year",
+	} {
+		w := httptest.NewRecorder()
+		hotLeadsRouter(reader).ServeHTTP(w, newAuthedRequest(t, target, uuid.New()))
+		assert.Equal(t, http.StatusBadRequest, w.Code, target)
+	}
+	assert.Equal(t, 0, reader.calls, "invalid filter must not reach the reader")
+}
+
+func TestHandler_GetHotLeads_Unauthenticated(t *testing.T) {
+	reader := &stubHotLeadsReader{dto: &analytics.HotLeadsDTO{}}
+	w := httptest.NewRecorder()
+	// No auth context on the request.
+	hotLeadsRouter(reader).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/analytics/hot-leads", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
 
 func TestParseStatusFilter(t *testing.T) {
 	tests := []struct {

--- a/backend/internal/analytics/repository.go
+++ b/backend/internal/analytics/repository.go
@@ -26,6 +26,7 @@ func NewRepository(pool *pgxpool.Pool) *Repository {
 var (
 	_ SequenceStatsReader = (*Repository)(nil)
 	_ CostRatiosReader    = (*Repository)(nil)
+	_ HotLeadsReader      = (*Repository)(nil)
 )
 
 // GetSequenceStats returns one row per sequence with activity in the
@@ -170,6 +171,63 @@ func (r *Repository) GetCostRatios(ctx context.Context, userID uuid.UUID, from, 
 	dto.CostPerQualifiedUSDMicro = safeRatioInt(dto.TotalCostUSDMicro, dto.QualifiedLeadsCount)
 	dto.CostPerConvertedUSDMicro = safeRatioInt(dto.TotalCostUSDMicro, dto.ConvertedCount)
 	dto.CostPerDraftSentUSDMicro = safeRatioInt(dto.TotalCostUSDMicro, dto.DraftsSentCount)
+	return dto, nil
+}
+
+// GetHotLeads returns the ranked lead list for View 4: leads LEFT JOIN
+// their (1:1, lead_id is UNIQUE) qualification, scored highest-first.
+// A single query with COUNT(*) OVER() yields the page and the pre-LIMIT
+// total in one round-trip. Unqualified leads keep a NULL score and sort
+// last (NULLS LAST). status=any excludes the terminal 'closed' state;
+// an explicit status returns exactly that state.
+//
+// Tenant scope via leads.user_id. Sort is (score DESC NULLS LAST,
+// updated_at DESC) so the freshest hottest leads surface first.
+func (r *Repository) GetHotLeads(ctx context.Context, userID uuid.UUID, filter HotLeadsFilter) (*HotLeadsDTO, error) {
+	cutoff, hasCutoff := periodCutoff(filter.Period, time.Now().UTC())
+
+	rows, err := r.pool.Query(ctx, `
+		SELECT l.id, l.contact_name, l.channel::text, l.status::text, l.updated_at,
+		       q.score, q.score_reason, q.generated_at,
+		       COUNT(*) OVER() AS total_matching
+		FROM leads l
+		LEFT JOIN qualifications q ON q.lead_id = l.id
+		WHERE l.user_id = $1
+		  AND ($2::timestamptz IS NULL OR l.created_at >= $2)
+		  AND (
+		        ($3 = 'any' AND l.status::text <> 'closed')
+		     OR ($3 <> 'any' AND l.status::text = $3)
+		      )
+		  AND ($4 = 'any' OR l.channel::text = $4)
+		ORDER BY q.score DESC NULLS LAST, l.updated_at DESC
+		LIMIT $5`,
+		userID, nullableCutoff(cutoff, hasCutoff), filter.Status, filter.Channel, filter.Limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("analytics get hot leads: %w", err)
+	}
+	defer rows.Close()
+
+	dto := &HotLeadsDTO{Leads: []HotLeadDTO{}, LimitApplied: filter.Limit}
+	for rows.Next() {
+		var (
+			row    HotLeadDTO
+			reason *string
+			total  int
+		)
+		if err := rows.Scan(&row.ID, &row.ContactName, &row.Channel, &row.Status, &row.LastActivityAt,
+			&row.Score, &reason, &row.QualifiedAt, &total); err != nil {
+			return nil, fmt.Errorf("analytics scan hot lead: %w", err)
+		}
+		if reason != nil {
+			row.ScoreReason = *reason
+		}
+		dto.Leads = append(dto.Leads, row)
+		dto.TotalMatching = total // identical on every row; window count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("analytics hot leads rows iter: %w", err)
+	}
 	return dto, nil
 }
 

--- a/backend/internal/analytics/usecase.go
+++ b/backend/internal/analytics/usecase.go
@@ -15,13 +15,34 @@ import (
 type UseCase struct {
 	seq  SequenceStatsReader
 	cost CostRatiosReader
+	hot  HotLeadsReader
 }
 
-// NewUseCase wires the two read ports. Either may be nil if the
+// Option configures optional read ports on the UseCase. Used for ports
+// added after the original two so existing call sites stay unchanged.
+type Option func(*UseCase)
+
+// WithHotLeadsReader wires the View 4 hot-leads reader.
+func WithHotLeadsReader(h HotLeadsReader) Option {
+	return func(uc *UseCase) { uc.hot = h }
+}
+
+// NewUseCase wires the read ports. seq and cost may be nil if the
 // surrounding wire-up only registers a subset of routes (tests do
-// this — production wire-up always passes both).
-func NewUseCase(seq SequenceStatsReader, cost CostRatiosReader) *UseCase {
-	return &UseCase{seq: seq, cost: cost}
+// this — production wire-up passes all). Optional readers are supplied
+// via Option.
+func NewUseCase(seq SequenceStatsReader, cost CostRatiosReader, opts ...Option) *UseCase {
+	uc := &UseCase{seq: seq, cost: cost}
+	for _, opt := range opts {
+		opt(uc)
+	}
+	return uc
+}
+
+// GetHotLeads forwards to the hot-leads reader. The filter is validated
+// at the handler boundary so this layer only sees typed values.
+func (uc *UseCase) GetHotLeads(ctx context.Context, userID uuid.UUID, filter HotLeadsFilter) (*HotLeadsDTO, error) {
+	return uc.hot.GetHotLeads(ctx, userID, filter)
 }
 
 // GetSequenceStats forwards the call to the configured reader. Period

--- a/frontend/src/app/(dashboard)/analytics/hot-leads/page.tsx
+++ b/frontend/src/app/(dashboard)/analytics/hot-leads/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import type { AnalyticsPeriod, ChannelFilter, LeadStatusFilter } from "@/lib/api";
+import { useHotLeads } from "@/hooks/useHotLeads";
+import { AnalyticsTabs } from "@/components/analytics/AnalyticsTabs";
+import { PeriodSelector } from "@/components/analytics/PeriodSelector";
+import { HotLeadsFilterBar } from "@/components/analytics/HotLeadsFilterBar";
+import { HotLeadsTable } from "@/components/analytics/HotLeadsTable";
+
+export default function HotLeadsAnalyticsPage() {
+  const [period, setPeriod] = useState<AnalyticsPeriod>("all");
+  const [status, setStatus] = useState<LeadStatusFilter>("any");
+  const [channel, setChannel] = useState<ChannelFilter>("any");
+
+  const { leads, totalMatching, loading, error, lastUpdated, refresh } = useHotLeads({
+    period,
+    status,
+    channel,
+  });
+
+  return (
+    <section className="flex-1 overflow-y-auto px-4 sm:px-8 lg:px-12 py-8">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <AnalyticsTabs />
+        <header className="flex items-end justify-between gap-4 flex-wrap">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-extrabold tracking-tight text-[#0d1c2e]">Горячие лиды</h1>
+            <p className="text-sm text-slate-500 mt-1">
+              Лиды по убыванию скора квалификации — кому звонить первым.
+            </p>
+          </div>
+          <div className="flex items-center gap-3 flex-wrap">
+            <HotLeadsFilterBar
+              status={status}
+              channel={channel}
+              onStatusChange={setStatus}
+              onChannelChange={setChannel}
+            />
+            <PeriodSelector value={period} onChange={setPeriod} />
+            <button
+              type="button"
+              onClick={() => void refresh()}
+              className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            >
+              Обновить
+            </button>
+          </div>
+        </header>
+
+        {error && (
+          <div role="alert" className="rounded-md border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
+            Не удалось загрузить данные: {error.message}
+          </div>
+        )}
+
+        {loading && leads.length === 0 ? (
+          <div className="rounded-lg border border-slate-200 bg-white p-8 text-center text-sm text-slate-500">
+            Загружаем…
+          </div>
+        ) : (
+          <>
+            <HotLeadsTable leads={leads} />
+            {leads.length > 0 && (
+              <div className="text-xs text-slate-400">
+                Показано {leads.length} из {totalMatching}
+                {lastUpdated && <> · обновлено {lastUpdated.toLocaleTimeString("ru-RU")}</>}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/analytics/AnalyticsTabs.tsx
+++ b/frontend/src/components/analytics/AnalyticsTabs.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 const TABS = [
   { href: "/analytics/sequences", label: "Sequences" },
   { href: "/analytics/cost", label: "Затраты" },
+  { href: "/analytics/hot-leads", label: "Горячие лиды" },
 ];
 
 // AnalyticsTabs renders the sub-navigation for /analytics/* pages.

--- a/frontend/src/components/analytics/HotLeadsFilterBar.tsx
+++ b/frontend/src/components/analytics/HotLeadsFilterBar.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import type { ChannelFilter, LeadStatusFilter } from "@/lib/api";
+
+const STATUS_OPTIONS: { value: LeadStatusFilter; label: string }[] = [
+  { value: "any", label: "Все статусы" },
+  { value: "new", label: "Новые" },
+  { value: "qualified", label: "Квалифицированы" },
+  { value: "in_conversation", label: "В диалоге" },
+  { value: "followup", label: "Followup" },
+  { value: "closed", label: "Закрытые" },
+];
+
+const CHANNEL_OPTIONS: { value: ChannelFilter; label: string }[] = [
+  { value: "any", label: "Все каналы" },
+  { value: "telegram", label: "Telegram" },
+  { value: "email", label: "Email" },
+];
+
+interface HotLeadsFilterBarProps {
+  status: LeadStatusFilter;
+  channel: ChannelFilter;
+  onStatusChange: (next: LeadStatusFilter) => void;
+  onChannelChange: (next: ChannelFilter) => void;
+}
+
+const selectClass =
+  "rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-300";
+
+export function HotLeadsFilterBar({ status, channel, onStatusChange, onChannelChange }: HotLeadsFilterBarProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <label className="sr-only" htmlFor="hot-leads-status">
+        Статус
+      </label>
+      <select
+        id="hot-leads-status"
+        className={selectClass}
+        value={status}
+        onChange={(e) => onStatusChange(e.target.value as LeadStatusFilter)}
+      >
+        {STATUS_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+
+      <label className="sr-only" htmlFor="hot-leads-channel">
+        Канал
+      </label>
+      <select
+        id="hot-leads-channel"
+        className={selectClass}
+        value={channel}
+        onChange={(e) => onChannelChange(e.target.value as ChannelFilter)}
+      >
+        {CHANNEL_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/components/analytics/HotLeadsTable.test.tsx
+++ b/frontend/src/components/analytics/HotLeadsTable.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { HotLead } from "@/lib/api";
+
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+import { HotLeadsTable } from "./HotLeadsTable";
+
+function lead(over: Partial<HotLead> = {}): HotLead {
+  return {
+    id: over.id ?? "lead-x",
+    contact_name: over.contact_name ?? "Acme",
+    channel: over.channel ?? "telegram",
+    status: over.status ?? "qualified",
+    score: over.score === undefined ? 50 : over.score,
+    score_reason: over.score_reason ?? "",
+    last_activity_at: over.last_activity_at ?? "2026-05-19T10:00:00Z",
+    qualified_at: over.qualified_at ?? null,
+  };
+}
+
+function rowOrder(): string[] {
+  // First cell of each body row is the contact name.
+  return screen
+    .getAllByRole("row")
+    .slice(1) // skip header
+    .map((r) => within(r).getAllByRole("cell")[0].textContent ?? "");
+}
+
+describe("HotLeadsTable", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+  });
+
+  it("renders an empty state when there are no leads", () => {
+    render(<HotLeadsTable leads={[]} />);
+    expect(screen.getByText(/Нет лидов/i)).toBeInTheDocument();
+  });
+
+  it("sorts by score descending by default with null scores last", () => {
+    render(
+      <HotLeadsTable
+        leads={[
+          lead({ id: "a", contact_name: "Mid", score: 50 }),
+          lead({ id: "b", contact_name: "Top", score: 90 }),
+          lead({ id: "c", contact_name: "NoScore", score: null }),
+        ]}
+      />,
+    );
+    expect(rowOrder()).toEqual(["Top", "Mid", "NoScore"]);
+  });
+
+  it("toggles to ascending on a second score header click, nulls still last", async () => {
+    const user = userEvent.setup();
+    render(
+      <HotLeadsTable
+        leads={[
+          lead({ id: "a", contact_name: "Mid", score: 50 }),
+          lead({ id: "b", contact_name: "Top", score: 90 }),
+          lead({ id: "c", contact_name: "NoScore", score: null }),
+        ]}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /Скор/ }));
+    // ascending: lowest score first, but NULL always sorts last.
+    expect(rowOrder()).toEqual(["Mid", "Top", "NoScore"]);
+  });
+
+  it("navigates to the lead inbox on row click", async () => {
+    const user = userEvent.setup();
+    render(<HotLeadsTable leads={[lead({ id: "lead-42", contact_name: "Click Me" })]} />);
+    await user.click(screen.getByText("Click Me"));
+    expect(pushMock).toHaveBeenCalledWith("/inbox/lead-42");
+  });
+});

--- a/frontend/src/components/analytics/HotLeadsTable.tsx
+++ b/frontend/src/components/analytics/HotLeadsTable.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { HotLead } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+interface HotLeadsTableProps {
+  leads: HotLead[];
+}
+
+type SortKey = "score" | "last_activity_at";
+type SortDir = "asc" | "desc";
+
+const STATUS_LABELS: Record<string, string> = {
+  new: "Новый",
+  qualified: "Квалифицирован",
+  in_conversation: "В диалоге",
+  followup: "Followup",
+  closed: "Закрыт",
+};
+
+const CHANNEL_LABELS: Record<string, string> = {
+  telegram: "Telegram",
+  email: "Email",
+};
+
+// scoreBadgeClass colours the score by band so the eye lands on the
+// hottest leads first: ≥80 green, 50-79 amber, <50 slate.
+function scoreBadgeClass(score: number | null): string {
+  if (score == null) return "bg-slate-100 text-slate-400";
+  if (score >= 80) return "bg-emerald-100 text-emerald-800";
+  if (score >= 50) return "bg-amber-100 text-amber-800";
+  return "bg-slate-100 text-slate-600";
+}
+
+function formatActivity(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString("ru-RU", { dateStyle: "medium", timeStyle: "short" });
+}
+
+export function HotLeadsTable({ leads }: HotLeadsTableProps) {
+  const router = useRouter();
+  const [sortKey, setSortKey] = useState<SortKey>("score");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const sorted = useMemo(() => {
+    const copy = [...leads];
+    copy.sort((a, b) => {
+      let cmp: number;
+      if (sortKey === "score") {
+        // Null scores always sort last regardless of direction.
+        const av = a.score;
+        const bv = b.score;
+        if (av == null && bv == null) cmp = 0;
+        else if (av == null) return 1;
+        else if (bv == null) return -1;
+        else cmp = av - bv;
+      } else {
+        cmp = new Date(a.last_activity_at).getTime() - new Date(b.last_activity_at).getTime();
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+    return copy;
+  }, [leads, sortKey, sortDir]);
+
+  function handleSort(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+  }
+
+  if (leads.length === 0) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white p-8 text-center text-sm text-slate-500">
+        Нет лидов под выбранные фильтры.
+      </div>
+    );
+  }
+
+  const sortMark = (key: SortKey) => (sortKey === key ? (sortDir === "asc" ? "↑" : "↓") : null);
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+      <table className="min-w-full divide-y divide-slate-200 text-sm">
+        <thead className="bg-slate-50">
+          <tr>
+            <th scope="col" className="px-4 py-2 text-left font-medium text-slate-700">Контакт</th>
+            <th scope="col" className="px-4 py-2 text-left font-medium text-slate-700">Канал</th>
+            <th scope="col" className="px-4 py-2 text-left font-medium text-slate-700">Статус</th>
+            <th scope="col" className="px-4 py-2 text-right font-medium text-slate-700">
+              <button type="button" onClick={() => handleSort("score")} className="inline-flex items-center gap-1 hover:text-slate-900">
+                Скор {sortMark("score") && <span aria-hidden="true">{sortMark("score")}</span>}
+              </button>
+            </th>
+            <th scope="col" className="px-4 py-2 text-right font-medium text-slate-700">
+              <button type="button" onClick={() => handleSort("last_activity_at")} className="inline-flex items-center gap-1 hover:text-slate-900">
+                Активность {sortMark("last_activity_at") && <span aria-hidden="true">{sortMark("last_activity_at")}</span>}
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {sorted.map((lead) => (
+            <tr
+              key={lead.id}
+              onClick={() => router.push(`/inbox/${lead.id}`)}
+              className="cursor-pointer hover:bg-slate-50"
+            >
+              <td className="px-4 py-2 font-medium text-slate-900">{lead.contact_name || "—"}</td>
+              <td className="px-4 py-2 text-slate-600">{CHANNEL_LABELS[lead.channel] ?? lead.channel}</td>
+              <td className="px-4 py-2 text-slate-600">{STATUS_LABELS[lead.status] ?? lead.status}</td>
+              <td className="px-4 py-2 text-right">
+                <span
+                  title={lead.score_reason || undefined}
+                  className={cn("inline-block rounded px-2 py-0.5 text-xs font-semibold tabular-nums", scoreBadgeClass(lead.score))}
+                >
+                  {lead.score ?? "—"}
+                </span>
+              </td>
+              <td className="px-4 py-2 text-right text-slate-500 tabular-nums">{formatActivity(lead.last_activity_at)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useHotLeads.test.ts
+++ b/frontend/src/hooks/useHotLeads.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { HotLeadsResponse } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getHotLeads: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { useHotLeads } from "./useHotLeads";
+
+function response(over: Partial<HotLeadsResponse> = {}): HotLeadsResponse {
+  return {
+    leads: over.leads ?? [
+      {
+        id: "lead-1",
+        contact_name: "Acme Corp",
+        channel: "telegram",
+        status: "qualified",
+        score: 87,
+        score_reason: "strong fit",
+        last_activity_at: "2026-05-19T14:23:00Z",
+        qualified_at: "2026-05-19T14:23:00Z",
+      },
+    ],
+    total_matching: over.total_matching ?? 45,
+    limit_applied: over.limit_applied ?? 20,
+  };
+}
+
+describe("useHotLeads", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("fetches on mount with the given filter and stops loading", async () => {
+    vi.mocked(api.getHotLeads).mockResolvedValueOnce(response());
+
+    const { result } = renderHook(() =>
+      useHotLeads({ period: "month", status: "qualified", channel: "telegram" }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(api.getHotLeads).toHaveBeenCalledWith({ period: "month", status: "qualified", channel: "telegram" });
+    expect(result.current.leads).toHaveLength(1);
+    expect(result.current.totalMatching).toBe(45);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("refetches when the filter changes", async () => {
+    vi.mocked(api.getHotLeads).mockResolvedValue(response());
+
+    const { result, rerender } = renderHook(
+      ({ status }: { status: "any" | "qualified" }) => useHotLeads({ status }),
+      { initialProps: { status: "any" as "any" | "qualified" } },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(api.getHotLeads).toHaveBeenLastCalledWith({ status: "any" });
+
+    rerender({ status: "qualified" });
+    await waitFor(() => expect(api.getHotLeads).toHaveBeenLastCalledWith({ status: "qualified" }));
+  });
+
+  it("surfaces error and keeps last good leads", async () => {
+    vi.mocked(api.getHotLeads).mockResolvedValueOnce(response());
+    vi.mocked(api.getHotLeads).mockRejectedValueOnce(new Error("network"));
+
+    const { result } = renderHook(() => useHotLeads({}));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.leads).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.leads).toHaveLength(1); // last good preserved
+  });
+});

--- a/frontend/src/hooks/useHotLeads.ts
+++ b/frontend/src/hooks/useHotLeads.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api, type HotLead, type HotLeadsParams } from "@/lib/api";
+
+// POLL_INTERVAL_MS exported so tests advance timers by an exact multiple.
+export const POLL_INTERVAL_MS = 30_000;
+
+interface UseHotLeadsResult {
+  leads: HotLead[];
+  totalMatching: number;
+  loading: boolean;
+  error: Error | null;
+  lastUpdated: Date | null;
+  refresh: () => Promise<void>;
+}
+
+// useHotLeads returns the ranked hot-leads read model for the given
+// filter. Polls every POLL_INTERVAL_MS so the operator dashboard stays
+// fresh, and keeps the last good rows visible on a transient fetch
+// error (the panel informs, not blanks-out). Refetches whenever any
+// filter field changes.
+export function useHotLeads(params: HotLeadsParams): UseHotLeadsResult {
+  const [leads, setLeads] = useState<HotLead[]>([]);
+  const [totalMatching, setTotalMatching] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const mountedRef = useRef(true);
+
+  // Destructure so the fetch callback depends on primitive values, not
+  // a fresh object literal each render (which would re-fire the effect
+  // every render and hammer the API).
+  const { period, status, channel, limit } = params;
+
+  const fetchOnce = useCallback(async () => {
+    try {
+      const data = await api.getHotLeads({ period, status, channel, limit });
+      if (!mountedRef.current) return;
+      setLeads(data.leads);
+      setTotalMatching(data.total_matching);
+      setError(null);
+      setLastUpdated(new Date());
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [period, status, channel, limit]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    setLoading(true);
+    void fetchOnce();
+    const interval = setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(interval);
+    };
+  }, [fetchOnce]);
+
+  return { leads, totalMatching, loading, error, lastUpdated, refresh: fetchOnce };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -369,6 +369,15 @@ export const api = {
     apiFetch<SequenceAnalyticsResponse>(`/api/analytics/sequences?period=${period}`),
   getCostRatios: (period: AnalyticsPeriod = "month") =>
     apiFetch<CostRatiosResponse>(`/api/analytics/cost-ratios?period=${period}`),
+  getHotLeads: (params: HotLeadsParams = {}) => {
+    const q = new URLSearchParams();
+    if (params.period) q.set("period", params.period);
+    if (params.status) q.set("status", params.status);
+    if (params.channel) q.set("channel", params.channel);
+    if (params.limit != null) q.set("limit", String(params.limit));
+    const qs = q.toString();
+    return apiFetch<HotLeadsResponse>(`/api/analytics/hot-leads${qs ? `?${qs}` : ""}`);
+  },
   getCostSummary: (from: string, to: string) =>
     apiFetch<CostSummaryResponse>(`/api/audit/cost-summary?from=${from}&to=${to}`),
 };
@@ -663,6 +672,33 @@ export interface CostRatiosResponse {
   cost_per_qualified_lead_usd: number;
   cost_per_converted_usd: number;
   cost_per_draft_sent_usd: number;
+}
+
+export type LeadStatusFilter = "any" | "new" | "qualified" | "in_conversation" | "followup" | "closed";
+export type ChannelFilter = "any" | "telegram" | "email";
+
+export interface HotLead {
+  id: string;
+  contact_name: string;
+  channel: string;
+  status: string;
+  score: number | null;
+  score_reason: string;
+  last_activity_at: string;
+  qualified_at: string | null;
+}
+
+export interface HotLeadsResponse {
+  leads: HotLead[];
+  total_matching: number;
+  limit_applied: number;
+}
+
+export interface HotLeadsParams {
+  period?: AnalyticsPeriod;
+  status?: LeadStatusFilter;
+  channel?: ChannelFilter;
+  limit?: number;
 }
 
 export interface CostBreakdownRow {


### PR DESCRIPTION
Closes #98 (View 4 of #91; #97 remains). Full-stack: backend GET /api/analytics/hot-leads (DTO-only read-side, leads LEFT JOIN qualifications 1:1, COUNT(*) OVER() pre-limit total, ORDER BY score DESC NULLS LAST + updated_at DESC, tenant-scoped, status=any excludes terminal 'closed', limit clamp 1..100, 400 on invalid filters, 401 unauth) + frontend Next16 (useHotLeads poll 30s/keep-last/refetch-on-filter, HotLeadsTable sortable score+activity NULLS-last score-badge row-click->/inbox/[id], HotLeadsFilterBar, page, AnalyticsTabs tab). Deviation (documented): real lead_status enum {new,qualified,in_conversation,followup,closed} != issue's lost/opted_out/replied/converted -> mapped 'exclude terminal' to 'closed', filter on actual enum. 12 commits RED->GREEN (parsers/handler/repo-integration/hook). 35 backend unit + analytics integration green; frontend useHotLeads+HotLeadsTable tests + 406 vitest green; tsc/lint clean; next build OK (/analytics/hot-leads route); smoke live 200/400/401. Review TDD/DDD/CA 9/9/9 PASS, minors fixed. Refs #91