### PR TITLE
feat(analytics): View 3 — inbox flow metrics (#97)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -311,7 +311,8 @@ func main() {
 		audit.RegisterRoutes(r, audit.NewHandler(audit.NewUseCase(auditRepo)))
 		analyticsRepo := analytics.NewRepository(pool)
 		analytics.RegisterRoutes(r, analytics.NewUseCase(analyticsRepo, analyticsRepo,
-			analytics.WithHotLeadsReader(analyticsRepo)))
+			analytics.WithHotLeadsReader(analyticsRepo),
+			analytics.WithInboxFlowReader(analyticsRepo)))
 		tgOpts := []tgclient.Option{}
 		if proxyDialer != nil {
 			tgOpts = append(tgOpts, tgclient.WithDialer(proxyDialer))

--- a/backend/internal/analytics/handler.go
+++ b/backend/internal/analytics/handler.go
@@ -201,8 +201,99 @@ func (h *handler) getHotLeads(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// inboxScoreBucketWire / inboxQualDistributionWire / inboxLeadsWire /
+// inboxPendingRepliesWire mirror the InboxFlowDTO sections onto the JSON
+// surface. approve_rate lives here (not in the DTO) because it's a
+// derived presentation value — the DTO stays count-pure.
+type inboxScoreBucketWire struct {
+	Range string `json:"range"`
+	Count int    `json:"count"`
+}
+
+type inboxQualDistributionWire struct {
+	ScoreHistogram []inboxScoreBucketWire `json:"score_histogram"`
+	AvgScore       float64                `json:"avg_score"`
+}
+
+type inboxLeadsWire struct {
+	Total     int            `json:"total"`
+	ByChannel map[string]int `json:"by_channel"`
+	ByStatus  map[string]int `json:"by_status"`
+}
+
+type inboxPendingRepliesWire struct {
+	Approved               int     `json:"approved"`
+	Rejected               int     `json:"rejected"`
+	CurrentlyPending       int     `json:"currently_pending"`
+	ApproveRate            float64 `json:"approve_rate"`
+	P50TimeToDecideSeconds int     `json:"p50_time_to_decide_seconds"`
+	P95TimeToDecideSeconds int     `json:"p95_time_to_decide_seconds"`
+}
+
+type inboxFlowResponse struct {
+	Period         costRatiosPeriodResponse  `json:"period"`
+	Leads          inboxLeadsWire            `json:"leads"`
+	Qualifications inboxQualDistributionWire `json:"qualifications"`
+	PendingReplies inboxPendingRepliesWire   `json:"pending_replies"`
+}
+
 func (h *handler) getInboxFlow(w http.ResponseWriter, r *http.Request) {
-	httputil.WriteError(w, http.StatusNotImplemented, "not implemented")
+	userID, ok := httputil.UserIDFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	periodParam := r.URL.Query().Get("period")
+	if periodParam == "" {
+		periodParam = string(PeriodMonth) // default for the inbox dashboard
+	}
+	period, err := ParsePeriod(periodParam)
+	if err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "period must be one of: week, month, all")
+		return
+	}
+
+	from, to := periodWindow(period, time.Now().UTC())
+	dto, err := h.uc.GetInboxFlow(r.Context(), userID, from, to)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "analytics: get inbox flow failed",
+			slog.String("user_id", userID.String()),
+			slog.String("period", string(period)),
+			slog.Any("err", err))
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to load inbox analytics")
+		return
+	}
+
+	histogram := make([]inboxScoreBucketWire, 0, len(dto.Qualifications.ScoreHistogram))
+	for _, b := range dto.Qualifications.ScoreHistogram {
+		histogram = append(histogram, inboxScoreBucketWire{Range: b.Range, Count: b.Count})
+	}
+
+	pr := dto.PendingReplies
+	httputil.WriteJSON(w, http.StatusOK, inboxFlowResponse{
+		Period: costRatiosPeriodResponse{
+			From: dto.PeriodFrom.UTC().Format(time.RFC3339),
+			To:   dto.PeriodTo.UTC().Format(time.RFC3339),
+		},
+		Leads: inboxLeadsWire{
+			Total:     dto.Leads.Total,
+			ByChannel: dto.Leads.ByChannel,
+			ByStatus:  dto.Leads.ByStatus,
+		},
+		Qualifications: inboxQualDistributionWire{
+			ScoreHistogram: histogram,
+			AvgScore:       dto.Qualifications.AvgScore,
+		},
+		PendingReplies: inboxPendingRepliesWire{
+			Approved:               pr.Approved,
+			Rejected:               pr.Rejected,
+			CurrentlyPending:       pr.CurrentlyPending,
+			ApproveRate:            safeRatio(int64(pr.Approved), int64(pr.Approved+pr.Rejected)),
+			P50TimeToDecideSeconds: pr.P50TimeToDecideSeconds,
+			P95TimeToDecideSeconds: pr.P95TimeToDecideSeconds,
+		},
+	})
 }
 
 // safeRatio divides numerator by denominator, returning 0 when the

--- a/backend/internal/analytics/handler.go
+++ b/backend/internal/analytics/handler.go
@@ -26,6 +26,7 @@ func RegisterRoutes(r chi.Router, uc *UseCase) {
 	r.Get("/api/analytics/sequences", h.getSequenceStats)
 	r.Get("/api/analytics/cost-ratios", h.getCostRatios)
 	r.Get("/api/analytics/hot-leads", h.getHotLeads)
+	r.Get("/api/analytics/inbox", h.getInboxFlow)
 }
 
 type handler struct {
@@ -198,6 +199,10 @@ func (h *handler) getHotLeads(w http.ResponseWriter, r *http.Request) {
 		TotalMatching: dto.TotalMatching,
 		LimitApplied:  dto.LimitApplied,
 	})
+}
+
+func (h *handler) getInboxFlow(w http.ResponseWriter, r *http.Request) {
+	httputil.WriteError(w, http.StatusNotImplemented, "not implemented")
 }
 
 // safeRatio divides numerator by denominator, returning 0 when the

--- a/backend/internal/analytics/inbox.go
+++ b/backend/internal/analytics/inbox.go
@@ -1,0 +1,90 @@
+package analytics
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// scoreBuckets defines the qualification-score histogram bands on the
+// 0-100 scale (domain ClampScore enforces [0,100]). Lo/Hi are inclusive.
+// Declared here, not in the repo, so the SQL FILTER ranges and the DTO
+// labels can never drift apart — one source of truth for both.
+//
+// Note: issue #97 illustrates a 0-10 histogram (0-2 / 3-5 / 6-8 / 9-10),
+// but the real qualifications.score column is 0-100. The bands below
+// reflect the actual schema; the deviation is intentional.
+var scoreBuckets = []struct {
+	Lo, Hi int
+	Label  string
+}{
+	{0, 20, "0-20"},
+	{21, 40, "21-40"},
+	{41, 60, "41-60"},
+	{61, 80, "61-80"},
+	{81, 100, "81-100"},
+}
+
+// ScoreBucketDTO is one bar of the qualification-score histogram. Range
+// is the inclusive label ("0-20"); Count is how many leads qualified in
+// the period fell in that band.
+type ScoreBucketDTO struct {
+	Range string
+	Count int
+}
+
+// LeadsBreakdownDTO is the lead-volume slice of View 3: the period total
+// plus per-channel and per-status counts. Maps keep the wire shape close
+// to the dashboard ({"telegram": n, ...}) without enumerating every enum
+// member as a struct field. Both maps are non-nil (possibly empty) so
+// they serialise as {} rather than null.
+type LeadsBreakdownDTO struct {
+	Total     int
+	ByChannel map[string]int
+	ByStatus  map[string]int
+}
+
+// QualificationDistributionDTO holds the score histogram and the mean
+// score over the period. AvgScore is 0 when no leads were qualified.
+type QualificationDistributionDTO struct {
+	ScoreHistogram []ScoreBucketDTO
+	AvgScore       float64
+}
+
+// PendingRepliesStatsDTO is the HITL approval slice. Approved counts the
+// approved+sent terminal states (both are operator approvals); Rejected
+// the rejected state; CurrentlyPending the still-undecided queue. P50/P95
+// are the time-to-decide percentiles in whole seconds over decided rows.
+//
+// The approve-rate is derived at the wire boundary from Approved/Rejected
+// so the DTO stays count-pure. There is no edited-then-approved metric:
+// pending_replies stores no original body to diff against, so issue #97's
+// "edited_then_approved" is dropped in v1 (the issue allows this).
+type PendingRepliesStatsDTO struct {
+	Approved               int
+	Rejected               int
+	CurrentlyPending       int
+	P50TimeToDecideSeconds int
+	P95TimeToDecideSeconds int
+}
+
+// InboxFlowDTO is the read model for View 3 — the inbound funnel lens.
+// Pure projection over leads + qualifications + pending_replies for the
+// [PeriodFrom, PeriodTo) window; no domain entities.
+type InboxFlowDTO struct {
+	PeriodFrom     time.Time
+	PeriodTo       time.Time
+	Leads          LeadsBreakdownDTO
+	Qualifications QualificationDistributionDTO
+	PendingReplies PendingRepliesStatsDTO
+}
+
+// InboxFlowReader is the port the usecase depends on for View 3. The pg
+// implementation lives in repository.go; tests stub it directly. The
+// [from, to) window is resolved at the handler boundary from the period
+// query param so this layer stays time-source agnostic (mirrors the
+// cost-ratios reader).
+type InboxFlowReader interface {
+	GetInboxFlow(ctx context.Context, userID uuid.UUID, from, to time.Time) (*InboxFlowDTO, error)
+}

--- a/backend/internal/analytics/inbox_integration_test.go
+++ b/backend/internal/analytics/inbox_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package analytics_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/daniil/floq/internal/analytics"
+	"github.com/daniil/floq/internal/testutil"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedPendingReply inserts a pending_replies row. decidedAt is nil for an
+// undecided row; otherwise it stamps decided_at so time-to-decide is
+// decidedAt-createdAt.
+func seedPendingReply(t *testing.T, pool *pgxpool.Pool, userID, leadID uuid.UUID, status string, createdAt time.Time, decidedAt *time.Time) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO pending_replies (id, user_id, lead_id, channel, kind, body, status, created_at, decided_at)
+		 VALUES ($1, $2, $3, 'telegram', 'booking_link', 'hi there', $4, $5, $6)`,
+		uuid.New(), userID, leadID, status, createdAt, decidedAt)
+	require.NoError(t, err, "seed pending reply")
+}
+
+// allWindow is a [epoch, now+1h) window — the integration equivalent of
+// PeriodAll, wide enough to include every freshly seeded row.
+func allWindow() (time.Time, time.Time) {
+	return time.Unix(0, 0).UTC(), time.Now().UTC().Add(time.Hour)
+}
+
+func TestRepository_GetInboxFlow_LeadsBreakdown(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	other := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+	now := time.Now().UTC()
+
+	seedHLLead(t, pool, userID, "telegram", "new", "a", now.Add(-time.Hour), now)
+	seedHLLead(t, pool, userID, "telegram", "qualified", "b", now.Add(-time.Hour), now)
+	seedHLLead(t, pool, userID, "email", "qualified", "c", now.Add(-time.Hour), now)
+	seedHLLead(t, pool, userID, "email", "closed", "d", now.Add(-time.Hour), now)
+	// Other tenant — must never appear.
+	seedHLLead(t, pool, other, "telegram", "new", "x", now.Add(-time.Hour), now)
+	// Old lead — outside a week window.
+	seedHLLead(t, pool, userID, "telegram", "new", "old", now.Add(-60*24*time.Hour), now)
+
+	from, to := allWindow()
+	dto, err := repo.GetInboxFlow(context.Background(), userID, from, to)
+	require.NoError(t, err)
+
+	assert.Equal(t, 5, dto.Leads.Total, "all of this user's leads in the full window")
+	assert.Equal(t, 3, dto.Leads.ByChannel["telegram"])
+	assert.Equal(t, 2, dto.Leads.ByChannel["email"])
+	assert.Equal(t, 2, dto.Leads.ByStatus["new"])
+	assert.Equal(t, 2, dto.Leads.ByStatus["qualified"])
+	assert.Equal(t, 1, dto.Leads.ByStatus["closed"])
+
+	// Week window excludes the 60-day-old lead.
+	weekFrom := now.Add(-7 * 24 * time.Hour)
+	wk, err := repo.GetInboxFlow(context.Background(), userID, weekFrom, to)
+	require.NoError(t, err)
+	assert.Equal(t, 4, wk.Leads.Total, "old lead excluded by window")
+}
+
+func TestRepository_GetInboxFlow_QualificationHistogram(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+	now := time.Now().UTC()
+
+	for _, sc := range []int{10, 30, 90, 90} {
+		l := seedHLLead(t, pool, userID, "telegram", "qualified", "q", now.Add(-time.Hour), now)
+		seedHLQual(t, pool, l, sc, "r", now)
+	}
+	// A lead with no qualification must not affect the histogram or avg.
+	seedHLLead(t, pool, userID, "telegram", "new", "noqual", now.Add(-time.Hour), now)
+
+	from, to := allWindow()
+	dto, err := repo.GetInboxFlow(context.Background(), userID, from, to)
+	require.NoError(t, err)
+
+	h := dto.Qualifications.ScoreHistogram
+	require.Len(t, h, 5, "all five 0-100 bands present even when empty")
+	assert.Equal(t, "0-20", h[0].Range)
+	assert.Equal(t, 1, h[0].Count) // score 10
+	assert.Equal(t, "21-40", h[1].Range)
+	assert.Equal(t, 1, h[1].Count) // score 30
+	assert.Equal(t, "41-60", h[2].Range)
+	assert.Equal(t, 0, h[2].Count)
+	assert.Equal(t, "61-80", h[3].Range)
+	assert.Equal(t, 0, h[3].Count)
+	assert.Equal(t, "81-100", h[4].Range)
+	assert.Equal(t, 2, h[4].Count) // two score 90
+	assert.InDelta(t, 55.0, dto.Qualifications.AvgScore, 0.001, "(10+30+90+90)/4")
+}
+
+func TestRepository_GetInboxFlow_QualificationAvgZeroWhenEmpty(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+
+	from, to := allWindow()
+	dto, err := repo.GetInboxFlow(context.Background(), userID, from, to)
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, dto.Qualifications.AvgScore, "no quals → zero avg, not NULL scan error")
+	require.Len(t, dto.Qualifications.ScoreHistogram, 5)
+	for _, b := range dto.Qualifications.ScoreHistogram {
+		assert.Equal(t, 0, b.Count)
+	}
+}
+
+func TestRepository_GetInboxFlow_PendingReplies(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	other := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+	now := time.Now().UTC()
+	base := now.Add(-2 * time.Hour)
+	lead := seedHLLead(t, pool, userID, "telegram", "qualified", "l", now.Add(-3*time.Hour), now)
+	otherLead := seedHLLead(t, pool, other, "telegram", "qualified", "ol", now.Add(-3*time.Hour), now)
+
+	dec := func(sec int) *time.Time { d := base.Add(time.Duration(sec) * time.Second); return &d }
+	seedPendingReply(t, pool, userID, lead, "approved", base, dec(100))
+	seedPendingReply(t, pool, userID, lead, "sent", base, dec(200))
+	seedPendingReply(t, pool, userID, lead, "rejected", base, dec(300))
+	seedPendingReply(t, pool, userID, lead, "pending", base, nil)
+	// Other tenant — excluded.
+	seedPendingReply(t, pool, other, otherLead, "approved", base, dec(999))
+
+	from, to := allWindow()
+	dto, err := repo.GetInboxFlow(context.Background(), userID, from, to)
+	require.NoError(t, err)
+
+	pr := dto.PendingReplies
+	assert.Equal(t, 2, pr.Approved, "approved + sent both count as operator approval")
+	assert.Equal(t, 1, pr.Rejected)
+	assert.Equal(t, 1, pr.CurrentlyPending)
+	// time-to-decide over decided rows {100,200,300}s.
+	assert.Equal(t, 200, pr.P50TimeToDecideSeconds, "median")
+	assert.Equal(t, 290, pr.P95TimeToDecideSeconds, "0.95 interpolated: 200 + 0.9*(300-200)")
+}
+
+func TestRepository_GetInboxFlow_PendingRepliesEmpty(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := analytics.NewRepository(pool)
+
+	from, to := allWindow()
+	dto, err := repo.GetInboxFlow(context.Background(), userID, from, to)
+	require.NoError(t, err)
+	pr := dto.PendingReplies
+	assert.Equal(t, 0, pr.Approved)
+	assert.Equal(t, 0, pr.Rejected)
+	assert.Equal(t, 0, pr.CurrentlyPending)
+	assert.Equal(t, 0, pr.P50TimeToDecideSeconds, "no decided rows → zero percentile, not NULL scan error")
+	assert.Equal(t, 0, pr.P95TimeToDecideSeconds)
+}

--- a/backend/internal/analytics/inbox_test.go
+++ b/backend/internal/analytics/inbox_test.go
@@ -1,0 +1,195 @@
+package analytics_test
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/daniil/floq/internal/analytics"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubInboxFlowReader records the window it was called with and returns
+// a canned DTO — keeps the handler test DB-free.
+type stubInboxFlowReader struct {
+	dto       *analytics.InboxFlowDTO
+	err       error
+	gotUserID uuid.UUID
+	gotFrom   time.Time
+	gotTo     time.Time
+	calls     int
+}
+
+func (s *stubInboxFlowReader) GetInboxFlow(_ context.Context, userID uuid.UUID, from, to time.Time) (*analytics.InboxFlowDTO, error) {
+	s.calls++
+	s.gotUserID = userID
+	s.gotFrom = from
+	s.gotTo = to
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.dto, nil
+}
+
+func inboxRouter(reader analytics.InboxFlowReader) chi.Router {
+	r := chi.NewRouter()
+	analytics.RegisterRoutes(r, analytics.NewUseCase(nil, nil, analytics.WithInboxFlowReader(reader)))
+	return r
+}
+
+func sampleInboxDTO() *analytics.InboxFlowDTO {
+	return &analytics.InboxFlowDTO{
+		PeriodFrom: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		PeriodTo:   time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		Leads: analytics.LeadsBreakdownDTO{
+			Total:     120,
+			ByChannel: map[string]int{"telegram": 70, "email": 50},
+			ByStatus:  map[string]int{"new": 10, "qualified": 40, "closed": 5},
+		},
+		Qualifications: analytics.QualificationDistributionDTO{
+			ScoreHistogram: []analytics.ScoreBucketDTO{
+				{Range: "0-20", Count: 5},
+				{Range: "81-100", Count: 25},
+			},
+			AvgScore: 64.5,
+		},
+		PendingReplies: analytics.PendingRepliesStatsDTO{
+			Approved:               80,
+			Rejected:               10,
+			CurrentlyPending:       5,
+			P50TimeToDecideSeconds: 120,
+			P95TimeToDecideSeconds: 600,
+		},
+	}
+}
+
+type inboxWire struct {
+	Period struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	} `json:"period"`
+	Leads struct {
+		Total     int            `json:"total"`
+		ByChannel map[string]int `json:"by_channel"`
+		ByStatus  map[string]int `json:"by_status"`
+	} `json:"leads"`
+	Qualifications struct {
+		ScoreHistogram []struct {
+			Range string `json:"range"`
+			Count int    `json:"count"`
+		} `json:"score_histogram"`
+		AvgScore float64 `json:"avg_score"`
+	} `json:"qualifications"`
+	PendingReplies struct {
+		Approved               int     `json:"approved"`
+		Rejected               int     `json:"rejected"`
+		CurrentlyPending       int     `json:"currently_pending"`
+		ApproveRate            float64 `json:"approve_rate"`
+		P50TimeToDecideSeconds int     `json:"p50_time_to_decide_seconds"`
+		P95TimeToDecideSeconds int     `json:"p95_time_to_decide_seconds"`
+	} `json:"pending_replies"`
+}
+
+func TestHandler_GetInboxFlow_ReturnsPayload(t *testing.T) {
+	userID := uuid.New()
+	reader := &stubInboxFlowReader{dto: sampleInboxDTO()}
+
+	w := httptest.NewRecorder()
+	inboxRouter(reader).ServeHTTP(w, newAuthedRequest(t, "/api/analytics/inbox?period=month", userID))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, userID, reader.gotUserID)
+
+	var got inboxWire
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+
+	assert.Equal(t, 120, got.Leads.Total)
+	assert.Equal(t, 70, got.Leads.ByChannel["telegram"])
+	assert.Equal(t, 40, got.Leads.ByStatus["qualified"])
+	require.Len(t, got.Qualifications.ScoreHistogram, 2)
+	assert.Equal(t, "0-20", got.Qualifications.ScoreHistogram[0].Range)
+	assert.Equal(t, 5, got.Qualifications.ScoreHistogram[0].Count)
+	assert.InDelta(t, 64.5, got.Qualifications.AvgScore, 0.001)
+	assert.Equal(t, 80, got.PendingReplies.Approved)
+	assert.Equal(t, 10, got.PendingReplies.Rejected)
+	assert.Equal(t, 5, got.PendingReplies.CurrentlyPending)
+	assert.Equal(t, 120, got.PendingReplies.P50TimeToDecideSeconds)
+	assert.Equal(t, 600, got.PendingReplies.P95TimeToDecideSeconds)
+}
+
+func TestHandler_GetInboxFlow_ApproveRateExcludesPending(t *testing.T) {
+	reader := &stubInboxFlowReader{dto: sampleInboxDTO()}
+	w := httptest.NewRecorder()
+	inboxRouter(reader).ServeHTTP(w, newAuthedRequest(t, "/api/analytics/inbox", uuid.New()))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got inboxWire
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	// 80 / (80 + 10) — currently_pending (5) is undecided and excluded.
+	assert.InDelta(t, 80.0/90.0, got.PendingReplies.ApproveRate, 0.0001)
+}
+
+func TestHandler_GetInboxFlow_ApproveRateZeroWhenNoDecisions(t *testing.T) {
+	dto := sampleInboxDTO()
+	dto.PendingReplies = analytics.PendingRepliesStatsDTO{Approved: 0, Rejected: 0, CurrentlyPending: 3}
+	reader := &stubInboxFlowReader{dto: dto}
+	w := httptest.NewRecorder()
+	inboxRouter(reader).ServeHTTP(w, newAuthedRequest(t, "/api/analytics/inbox", uuid.New()))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got inboxWire
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	assert.Equal(t, 0.0, got.PendingReplies.ApproveRate, "no decisions → zero rate, never NaN")
+	assert.False(t, math.IsNaN(got.PendingReplies.ApproveRate))
+}
+
+func TestHandler_GetInboxFlow_PeriodWindows(t *testing.T) {
+	cases := []struct {
+		query      string
+		wantSpan   time.Duration
+		wantEpoch0 bool
+	}{
+		{"?period=week", 7 * 24 * time.Hour, false},
+		{"?period=month", 30 * 24 * time.Hour, false},
+		{"", 30 * 24 * time.Hour, false}, // default is month
+		{"?period=all", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			reader := &stubInboxFlowReader{dto: sampleInboxDTO()}
+			w := httptest.NewRecorder()
+			inboxRouter(reader).ServeHTTP(w, newAuthedRequest(t, "/api/analytics/inbox"+tc.query, uuid.New()))
+			require.Equal(t, http.StatusOK, w.Code)
+			require.Equal(t, 1, reader.calls)
+			if tc.wantEpoch0 {
+				assert.Equal(t, time.Unix(0, 0).UTC(), reader.gotFrom, "period=all starts at epoch")
+				return
+			}
+			span := reader.gotTo.Sub(reader.gotFrom)
+			assert.InDelta(t, tc.wantSpan.Seconds(), span.Seconds(), 5, "window span")
+		})
+	}
+}
+
+func TestHandler_GetInboxFlow_InvalidPeriod(t *testing.T) {
+	reader := &stubInboxFlowReader{dto: sampleInboxDTO()}
+	w := httptest.NewRecorder()
+	inboxRouter(reader).ServeHTTP(w, newAuthedRequest(t, "/api/analytics/inbox?period=year", uuid.New()))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, 0, reader.calls, "invalid period must not reach the reader")
+}
+
+func TestHandler_GetInboxFlow_Unauthenticated(t *testing.T) {
+	reader := &stubInboxFlowReader{dto: sampleInboxDTO()}
+	w := httptest.NewRecorder()
+	inboxRouter(reader).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/analytics/inbox", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Equal(t, 0, reader.calls)
+}

--- a/backend/internal/analytics/repository.go
+++ b/backend/internal/analytics/repository.go
@@ -3,6 +3,8 @@ package analytics
 import (
 	"context"
 	"fmt"
+	"math"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -30,15 +32,132 @@ var (
 	_ InboxFlowReader     = (*Repository)(nil)
 )
 
-// GetInboxFlow is stubbed pending the GREEN implementation — returns an
-// empty read model so the integration tests compile and fail on the
-// real assertions rather than panicking on a nil deref.
+// GetInboxFlow composes the View 3 inbound-funnel read model over the
+// [from, to) window: lead volume sliced by channel and status, the
+// qualification-score histogram + mean, and the HITL approval stats
+// (approve/reject/pending counts + time-to-decide percentiles). Three
+// sequential queries — clarity over throughput, the dashboard is not a
+// hot path (mirrors GetCostRatios).
+//
+// Every section is tenant-scoped through its own user_id column. The
+// histogram bands come from the shared scoreBuckets table so the SQL
+// FILTERs and the DTO labels stay in lockstep.
 func (r *Repository) GetInboxFlow(ctx context.Context, userID uuid.UUID, from, to time.Time) (*InboxFlowDTO, error) {
-	return &InboxFlowDTO{
+	dto := &InboxFlowDTO{
 		PeriodFrom: from,
 		PeriodTo:   to,
 		Leads:      LeadsBreakdownDTO{ByChannel: map[string]int{}, ByStatus: map[string]int{}},
-	}, nil
+	}
+
+	if err := r.loadLeadsBreakdown(ctx, userID, from, to, &dto.Leads); err != nil {
+		return nil, err
+	}
+	if err := r.loadQualificationDistribution(ctx, userID, from, to, &dto.Qualifications); err != nil {
+		return nil, err
+	}
+	if err := r.loadPendingRepliesStats(ctx, userID, from, to, &dto.PendingReplies); err != nil {
+		return nil, err
+	}
+	return dto, nil
+}
+
+// loadLeadsBreakdown fills total/by-channel/by-status from a single
+// GROUP BY channel, status. Counts are folded into the maps in Go so the
+// query stays one round-trip regardless of how many enum members are
+// present.
+func (r *Repository) loadLeadsBreakdown(ctx context.Context, userID uuid.UUID, from, to time.Time, out *LeadsBreakdownDTO) error {
+	rows, err := r.pool.Query(ctx, `
+		SELECT channel::text, status::text, COUNT(*)
+		FROM leads
+		WHERE user_id = $1 AND created_at >= $2 AND created_at < $3
+		GROUP BY channel, status`,
+		userID, from, to,
+	)
+	if err != nil {
+		return fmt.Errorf("analytics inbox leads breakdown: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			channel, status string
+			count           int
+		)
+		if err := rows.Scan(&channel, &status, &count); err != nil {
+			return fmt.Errorf("analytics inbox scan leads breakdown: %w", err)
+		}
+		out.Total += count
+		out.ByChannel[channel] += count
+		out.ByStatus[status] += count
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("analytics inbox leads breakdown iter: %w", err)
+	}
+	return nil
+}
+
+// loadQualificationDistribution fills the score histogram and mean. The
+// per-band COUNT(*) FILTER columns are built from scoreBuckets so the
+// SQL and the DTO labels can't drift; the bounds are compile-time int
+// constants so the fmt-built SQL carries no injection surface. Period
+// scope is on the lead's created_at (same cohort as the leads slice).
+func (r *Repository) loadQualificationDistribution(ctx context.Context, userID uuid.UUID, from, to time.Time, out *QualificationDistributionDTO) error {
+	var sb strings.Builder
+	sb.WriteString("SELECT COALESCE(AVG(q.score), 0)")
+	for i, b := range scoreBuckets {
+		fmt.Fprintf(&sb, ", COUNT(*) FILTER (WHERE q.score BETWEEN %d AND %d) AS b%d", b.Lo, b.Hi, i)
+	}
+	sb.WriteString(`
+		FROM qualifications q
+		JOIN leads l ON l.id = q.lead_id
+		WHERE l.user_id = $1 AND l.created_at >= $2 AND l.created_at < $3`)
+
+	counts := make([]int, len(scoreBuckets))
+	dests := make([]any, 0, len(scoreBuckets)+1)
+	dests = append(dests, &out.AvgScore)
+	for i := range counts {
+		dests = append(dests, &counts[i])
+	}
+	if err := r.pool.QueryRow(ctx, sb.String(), userID, from, to).Scan(dests...); err != nil {
+		return fmt.Errorf("analytics inbox qualification histogram: %w", err)
+	}
+
+	out.ScoreHistogram = make([]ScoreBucketDTO, len(scoreBuckets))
+	for i, b := range scoreBuckets {
+		out.ScoreHistogram[i] = ScoreBucketDTO{Range: b.Label, Count: counts[i]}
+	}
+	return nil
+}
+
+// loadPendingRepliesStats fills the HITL approval slice. approved counts
+// the approved+sent terminal states (both operator approvals); the
+// percentiles are computed in SQL over decided rows (decided_at NOT
+// NULL) via percentile_cont, COALESCEd to 0 so an empty queue scans a
+// number rather than NULL. Seconds are rounded to whole integers at the
+// boundary.
+func (r *Repository) loadPendingRepliesStats(ctx context.Context, userID uuid.UUID, from, to time.Time, out *PendingRepliesStatsDTO) error {
+	var p50, p95 float64
+	err := r.pool.QueryRow(ctx, `
+		SELECT
+		    COUNT(*) FILTER (WHERE status IN ('approved', 'sent')) AS approved,
+		    COUNT(*) FILTER (WHERE status = 'rejected')           AS rejected,
+		    COUNT(*) FILTER (WHERE status = 'pending')            AS pending,
+		    COALESCE(percentile_cont(0.5) WITHIN GROUP (
+		        ORDER BY EXTRACT(EPOCH FROM (decided_at - created_at))
+		    ) FILTER (WHERE decided_at IS NOT NULL), 0) AS p50,
+		    COALESCE(percentile_cont(0.95) WITHIN GROUP (
+		        ORDER BY EXTRACT(EPOCH FROM (decided_at - created_at))
+		    ) FILTER (WHERE decided_at IS NOT NULL), 0) AS p95
+		FROM pending_replies
+		WHERE user_id = $1 AND created_at >= $2 AND created_at < $3`,
+		userID, from, to,
+	).Scan(&out.Approved, &out.Rejected, &out.CurrentlyPending, &p50, &p95)
+	if err != nil {
+		return fmt.Errorf("analytics inbox pending replies: %w", err)
+	}
+	out.P50TimeToDecideSeconds = int(math.Round(p50))
+	out.P95TimeToDecideSeconds = int(math.Round(p95))
+	return nil
 }
 
 // GetSequenceStats returns one row per sequence with activity in the

--- a/backend/internal/analytics/repository.go
+++ b/backend/internal/analytics/repository.go
@@ -27,7 +27,19 @@ var (
 	_ SequenceStatsReader = (*Repository)(nil)
 	_ CostRatiosReader    = (*Repository)(nil)
 	_ HotLeadsReader      = (*Repository)(nil)
+	_ InboxFlowReader     = (*Repository)(nil)
 )
+
+// GetInboxFlow is stubbed pending the GREEN implementation — returns an
+// empty read model so the integration tests compile and fail on the
+// real assertions rather than panicking on a nil deref.
+func (r *Repository) GetInboxFlow(ctx context.Context, userID uuid.UUID, from, to time.Time) (*InboxFlowDTO, error) {
+	return &InboxFlowDTO{
+		PeriodFrom: from,
+		PeriodTo:   to,
+		Leads:      LeadsBreakdownDTO{ByChannel: map[string]int{}, ByStatus: map[string]int{}},
+	}, nil
+}
 
 // GetSequenceStats returns one row per sequence with activity in the
 // requested period. Sequences with zero outbound rows in the window

--- a/backend/internal/analytics/usecase.go
+++ b/backend/internal/analytics/usecase.go
@@ -13,9 +13,10 @@ import (
 // audit_log + sequence stats joined together) don't have to rewire
 // every handler.
 type UseCase struct {
-	seq  SequenceStatsReader
-	cost CostRatiosReader
-	hot  HotLeadsReader
+	seq   SequenceStatsReader
+	cost  CostRatiosReader
+	hot   HotLeadsReader
+	inbox InboxFlowReader
 }
 
 // Option configures optional read ports on the UseCase. Used for ports
@@ -25,6 +26,11 @@ type Option func(*UseCase)
 // WithHotLeadsReader wires the View 4 hot-leads reader.
 func WithHotLeadsReader(h HotLeadsReader) Option {
 	return func(uc *UseCase) { uc.hot = h }
+}
+
+// WithInboxFlowReader wires the View 3 inbox-flow reader.
+func WithInboxFlowReader(i InboxFlowReader) Option {
+	return func(uc *UseCase) { uc.inbox = i }
 }
 
 // NewUseCase wires the read ports. seq and cost may be nil if the
@@ -50,6 +56,12 @@ func (uc *UseCase) GetHotLeads(ctx context.Context, userID uuid.UUID, filter Hot
 // layer only sees the typed value.
 func (uc *UseCase) GetSequenceStats(ctx context.Context, userID uuid.UUID, period Period) ([]SequenceStatsDTO, error) {
 	return uc.seq.GetSequenceStats(ctx, userID, period)
+}
+
+// GetInboxFlow forwards to the inbox-flow reader. The [from, to) window
+// is resolved at the handler boundary from the period query param.
+func (uc *UseCase) GetInboxFlow(ctx context.Context, userID uuid.UUID, from, to time.Time) (*InboxFlowDTO, error) {
+	return uc.inbox.GetInboxFlow(ctx, userID, from, to)
 }
 
 // GetCostRatios forwards the call to the cost-ratios reader. The

--- a/frontend/src/app/(dashboard)/analytics/inbox/page.tsx
+++ b/frontend/src/app/(dashboard)/analytics/inbox/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import type { AnalyticsPeriod } from "@/lib/api";
+import { useInboxAnalytics } from "@/hooks/useInboxAnalytics";
+import { AnalyticsTabs } from "@/components/analytics/AnalyticsTabs";
+import { PeriodSelector } from "@/components/analytics/PeriodSelector";
+import { LeadsByChannelCard } from "@/components/analytics/LeadsByChannelCard";
+import { LeadsByStatusTable } from "@/components/analytics/LeadsByStatusTable";
+import { QualificationHistogram } from "@/components/analytics/QualificationHistogram";
+import { PendingRepliesSummary } from "@/components/analytics/PendingRepliesSummary";
+
+export default function InboxAnalyticsPage() {
+  const [period, setPeriod] = useState<AnalyticsPeriod>("month");
+  const { data, loading, error, lastUpdated, refresh } = useInboxAnalytics(period);
+
+  return (
+    <section className="flex-1 overflow-y-auto px-4 sm:px-8 lg:px-12 py-8">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <AnalyticsTabs />
+        <header className="flex items-end justify-between gap-4 flex-wrap">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-extrabold tracking-tight text-[#0d1c2e]">Входящие</h1>
+            <p className="text-sm text-slate-500 mt-1">
+              Поток входящих лидов: каналы, статусы, квалификация и AI-черновики.
+            </p>
+          </div>
+          <div className="flex items-center gap-3 flex-wrap">
+            <PeriodSelector value={period} onChange={setPeriod} />
+            <button
+              type="button"
+              onClick={() => void refresh()}
+              className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            >
+              Обновить
+            </button>
+          </div>
+        </header>
+
+        {error && (
+          <div role="alert" className="rounded-md border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
+            Не удалось загрузить данные: {error.message}
+          </div>
+        )}
+
+        {loading && !data ? (
+          <div className="rounded-lg border border-slate-200 bg-white p-8 text-center text-sm text-slate-500">
+            Загружаем…
+          </div>
+        ) : data ? (
+          <>
+            <div className="grid gap-4 lg:grid-cols-2">
+              <LeadsByChannelCard byChannel={data.leads.by_channel} total={data.leads.total} />
+              <LeadsByStatusTable byStatus={data.leads.by_status} total={data.leads.total} />
+            </div>
+            <div className="grid gap-4 lg:grid-cols-2">
+              <QualificationHistogram
+                histogram={data.qualifications.score_histogram}
+                avgScore={data.qualifications.avg_score}
+              />
+              <PendingRepliesSummary stats={data.pending_replies} />
+            </div>
+            {lastUpdated && (
+              <div className="text-xs text-slate-400">
+                Обновлено {lastUpdated.toLocaleTimeString("ru-RU")}
+              </div>
+            )}
+          </>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/analytics/AnalyticsTabs.tsx
+++ b/frontend/src/components/analytics/AnalyticsTabs.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 const TABS = [
   { href: "/analytics/sequences", label: "Sequences" },
   { href: "/analytics/cost", label: "Затраты" },
+  { href: "/analytics/inbox", label: "Входящие" },
   { href: "/analytics/hot-leads", label: "Горячие лиды" },
 ];
 

--- a/frontend/src/components/analytics/LeadsByChannelCard.test.tsx
+++ b/frontend/src/components/analytics/LeadsByChannelCard.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LeadsByChannelCard } from "./LeadsByChannelCard";
+
+describe("LeadsByChannelCard", () => {
+  it("renders each channel with its count and share", () => {
+    render(<LeadsByChannelCard byChannel={{ telegram: 70, email: 30 }} total={100} />);
+    expect(screen.getByTestId("channel-telegram")).toHaveTextContent("70");
+    expect(screen.getByTestId("channel-email")).toHaveTextContent("30");
+    expect(screen.getByTestId("channel-telegram")).toHaveTextContent("70%");
+  });
+
+  it("shows a zero count for a channel absent from the map", () => {
+    render(<LeadsByChannelCard byChannel={{ telegram: 5 }} total={5} />);
+    expect(screen.getByTestId("channel-email")).toHaveTextContent("0");
+  });
+
+  it("renders an empty state when there are no leads", () => {
+    render(<LeadsByChannelCard byChannel={{}} total={0} />);
+    expect(screen.getByText(/Нет лидов/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/analytics/LeadsByChannelCard.tsx
+++ b/frontend/src/components/analytics/LeadsByChannelCard.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+interface LeadsByChannelCardProps {
+  byChannel: Record<string, number>;
+  total: number;
+}
+
+// CHANNELS is the fixed set of inbound channels (the lead_channel enum),
+// rendered in a stable order so a channel with zero leads in the period
+// still shows as a 0 row rather than vanishing.
+const CHANNELS: { key: string; label: string; color: string }[] = [
+  { key: "telegram", label: "Telegram", color: "bg-sky-500" },
+  { key: "email", label: "Email", color: "bg-amber-500" },
+];
+
+// LeadsByChannelCard shows the inbound split across channels with each
+// channel's count and share of the total. A proportional bar gives the
+// donut-like glance the dashboard wants without a charting dependency.
+export function LeadsByChannelCard({ byChannel, total }: LeadsByChannelCardProps) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-6">
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-sm font-semibold text-slate-700">Лиды по каналам</h2>
+        <span className="text-sm text-slate-500 tabular-nums">{total}</span>
+      </div>
+      {total === 0 ? (
+        <p className="mt-4 text-center text-sm text-slate-500">Нет лидов за период.</p>
+      ) : (
+        <div className="mt-4 space-y-3">
+          {CHANNELS.map((ch) => {
+            const count = byChannel[ch.key] ?? 0;
+            const pct = total > 0 ? Math.round((count / total) * 100) : 0;
+            return (
+              <div key={ch.key} data-testid={`channel-${ch.key}`} className="text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-slate-700">{ch.label}</span>
+                  <span className="tabular-nums text-slate-900">
+                    {count} <span className="text-slate-400">· {pct}%</span>
+                  </span>
+                </div>
+                <div className="mt-1 h-2 overflow-hidden rounded bg-slate-100">
+                  <div className={`h-full rounded ${ch.color}`} style={{ width: `${pct}%` }} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/analytics/LeadsByStatusTable.test.tsx
+++ b/frontend/src/components/analytics/LeadsByStatusTable.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+import { LeadsByStatusTable } from "./LeadsByStatusTable";
+
+describe("LeadsByStatusTable", () => {
+  beforeEach(() => pushMock.mockReset());
+
+  it("renders status rows in funnel order with counts", () => {
+    render(<LeadsByStatusTable byStatus={{ new: 10, qualified: 40, closed: 5 }} total={55} />);
+    const rows = screen.getAllByRole("row").slice(1); // skip header
+    // Funnel order: new before qualified before closed.
+    expect(rows[0]).toHaveTextContent("Новые");
+    expect(rows[0]).toHaveTextContent("10");
+    expect(screen.getByText("Квалифицированные")).toBeInTheDocument();
+  });
+
+  it("navigates to the inbox on row click", async () => {
+    const user = userEvent.setup();
+    render(<LeadsByStatusTable byStatus={{ new: 10 }} total={10} />);
+    await user.click(screen.getByText("Новые"));
+    expect(pushMock).toHaveBeenCalledWith("/inbox");
+  });
+
+  it("renders an empty state when there are no leads", () => {
+    render(<LeadsByStatusTable byStatus={{}} total={0} />);
+    expect(screen.getByText(/Нет лидов/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/analytics/LeadsByStatusTable.tsx
+++ b/frontend/src/components/analytics/LeadsByStatusTable.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+interface LeadsByStatusTableProps {
+  byStatus: Record<string, number>;
+  total: number;
+}
+
+// STATUSES is the lead_status enum in funnel order, with Russian labels.
+// Rendered in this fixed order so the table reads as a funnel and a
+// status with zero leads still appears (as a 0 row) rather than
+// reshuffling between periods.
+const STATUSES: { key: string; label: string }[] = [
+  { key: "new", label: "Новые" },
+  { key: "qualified", label: "Квалифицированные" },
+  { key: "in_conversation", label: "В диалоге" },
+  { key: "followup", label: "Follow-up" },
+  { key: "closed", label: "Закрытые" },
+];
+
+// LeadsByStatusTable lists lead volume per status with share-of-total.
+// A row click drills through to the inbox lead list. Pre-selecting the
+// clicked status there is a follow-up — the inbox filter is local state
+// today, not a URL param — so the click lands on the unfiltered inbox.
+export function LeadsByStatusTable({ byStatus, total }: LeadsByStatusTableProps) {
+  const router = useRouter();
+
+  if (total === 0) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white p-6">
+        <h2 className="text-sm font-semibold text-slate-700">Лиды по статусам</h2>
+        <p className="mt-4 text-center text-sm text-slate-500">Нет лидов за период.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white">
+      <h2 className="px-4 py-2 text-sm font-semibold text-slate-700 border-b border-slate-100">
+        Лиды по статусам
+      </h2>
+      <table className="min-w-full divide-y divide-slate-200 text-sm">
+        <thead className="bg-slate-50">
+          <tr>
+            <th scope="col" className="px-4 py-2 text-left font-medium text-slate-700">Статус</th>
+            <th scope="col" className="px-4 py-2 text-right font-medium text-slate-700">Лидов</th>
+            <th scope="col" className="px-4 py-2 text-right font-medium text-slate-700">Доля</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {STATUSES.map((s) => {
+            const count = byStatus[s.key] ?? 0;
+            const pct = total > 0 ? Math.round((count / total) * 100) : 0;
+            return (
+              <tr
+                key={s.key}
+                onClick={() => router.push("/inbox")}
+                className="cursor-pointer hover:bg-slate-50"
+              >
+                <td className="px-4 py-2 font-medium text-slate-900">{s.label}</td>
+                <td className="px-4 py-2 text-right tabular-nums">{count}</td>
+                <td className="px-4 py-2 text-right tabular-nums text-slate-500">{pct}%</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/analytics/PendingRepliesSummary.test.tsx
+++ b/frontend/src/components/analytics/PendingRepliesSummary.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { InboxFlowResponse } from "@/lib/api";
+import { PendingRepliesSummary, formatDecideDuration } from "./PendingRepliesSummary";
+
+type PR = InboxFlowResponse["pending_replies"];
+
+function pr(over: Partial<PR> = {}): PR {
+  return {
+    approved: 80,
+    rejected: 10,
+    currently_pending: 5,
+    approve_rate: 0.842,
+    p50_time_to_decide_seconds: 120,
+    p95_time_to_decide_seconds: 600,
+    ...over,
+  };
+}
+
+describe("formatDecideDuration", () => {
+  it("formats sub-minute as seconds", () => {
+    expect(formatDecideDuration(45)).toBe("45 с");
+  });
+  it("formats whole minutes", () => {
+    expect(formatDecideDuration(120)).toBe("2 мин");
+    expect(formatDecideDuration(600)).toBe("10 мин");
+  });
+  it("formats minutes with remainder seconds", () => {
+    expect(formatDecideDuration(90)).toBe("1 мин 30 с");
+  });
+  it("renders a dash for zero (no decided rows)", () => {
+    expect(formatDecideDuration(0)).toBe("—");
+  });
+});
+
+describe("PendingRepliesSummary", () => {
+  it("shows the approve rate as a rounded percentage", () => {
+    render(<PendingRepliesSummary stats={pr()} />);
+    expect(screen.getByText("84%")).toBeInTheDocument();
+  });
+
+  it("shows approved / rejected / pending counts", () => {
+    render(<PendingRepliesSummary stats={pr()} />);
+    expect(screen.getByTestId("pr-approved")).toHaveTextContent("80");
+    expect(screen.getByTestId("pr-rejected")).toHaveTextContent("10");
+    expect(screen.getByTestId("pr-pending")).toHaveTextContent("5");
+  });
+
+  it("shows the time-to-decide percentiles formatted", () => {
+    render(<PendingRepliesSummary stats={pr()} />);
+    expect(screen.getByTestId("pr-p50")).toHaveTextContent("2 мин");
+    expect(screen.getByTestId("pr-p95")).toHaveTextContent("10 мин");
+  });
+
+  it("handles a zero-decision queue without NaN", () => {
+    render(<PendingRepliesSummary stats={pr({ approved: 0, rejected: 0, approve_rate: 0, p50_time_to_decide_seconds: 0, p95_time_to_decide_seconds: 0 })} />);
+    expect(screen.getByText("0%")).toBeInTheDocument();
+    expect(screen.getByTestId("pr-p50")).toHaveTextContent("—");
+  });
+});

--- a/frontend/src/components/analytics/PendingRepliesSummary.tsx
+++ b/frontend/src/components/analytics/PendingRepliesSummary.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { InboxFlowResponse } from "@/lib/api";
+
+interface PendingRepliesSummaryProps {
+  stats: InboxFlowResponse["pending_replies"];
+}
+
+// formatDecideDuration renders a time-to-decide value (whole seconds)
+// for the operator dashboard. Zero means "no decided rows" and shows a
+// dash rather than "0 с" — a real decision is never instantaneous, so 0
+// is the empty sentinel, not a measurement.
+export function formatDecideDuration(seconds: number): string {
+  if (seconds <= 0) return "—";
+  if (seconds < 60) return `${seconds} с`;
+  const mins = Math.floor(seconds / 60);
+  const rem = seconds % 60;
+  return rem === 0 ? `${mins} мин` : `${mins} мин ${rem} с`;
+}
+
+function Metric({ label, value, testId }: { label: string; value: string; testId: string }) {
+  return (
+    <div className="rounded-md border border-slate-100 bg-slate-50 px-3 py-2">
+      <div className="text-xs text-slate-500">{label}</div>
+      <div data-testid={testId} className="mt-0.5 text-lg font-semibold tabular-nums text-slate-900">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+// PendingRepliesSummary shows the HITL approval health: the approve rate
+// (operator approvals over decisions made), the approved/rejected/pending
+// breakdown, and the p50/p95 time-to-decide. The approve rate arrives
+// pre-computed from the backend (0 on no decisions) so this component
+// only formats.
+export function PendingRepliesSummary({ stats }: PendingRepliesSummaryProps) {
+  const approvePct = Math.round(stats.approve_rate * 100);
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-6">
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-sm font-semibold text-slate-700">AI-черновики (HITL)</h2>
+        <span className="text-sm text-slate-500">
+          Одобрено: <span className="font-semibold text-slate-900 tabular-nums">{approvePct}%</span>
+        </span>
+      </div>
+      <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3">
+        <Metric label="Одобрено" value={String(stats.approved)} testId="pr-approved" />
+        <Metric label="Отклонено" value={String(stats.rejected)} testId="pr-rejected" />
+        <Metric label="В очереди" value={String(stats.currently_pending)} testId="pr-pending" />
+        <Metric label="Решение (p50)" value={formatDecideDuration(stats.p50_time_to_decide_seconds)} testId="pr-p50" />
+        <Metric label="Решение (p95)" value={formatDecideDuration(stats.p95_time_to_decide_seconds)} testId="pr-p95" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/analytics/QualificationHistogram.test.tsx
+++ b/frontend/src/components/analytics/QualificationHistogram.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ScoreBucket } from "@/lib/api";
+import { QualificationHistogram } from "./QualificationHistogram";
+
+const bands: ScoreBucket[] = [
+  { range: "0-20", count: 1 },
+  { range: "21-40", count: 0 },
+  { range: "41-60", count: 0 },
+  { range: "61-80", count: 2 },
+  { range: "81-100", count: 5 },
+];
+
+describe("QualificationHistogram", () => {
+  it("renders every band label with its count", () => {
+    render(<QualificationHistogram histogram={bands} avgScore={55} />);
+    for (const b of bands) {
+      expect(screen.getByText(b.range)).toBeInTheDocument();
+    }
+    expect(screen.getByTestId("bar-count-81-100")).toHaveTextContent("5");
+    expect(screen.getByTestId("bar-count-21-40")).toHaveTextContent("0");
+  });
+
+  it("scales the tallest band to full width and others proportionally", () => {
+    render(<QualificationHistogram histogram={bands} avgScore={55} />);
+    // tallest is 81-100 (count 5) → 100%; 61-80 (count 2) → 40%.
+    expect(screen.getByTestId("bar-fill-81-100")).toHaveStyle({ width: "100%" });
+    expect(screen.getByTestId("bar-fill-61-80")).toHaveStyle({ width: "40%" });
+    expect(screen.getByTestId("bar-fill-21-40")).toHaveStyle({ width: "0%" });
+  });
+
+  it("shows the average score", () => {
+    render(<QualificationHistogram histogram={bands} avgScore={55.4} />);
+    expect(screen.getByText(/55\.4/)).toBeInTheDocument();
+  });
+
+  it("renders an empty state when there are no qualifications", () => {
+    const empty: ScoreBucket[] = bands.map((b) => ({ ...b, count: 0 }));
+    render(<QualificationHistogram histogram={empty} avgScore={0} />);
+    expect(screen.getByText(/Нет квалификаций/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/analytics/QualificationHistogram.tsx
+++ b/frontend/src/components/analytics/QualificationHistogram.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import type { ScoreBucket } from "@/lib/api";
+
+interface QualificationHistogramProps {
+  histogram: ScoreBucket[];
+  avgScore: number;
+}
+
+// QualificationHistogram draws the qualification-score distribution as a
+// set of horizontal bars (one per 0-100 band) plus the mean score. Bars
+// are scaled against the tallest band so the shape reads at a glance
+// without a charting dependency. An all-zero histogram shows an empty
+// state rather than five flat bars.
+export function QualificationHistogram({ histogram, avgScore }: QualificationHistogramProps) {
+  const max = histogram.reduce((m, b) => Math.max(m, b.count), 0);
+
+  if (max === 0) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white p-6">
+        <h2 className="text-sm font-semibold text-slate-700">Распределение скоров</h2>
+        <p className="mt-4 text-center text-sm text-slate-500">Нет квалификаций за период.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-6">
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-sm font-semibold text-slate-700">Распределение скоров</h2>
+        <span className="text-sm text-slate-500">
+          Средний: <span className="font-semibold text-slate-900 tabular-nums">{avgScore.toFixed(1)}</span>
+        </span>
+      </div>
+      <div className="mt-4 space-y-2">
+        {histogram.map((b) => {
+          const pct = Math.round((b.count / max) * 100);
+          return (
+            <div key={b.range} className="flex items-center gap-3 text-sm">
+              <span className="w-16 shrink-0 text-right tabular-nums text-slate-500">{b.range}</span>
+              <div className="relative h-5 flex-1 overflow-hidden rounded bg-slate-100">
+                <div
+                  data-testid={`bar-fill-${b.range}`}
+                  className="h-full rounded bg-indigo-500"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              <span data-testid={`bar-count-${b.range}`} className="w-8 shrink-0 tabular-nums text-slate-900">
+                {b.count}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useInboxAnalytics.test.ts
+++ b/frontend/src/hooks/useInboxAnalytics.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { InboxFlowResponse } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getInboxAnalytics: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { POLL_INTERVAL_MS, useInboxAnalytics } from "./useInboxAnalytics";
+
+function inbox(over: Partial<InboxFlowResponse> = {}): InboxFlowResponse {
+  return {
+    period: over.period ?? { from: "2026-05-01T00:00:00Z", to: "2026-06-01T00:00:00Z" },
+    leads: over.leads ?? {
+      total: 120,
+      by_channel: { telegram: 70, email: 50 },
+      by_status: { new: 10, qualified: 40, closed: 5 },
+    },
+    qualifications: over.qualifications ?? {
+      score_histogram: [
+        { range: "0-20", count: 5 },
+        { range: "81-100", count: 25 },
+      ],
+      avg_score: 64.5,
+    },
+    pending_replies: over.pending_replies ?? {
+      approved: 80,
+      rejected: 10,
+      currently_pending: 5,
+      approve_rate: 0.842,
+      p50_time_to_decide_seconds: 120,
+      p95_time_to_decide_seconds: 600,
+    },
+  };
+}
+
+describe("useInboxAnalytics", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(api.getInboxAnalytics).mockResolvedValue(inbox());
+  });
+
+  it("fetches on mount with the default month period", async () => {
+    const { result } = renderHook(() => useInboxAnalytics());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(api.getInboxAnalytics).toHaveBeenCalledTimes(1);
+    expect(api.getInboxAnalytics).toHaveBeenCalledWith("month");
+    expect(result.current.data?.leads.total).toBe(120);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastUpdated).not.toBeNull();
+  });
+
+  it("refetches when the period changes", async () => {
+    const { rerender } = renderHook(({ p }: { p: "week" | "month" | "all" }) => useInboxAnalytics(p), {
+      initialProps: { p: "month" },
+    });
+    await waitFor(() => expect(api.getInboxAnalytics).toHaveBeenCalledTimes(1));
+
+    rerender({ p: "week" });
+    await waitFor(() => expect(api.getInboxAnalytics).toHaveBeenLastCalledWith("week"));
+    await waitFor(() => expect(api.getInboxAnalytics).toHaveBeenCalledTimes(2));
+  });
+
+  it("polls every POLL_INTERVAL_MS", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      renderHook(() => useInboxAnalytics());
+      await waitFor(() => expect(api.getInboxAnalytics).toHaveBeenCalledTimes(1));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      });
+      expect(api.getInboxAnalytics).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces fetch errors and preserves the last good data", async () => {
+    vi.mocked(api.getInboxAnalytics).mockResolvedValueOnce(inbox());
+    vi.mocked(api.getInboxAnalytics).mockRejectedValueOnce(new Error("network"));
+
+    const { result } = renderHook(() => useInboxAnalytics());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).not.toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.error).not.toBeNull();
+    // Last-good data preserved through the failed refresh (keep-last).
+    expect(result.current.data?.leads.total).toBe(120);
+  });
+});

--- a/frontend/src/hooks/useInboxAnalytics.ts
+++ b/frontend/src/hooks/useInboxAnalytics.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api, type AnalyticsPeriod, type InboxFlowResponse } from "@/lib/api";
+
+// POLL_INTERVAL_MS exported so tests advance timers by an exact multiple.
+export const POLL_INTERVAL_MS = 30_000;
+
+interface UseInboxAnalyticsResult {
+  data: InboxFlowResponse | null;
+  loading: boolean;
+  error: Error | null;
+  lastUpdated: Date | null;
+  refresh: () => Promise<void>;
+}
+
+// useInboxAnalytics returns the View 3 inbound-flow read model for the
+// given period. Polls every POLL_INTERVAL_MS so the dashboard stays
+// fresh and keeps the last good data visible on a transient fetch error
+// (the panel informs, not blanks-out). Mirrors useCostAnalytics.
+export function useInboxAnalytics(period: AnalyticsPeriod = "month"): UseInboxAnalyticsResult {
+  const [data, setData] = useState<InboxFlowResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const mountedRef = useRef(true);
+
+  const fetchOnce = useCallback(async () => {
+    try {
+      const resp = await api.getInboxAnalytics(period);
+      if (!mountedRef.current) return;
+      setData(resp);
+      setError(null);
+      setLastUpdated(new Date());
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [period]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    setLoading(true);
+    void fetchOnce();
+    const interval = setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(interval);
+    };
+  }, [fetchOnce]);
+
+  return { data, loading, error, lastUpdated, refresh: fetchOnce };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -378,6 +378,8 @@ export const api = {
     const qs = q.toString();
     return apiFetch<HotLeadsResponse>(`/api/analytics/hot-leads${qs ? `?${qs}` : ""}`);
   },
+  getInboxAnalytics: (period: AnalyticsPeriod = "month") =>
+    apiFetch<InboxFlowResponse>(`/api/analytics/inbox?period=${period}`),
   getCostSummary: (from: string, to: string) =>
     apiFetch<CostSummaryResponse>(`/api/audit/cost-summary?from=${from}&to=${to}`),
 };
@@ -699,6 +701,36 @@ export interface HotLeadsParams {
   status?: LeadStatusFilter;
   channel?: ChannelFilter;
   limit?: number;
+}
+
+export interface ScoreBucket {
+  range: string;
+  count: number;
+}
+
+// InboxFlowResponse is the View 3 (inbox flow) read model. by_channel /
+// by_status are open maps keyed by the lead enum members present in the
+// period. There is no edited_then_approved field — pending_replies
+// stores no original body to diff against, so it's dropped in v1.
+export interface InboxFlowResponse {
+  period: { from: string; to: string };
+  leads: {
+    total: number;
+    by_channel: Record<string, number>;
+    by_status: Record<string, number>;
+  };
+  qualifications: {
+    score_histogram: ScoreBucket[];
+    avg_score: number;
+  };
+  pending_replies: {
+    approved: number;
+    rejected: number;
+    currently_pending: number;
+    approve_rate: number;
+    p50_time_to_decide_seconds: number;
+    p95_time_to_decide_seconds: number;
+  };
 }
 
 export interface CostBreakdownRow {


### PR DESCRIPTION
## View 3 — inbox flow metrics (закрывает #97, последний из 4 view'ов → закрывает parent #91)

Третий из четырёх view'ов аналитического дашборда. С ним закрыта вся четвёрка (#102 sequences, #103 cost, #98 hot-leads, #97 inbox), поэтому PR закрывает и parent-эпик #91.

### Backend
- **Новый эндпоинт** `GET /api/analytics/inbox?period={week|month|all}` в bounded context `internal/analytics` (read-side, DTO-only, без domain-entities).
- `GetInboxFlow` = три tenant-scoped запроса (clarity over throughput, зеркало `GetCostRatios`):
  1. **leads breakdown** — `GROUP BY channel, status`, свёртка в `total / by_channel / by_status` в Go.
  2. **qualification histogram** — per-band `COUNT(*) FILTER`, собранные динамически из `scoreBuckets` (single source of truth для SQL-границ и DTO-лейблов) + `AVG(score)`.
  3. **pending_replies stats** — approved (`approved`+`sent`) / rejected / pending + `percentile_cont` p50/p95 time-to-decide над решёнными строками.
- `approve_rate` деривится на wire-границе (`Approved/(Approved+Rejected)`, pending исключён) — DTO остаётся count-pure.

### Frontend
- `useInboxAnalytics` (poll 30s, keep-last on error) + типы/метод в `api.ts`.
- 4 компонента: `LeadsByChannelCard`, `LeadsByStatusTable` (drill → `/inbox`), `QualificationHistogram`, `PendingRepliesSummary`.
- Страница `/analytics/inbox` + вкладка «Входящие».

### Осознанные отклонения от текста issue
- **Histogram 0-100, не 0-10.** Реальная схема `qualifications.score` — INT с доменным инвариантом `ClampScore [0,100]`; иллюстрация 0-10 в issue устарела. Бэнды: 0-20 / 21-40 / 41-60 / 61-80 / 81-100.
- **`edited_then_approved` отброшен.** `pending_replies` не хранит original body для diff — issue прямо допускает отбросить в v1.
- **Click по статусу → `/inbox` без предвыбора фильтра.** Inbox использует локальный стейт фильтра, не URL-параметр; предвыбор — follow-up.

### Tests
- Backend: handler (DB-free stub, 8 кейсов) + repository (integration на реальной 036-схеме: breakdown/histogram/percentile/tenant-scope/empty). TDD RED→GREEN пары.
- Frontend: 6 component-тестов + 4 hook-теста. `next build` зелёный (роут `/analytics/inbox` в листе).
- Code-review (TDD/DDD/CA/SQL/FE): backend ≥9 по всем осям, после добавления hook-теста все 5 осей ≥8.
