### PR TITLE
feat(onec): UI настроек интеграции + хранение секретов (#110)

### DIFF
--- a/backend/cmd/server/helpers.go
+++ b/backend/cmd/server/helpers.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net"
@@ -13,6 +15,8 @@ import (
 	"github.com/daniil/floq/internal/ai"
 	"github.com/daniil/floq/internal/ai/providers"
 	"github.com/daniil/floq/internal/config"
+	"github.com/daniil/floq/internal/integrations/onec"
+	"github.com/daniil/floq/internal/integrations/onec/domain"
 	"github.com/daniil/floq/internal/leads"
 	"github.com/daniil/floq/internal/proxy"
 	"github.com/daniil/floq/internal/settings"
@@ -20,6 +24,25 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	openaiopt "github.com/openai/openai-go/option"
 )
+
+// onecSecretGenerator produces 1C webhook secrets from crypto/rand. This is the
+// infra side of the onec.SecretGenerator port — the usecase stays oblivious to
+// how the entropy is sourced.
+type onecSecretGenerator struct{}
+
+// WebhookSecret returns the hex encoding of WebhookSecretBytes random bytes.
+func (onecSecretGenerator) WebhookSecret() (string, error) {
+	b := make([]byte, domain.WebhookSecretBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("onec: read random: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// buildOnecSecretGenerator returns the crypto/rand webhook-secret generator.
+func buildOnecSecretGenerator() onec.SecretGenerator {
+	return onecSecretGenerator{}
+}
 
 func buildUsageCounter(repo *leads.Repository) settings.UsageCounter {
 	return func(ctx context.Context, userID uuid.UUID) (int, int, error) {

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -309,6 +309,8 @@ func main() {
 		chat.RegisterRoutes(r, chat.NewHandler(chat.NewRepository(pool), newChatAIAdapter(aiClient)))
 		inbox.RegisterPendingReplyRoutes(r, pendingReplyUC, leadsUC, pendingReplyDecideMW)
 		audit.RegisterRoutes(r, audit.NewHandler(audit.NewUseCase(auditRepo)))
+		onec.RegisterConfigRoutes(r, onec.NewConfigHandler(
+			onec.NewConfigUseCase(onecRepo, onecRepo, onecClient, buildOnecSecretGenerator())))
 		analyticsRepo := analytics.NewRepository(pool)
 		analytics.RegisterRoutes(r, analytics.NewUseCase(analyticsRepo, analyticsRepo,
 			analytics.WithHotLeadsReader(analyticsRepo),

--- a/backend/internal/integrations/onec/client.go
+++ b/backend/internal/integrations/onec/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,51 @@ import (
 
 	"github.com/daniil/floq/internal/integrations/onec/domain"
 )
+
+// Connection-probe sentinels for the settings "test connection" action (#110).
+// Technical/infrastructure errors — the handler maps them to user-facing
+// Russian strings; they are not domain errors.
+var (
+	// ErrOnecAuth means 1C rejected the credentials (401/403).
+	ErrOnecAuth = errors.New("onec: 1C rejected credentials")
+	// ErrOnecUnreachable means the endpoint could not be reached (DNS, dial,
+	// TLS, timeout — a transport-level failure before any HTTP status).
+	ErrOnecUnreachable = errors.New("onec: 1C endpoint unreachable")
+	// ErrOnecBadResponse means 1C answered but with an unexpected non-2xx,
+	// non-auth status.
+	ErrOnecBadResponse = errors.New("onec: 1C returned an unexpected response")
+)
+
+// TestConnection probes the tenant's 1C endpoint with a single authenticated
+// GET to the OData root — enough to confirm reachability and that the
+// credentials are accepted, without mutating anything. No retries: a
+// connectivity check is a one-shot, bounded by the caller's context timeout.
+// The OData root (not /$metadata) is used because a published 1C service always
+// answers at its root, whereas $metadata pathing varies by install (#108).
+func (c *HTTPClient) TestConnection(ctx context.Context, creds *domain.OutboundCredentials) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, creds.BaseURL, nil)
+	if err != nil {
+		return fmt.Errorf("onec: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	setAuth(req, creds)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrOnecUnreachable, err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxCreateRespBytes))
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return nil
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return fmt.Errorf("%w (%d)", ErrOnecAuth, resp.StatusCode)
+	default:
+		return fmt.Errorf("%w (%d)", ErrOnecBadResponse, resp.StatusCode)
+	}
+}
 
 // counterpartyCatalogPath is the OData resource for counterparties. The
 // connector is universal (the concrete 1C config is out of scope, #108), so we

--- a/backend/internal/integrations/onec/client_testconn_test.go
+++ b/backend/internal/integrations/onec/client_testconn_test.go
@@ -1,0 +1,69 @@
+package onec
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPClient_TestConnection(t *testing.T) {
+	t.Run("2xx returns nil and sends auth", func(t *testing.T) {
+		var gotMethod, gotAuth string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		creds := testCreds(t, srv.URL, domain.AuthTypeToken, "tok123")
+		err := fastClient().TestConnection(context.Background(), creds)
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodGet, gotMethod)
+		assert.Equal(t, "Bearer tok123", gotAuth)
+	})
+
+	t.Run("401 maps to ErrOnecAuth", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+		err := fastClient().TestConnection(context.Background(), testCreds(t, srv.URL, domain.AuthTypeBasic, "x"))
+		assert.True(t, errors.Is(err, ErrOnecAuth), "got %v", err)
+	})
+
+	t.Run("403 maps to ErrOnecAuth", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer srv.Close()
+		err := fastClient().TestConnection(context.Background(), testCreds(t, srv.URL, domain.AuthTypeBasic, "x"))
+		assert.True(t, errors.Is(err, ErrOnecAuth), "got %v", err)
+	})
+
+	t.Run("500 maps to ErrOnecBadResponse", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+		err := fastClient().TestConnection(context.Background(), testCreds(t, srv.URL, domain.AuthTypeBasic, "x"))
+		assert.True(t, errors.Is(err, ErrOnecBadResponse), "got %v", err)
+	})
+
+	t.Run("dial failure maps to ErrOnecUnreachable", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+		url := srv.URL
+		srv.Close() // server gone → connection refused
+		err := fastClient().TestConnection(context.Background(), testCreds(t, url, domain.AuthTypeBasic, "x"))
+		assert.True(t, errors.Is(err, ErrOnecUnreachable), "got %v", err)
+	})
+}
+
+// Compile-time check: HTTPClient satisfies the ConnectionTester port.
+var _ ConnectionTester = (*HTTPClient)(nil)

--- a/backend/internal/integrations/onec/config_handler.go
+++ b/backend/internal/integrations/onec/config_handler.go
@@ -1,0 +1,264 @@
+package onec
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/daniil/floq/internal/httputil"
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/go-chi/chi/v5"
+)
+
+// ConfigHandler exposes the settings-UI surface for the 1C integration (#110).
+// Thin: it parses, calls the usecase, and maps results/errors to HTTP — no
+// business logic, no persistence, no secret handling beyond what the usecase
+// already masked.
+type ConfigHandler struct {
+	uc *ConfigUseCase
+}
+
+// NewConfigHandler builds the config handler over its usecase.
+func NewConfigHandler(uc *ConfigUseCase) *ConfigHandler {
+	return &ConfigHandler{uc: uc}
+}
+
+// RegisterConfigRoutes mounts the 1C config endpoints. All require auth — the
+// caller installs this inside the JWT-protected group (the public webhook
+// RegisterRoutes is separate).
+func RegisterConfigRoutes(r chi.Router, h *ConfigHandler) {
+	r.Get("/api/onec/config", h.getConfig)
+	r.Put("/api/onec/config", h.updateConfig)
+	r.Post("/api/onec/config/regenerate-webhook", h.regenerateWebhook)
+	r.Post("/api/onec/test", h.testConnection)
+	r.Get("/api/onec/mapping", h.getMapping)
+	r.Put("/api/onec/mapping", h.updateMapping)
+}
+
+// --- wire DTOs ---
+
+type configWire struct {
+	BaseURL       string `json:"base_url"`
+	AuthType      string `json:"auth_type"`
+	AuthSecret    string `json:"auth_secret"`
+	WebhookSecret string `json:"webhook_secret"`
+	IsActive      bool   `json:"is_active"`
+}
+
+type configUpdateWire struct {
+	BaseURL    *string `json:"base_url"`
+	AuthType   *string `json:"auth_type"`
+	AuthSecret *string `json:"auth_secret"`
+	IsActive   *bool   `json:"is_active"`
+}
+
+type configTestWire struct {
+	BaseURL    *string `json:"base_url"`
+	AuthType   *string `json:"auth_type"`
+	AuthSecret *string `json:"auth_secret"`
+}
+
+type testResultWire struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+}
+
+type mappingRuleWire struct {
+	ExternalType string `json:"external_type"`
+	Kind         string `json:"kind"`
+	EmailField   string `json:"email_field"`
+	NameField    string `json:"name_field,omitempty"`
+	CompanyField string `json:"company_field,omitempty"`
+}
+
+type mappingWire struct {
+	Rules []mappingRuleWire `json:"rules"`
+}
+
+func toConfigWire(v *ConfigView) configWire {
+	return configWire{
+		BaseURL:       v.BaseURL,
+		AuthType:      v.AuthType,
+		AuthSecret:    v.AuthSecret,
+		WebhookSecret: v.WebhookSecret,
+		IsActive:      v.IsActive,
+	}
+}
+
+// --- handlers ---
+
+func (h *ConfigHandler) getConfig(w http.ResponseWriter, r *http.Request) {
+	userID, ok := httputil.UserIDFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	v, err := h.uc.GetConfig(r.Context(), userID)
+	if err != nil {
+		status, msg := configErrorToHTTP(err)
+		httputil.WriteError(w, status, msg)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, toConfigWire(v))
+}
+
+func (h *ConfigHandler) updateConfig(w http.ResponseWriter, r *http.Request) {
+	userID, ok := httputil.UserIDFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var in configUpdateWire
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	v, err := h.uc.UpdateConfig(r.Context(), userID, ConfigUpdate{
+		BaseURL:    in.BaseURL,
+		AuthType:   in.AuthType,
+		AuthSecret: in.AuthSecret,
+		IsActive:   in.IsActive,
+	})
+	if err != nil {
+		status, msg := configErrorToHTTP(err)
+		httputil.WriteError(w, status, msg)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, toConfigWire(v))
+}
+
+func (h *ConfigHandler) regenerateWebhook(w http.ResponseWriter, r *http.Request) {
+	userID, ok := httputil.UserIDFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	secret, err := h.uc.RegenerateWebhook(r.Context(), userID)
+	if err != nil {
+		status, msg := configErrorToHTTP(err)
+		httputil.WriteError(w, status, msg)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, map[string]string{"webhook_secret": secret})
+}
+
+func (h *ConfigHandler) testConnection(w http.ResponseWriter, r *http.Request) {
+	userID, ok := httputil.UserIDFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var in configTestWire
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	err := h.uc.TestConnection(r.Context(), userID, ConfigTestOverride{
+		BaseURL:    in.BaseURL,
+		AuthType:   in.AuthType,
+		AuthSecret: in.AuthSecret,
+	})
+	if err != nil {
+		// A failed connection test is a 200 with success:false (mirrors the
+		// settings testers) — it's a probe result, not an HTTP-level error.
+		httputil.WriteJSON(w, http.StatusOK, testResultWire{Success: false, Error: onecTestErrorToUserMessage(err)})
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, testResultWire{Success: true})
+}
+
+func (h *ConfigHandler) getMapping(w http.ResponseWriter, r *http.Request) {
+	userID, ok := httputil.UserIDFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	rules, err := h.uc.GetMapping(r.Context(), userID)
+	if err != nil {
+		status, msg := configErrorToHTTP(err)
+		httputil.WriteError(w, status, msg)
+		return
+	}
+	out := mappingWire{Rules: make([]mappingRuleWire, len(rules))}
+	for i, ru := range rules {
+		out.Rules[i] = mappingRuleWire{
+			ExternalType: ru.ExternalType,
+			Kind:         ru.Kind,
+			EmailField:   ru.EmailField,
+			NameField:    ru.NameField,
+			CompanyField: ru.CompanyField,
+		}
+	}
+	httputil.WriteJSON(w, http.StatusOK, out)
+}
+
+func (h *ConfigHandler) updateMapping(w http.ResponseWriter, r *http.Request) {
+	userID, ok := httputil.UserIDFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var in mappingWire
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	inputs := make([]MappingRuleInput, len(in.Rules))
+	for i, ru := range in.Rules {
+		inputs[i] = MappingRuleInput{
+			ExternalType: ru.ExternalType,
+			Kind:         ru.Kind,
+			EmailField:   ru.EmailField,
+			NameField:    ru.NameField,
+			CompanyField: ru.CompanyField,
+		}
+	}
+	if err := h.uc.UpdateMapping(r.Context(), userID, inputs); err != nil {
+		status, msg := configErrorToHTTP(err)
+		httputil.WriteError(w, status, msg)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, map[string]bool{"saved": true})
+}
+
+// configErrorToHTTP maps a usecase/domain error to an HTTP status and message.
+// Validation/invariant errors are client errors (400); anything else is 500.
+func configErrorToHTTP(err error) (int, string) {
+	switch {
+	case errors.Is(err, domain.ErrActiveRequiresBaseURL):
+		return http.StatusBadRequest, "Нельзя включить интеграцию без адреса 1С."
+	case errors.Is(err, domain.ErrInvalidAuthType):
+		return http.StatusBadRequest, "Некорректный тип авторизации (basic или token)."
+	case errors.Is(err, domain.ErrInvalidWebhookSecretFormat):
+		return http.StatusBadRequest, "Некорректный формат webhook-секрета."
+	case errors.Is(err, domain.ErrNoRules):
+		return http.StatusBadRequest, "Добавьте хотя бы одно правило маппинга."
+	case errors.Is(err, domain.ErrEmptyExternalType):
+		return http.StatusBadRequest, "У каждого правила должен быть тип объекта 1С."
+	case errors.Is(err, domain.ErrInvalidEventKind):
+		return http.StatusBadRequest, "Недопустимый тип события в правиле маппинга."
+	case errors.Is(err, domain.ErrDuplicateExternalType):
+		return http.StatusBadRequest, "Типы объектов 1С в правилах не должны повторяться."
+	default:
+		return http.StatusInternalServerError, "Не удалось выполнить операцию."
+	}
+}
+
+// onecTestErrorToUserMessage maps a connection-test failure to a Russian
+// operator-facing string.
+func onecTestErrorToUserMessage(err error) string {
+	switch {
+	case errors.Is(err, ErrOnecAuth):
+		return "1С отклонила учётные данные — проверьте логин/пароль или токен."
+	case errors.Is(err, ErrOnecUnreachable):
+		return "Не удалось подключиться к 1С — проверьте адрес и доступность сервера."
+	case errors.Is(err, ErrOnecBadResponse):
+		return "1С ответила неожиданно — проверьте адрес OData-сервиса."
+	case errors.Is(err, domain.ErrEmptyBaseURL):
+		return "Укажите адрес 1С."
+	case errors.Is(err, domain.ErrInvalidAuthType):
+		return "Некорректный тип авторизации (basic или token)."
+	default:
+		return "Не удалось проверить соединение с 1С."
+	}
+}

--- a/backend/internal/integrations/onec/config_handler_test.go
+++ b/backend/internal/integrations/onec/config_handler_test.go
@@ -1,0 +1,214 @@
+package onec_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/daniil/floq/internal/httputil"
+	"github.com/daniil/floq/internal/integrations/onec"
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newConfigRouter(store onec.ConfigStore, mapping onec.MappingConfigStore, tester onec.ConnectionTester, gen onec.SecretGenerator) chi.Router {
+	uc := onec.NewConfigUseCase(store, mapping, tester, gen)
+	r := chi.NewRouter()
+	onec.RegisterConfigRoutes(r, onec.NewConfigHandler(uc))
+	return r
+}
+
+func authedReq(method, target string, userID uuid.UUID, body string) *http.Request {
+	var b io.Reader
+	if body != "" {
+		b = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, target, b)
+	return req.WithContext(httputil.WithUserID(req.Context(), userID))
+}
+
+func TestConfigHandler_Unauthorized(t *testing.T) {
+	r := newConfigRouter(&fakeConfigStore{}, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{secret: validWebhook})
+	endpoints := []struct{ method, path string }{
+		{http.MethodGet, "/api/onec/config"},
+		{http.MethodPut, "/api/onec/config"},
+		{http.MethodPost, "/api/onec/config/regenerate-webhook"},
+		{http.MethodPost, "/api/onec/test"},
+		{http.MethodGet, "/api/onec/mapping"},
+		{http.MethodPut, "/api/onec/mapping"},
+	}
+	for _, e := range endpoints {
+		t.Run(e.method+" "+e.path, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			// No user context → unauthenticated.
+			r.ServeHTTP(w, httptest.NewRequest(e.method, e.path, strings.NewReader("{}")))
+			assert.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+	}
+}
+
+func TestConfigHandler_GetConfig_MasksSecret(t *testing.T) {
+	store := &fakeConfigStore{found: true, cfg: storedCfg(t, "https://1c.example.com", domain.AuthTypeToken, "abcdef123456", validWebhook, true)}
+	r := newConfigRouter(store, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, authedReq(http.MethodGet, "/api/onec/config", uuid.New(), ""))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got struct {
+		BaseURL       string `json:"base_url"`
+		AuthType      string `json:"auth_type"`
+		AuthSecret    string `json:"auth_secret"`
+		WebhookSecret string `json:"webhook_secret"`
+		IsActive      bool   `json:"is_active"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	assert.Equal(t, "https://1c.example.com", got.BaseURL)
+	assert.Equal(t, "token", got.AuthType)
+	assert.Equal(t, "...3456", got.AuthSecret)
+	assert.NotContains(t, got.AuthSecret, "abcdef")
+	assert.True(t, got.IsActive)
+}
+
+func TestConfigHandler_PutConfig_InvalidJSON(t *testing.T) {
+	r := newConfigRouter(&fakeConfigStore{}, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, authedReq(http.MethodPut, "/api/onec/config", uuid.New(), "{not json"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestConfigHandler_PutConfig_ActiveWithoutBaseURL(t *testing.T) {
+	store := &fakeConfigStore{found: false}
+	r := newConfigRouter(store, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{secret: validWebhook})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, authedReq(http.MethodPut, "/api/onec/config", uuid.New(), `{"is_active":true}`))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, 0, store.upsertCalls)
+}
+
+func TestConfigHandler_PutConfig_Valid(t *testing.T) {
+	store := &fakeConfigStore{found: false}
+	r := newConfigRouter(store, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{secret: validWebhook})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, authedReq(http.MethodPut, "/api/onec/config", uuid.New(), `{"base_url":"https://1c.example.com","auth_type":"basic","auth_secret":"sek"}`))
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, store.upsertCalls)
+	assert.Equal(t, "sek", store.upserted.AuthSecret)
+}
+
+func TestConfigHandler_Test(t *testing.T) {
+	t.Run("success → 200 success:true", func(t *testing.T) {
+		store := &fakeConfigStore{found: true, cfg: storedCfg(t, "https://1c.example.com", domain.AuthTypeBasic, "s", "", true)}
+		r := newConfigRouter(store, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{})
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, authedReq(http.MethodPost, "/api/onec/test", uuid.New(), "{}"))
+		require.Equal(t, http.StatusOK, w.Code)
+		var got struct {
+			Success bool   `json:"success"`
+			Error   string `json:"error"`
+		}
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+		assert.True(t, got.Success)
+	})
+
+	t.Run("auth failure → 200 success:false with russian message", func(t *testing.T) {
+		store := &fakeConfigStore{found: true, cfg: storedCfg(t, "https://1c.example.com", domain.AuthTypeBasic, "s", "", true)}
+		tester := &fakeTester{err: onec.ErrOnecAuth}
+		r := newConfigRouter(store, &fakeMappingStore{}, tester, &fakeSecretGen{})
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, authedReq(http.MethodPost, "/api/onec/test", uuid.New(), "{}"))
+		require.Equal(t, http.StatusOK, w.Code)
+		var got struct {
+			Success bool   `json:"success"`
+			Error   string `json:"error"`
+		}
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+		assert.False(t, got.Success)
+		assert.NotEmpty(t, got.Error)
+	})
+
+	t.Run("empty base url → 200 success:false", func(t *testing.T) {
+		store := &fakeConfigStore{found: false}
+		tester := &fakeTester{}
+		r := newConfigRouter(store, &fakeMappingStore{}, tester, &fakeSecretGen{})
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, authedReq(http.MethodPost, "/api/onec/test", uuid.New(), "{}"))
+		require.Equal(t, http.StatusOK, w.Code)
+		var got struct {
+			Success bool `json:"success"`
+		}
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+		assert.False(t, got.Success)
+		assert.Equal(t, 0, tester.calls)
+	})
+}
+
+func TestConfigHandler_RegenerateWebhook(t *testing.T) {
+	store := &fakeConfigStore{found: true, cfg: storedCfg(t, "https://1c.example.com", domain.AuthTypeBasic, "s", "", false)}
+	r := newConfigRouter(store, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{secret: validWebhook})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, authedReq(http.MethodPost, "/api/onec/config/regenerate-webhook", uuid.New(), ""))
+	require.Equal(t, http.StatusOK, w.Code)
+	var got struct {
+		WebhookSecret string `json:"webhook_secret"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	assert.Equal(t, validWebhook, got.WebhookSecret, "full secret returned once")
+}
+
+func TestConfigHandler_PutMapping(t *testing.T) {
+	t.Run("valid → 200", func(t *testing.T) {
+		mapping := &fakeMappingStore{}
+		r := newConfigRouter(&fakeConfigStore{}, mapping, &fakeTester{}, &fakeSecretGen{})
+		body := `{"rules":[{"external_type":"Документ.ОплатаПокупателя","kind":"payment","email_field":"email"}]}`
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, authedReq(http.MethodPut, "/api/onec/mapping", uuid.New(), body))
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, 1, mapping.saveCalls)
+	})
+
+	t.Run("invalid kind → 400", func(t *testing.T) {
+		mapping := &fakeMappingStore{}
+		r := newConfigRouter(&fakeConfigStore{}, mapping, &fakeTester{}, &fakeSecretGen{})
+		body := `{"rules":[{"external_type":"X","kind":"bogus","email_field":"email"}]}`
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, authedReq(http.MethodPut, "/api/onec/mapping", uuid.New(), body))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, 0, mapping.saveCalls)
+	})
+
+	t.Run("empty rules → 400", func(t *testing.T) {
+		mapping := &fakeMappingStore{}
+		r := newConfigRouter(&fakeConfigStore{}, mapping, &fakeTester{}, &fakeSecretGen{})
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, authedReq(http.MethodPut, "/api/onec/mapping", uuid.New(), `{"rules":[]}`))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, 0, mapping.saveCalls)
+	})
+}
+
+func TestConfigHandler_GetMapping(t *testing.T) {
+	rule := domain.MappingRule{ExternalType: "Документ.ОплатаПокупателя", Kind: domain.EventKindPayment, EmailField: "email"}
+	cfg, err := domain.NewMappingConfig(uuid.New(), []domain.MappingRule{rule})
+	require.NoError(t, err)
+	mapping := &fakeMappingStore{cfg: cfg}
+	r := newConfigRouter(&fakeConfigStore{}, mapping, &fakeTester{}, &fakeSecretGen{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, authedReq(http.MethodGet, "/api/onec/mapping", uuid.New(), ""))
+	require.Equal(t, http.StatusOK, w.Code)
+	var got struct {
+		Rules []struct {
+			ExternalType string `json:"external_type"`
+			Kind         string `json:"kind"`
+		} `json:"rules"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	require.Len(t, got.Rules, 1)
+	assert.Equal(t, "payment", got.Rules[0].Kind)
+}

--- a/backend/internal/integrations/onec/config_repository.go
+++ b/backend/internal/integrations/onec/config_repository.go
@@ -1,0 +1,60 @@
+package onec
+
+import (
+	"context"
+	"errors"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Compile-time checks: Repository satisfies the config-management ports.
+var (
+	_ ConfigStore        = (*Repository)(nil)
+	_ MappingConfigStore = (*Repository)(nil)
+)
+
+// GetCredentialsConfig loads a user's editable 1C config — every field
+// regardless of is_active or base_url. This is deliberately broader than
+// GetOutboundCredentials (which only returns a usable, active connection): the
+// settings UI must show a half-filled or disabled config too. found=false
+// means the user has no row yet, so the usecase serves defaults.
+func (r *Repository) GetCredentialsConfig(ctx context.Context, userID uuid.UUID) (*domain.CredentialsConfig, bool, error) {
+	var baseURL, authType, authSecret, webhookSecret string
+	var isActive bool
+	err := r.pool.QueryRow(ctx, `
+		SELECT base_url, auth_type, auth_secret, webhook_secret, is_active
+		FROM onec_credentials WHERE user_id = $1`, userID).
+		Scan(&baseURL, &authType, &authSecret, &webhookSecret, &isActive)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	cfg, err := domain.NewCredentialsConfig(baseURL, domain.AuthType(authType), authSecret, webhookSecret, isActive)
+	if err != nil {
+		return nil, false, err
+	}
+	return cfg, true, nil
+}
+
+// UpsertCredentialsConfig persists the full config (one row per user). The
+// read-merge-write happens in the usecase, so this just writes the resulting
+// validated VO; ON CONFLICT keeps the single-row-per-user invariant.
+func (r *Repository) UpsertCredentialsConfig(ctx context.Context, userID uuid.UUID, cfg *domain.CredentialsConfig) error {
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO onec_credentials
+			(user_id, base_url, auth_type, auth_secret, webhook_secret, is_active, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, NOW())
+		ON CONFLICT (user_id) DO UPDATE SET
+			base_url       = EXCLUDED.base_url,
+			auth_type      = EXCLUDED.auth_type,
+			auth_secret    = EXCLUDED.auth_secret,
+			webhook_secret = EXCLUDED.webhook_secret,
+			is_active      = EXCLUDED.is_active,
+			updated_at     = NOW()`,
+		userID, cfg.BaseURL, string(cfg.AuthType), cfg.AuthSecret, cfg.WebhookSecret, cfg.IsActive)
+	return err
+}

--- a/backend/internal/integrations/onec/config_repository_integration_test.go
+++ b/backend/internal/integrations/onec/config_repository_integration_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+
+package onec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/daniil/floq/internal/integrations/onec"
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/daniil/floq/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustConfig(t *testing.T, baseURL string, at domain.AuthType, secret, webhook string, active bool) *domain.CredentialsConfig {
+	t.Helper()
+	c, err := domain.NewCredentialsConfig(baseURL, at, secret, webhook, active)
+	require.NoError(t, err)
+	return c
+}
+
+func TestRepository_CredentialsConfig_NotFoundThenInsertThenUpdate(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+
+	// No row yet → found=false, no error.
+	_, found, err := repo.GetCredentialsConfig(ctx, userID)
+	require.NoError(t, err)
+	assert.False(t, found, "fresh user has no config")
+
+	// Insert.
+	require.NoError(t, repo.UpsertCredentialsConfig(ctx, userID,
+		mustConfig(t, "https://1c.example.com", domain.AuthTypeToken, "sek", "", false)))
+
+	got, found, err := repo.GetCredentialsConfig(ctx, userID)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "https://1c.example.com", got.BaseURL)
+	assert.Equal(t, domain.AuthTypeToken, got.AuthType)
+	assert.Equal(t, "sek", got.AuthSecret)
+	assert.False(t, got.IsActive)
+
+	// Update a subset (flip active, change secret) — upsert merges in place.
+	require.NoError(t, repo.UpsertCredentialsConfig(ctx, userID,
+		mustConfig(t, "https://1c.example.com", domain.AuthTypeToken, "sek2", "", true)))
+
+	got2, _, err := repo.GetCredentialsConfig(ctx, userID)
+	require.NoError(t, err)
+	assert.True(t, got2.IsActive)
+	assert.Equal(t, "sek2", got2.AuthSecret)
+}
+
+func TestRepository_GetCredentialsConfig_ReturnsInactiveBlankBaseURL(t *testing.T) {
+	pool := testutil.TestDB(t)
+	userID := testutil.SeedUser(t, pool)
+	repo := onec.NewRepository(pool)
+	ctx := context.Background()
+
+	// An inactive, blank-base-url row is a real saved state (user filled the
+	// secret first). GetOutboundCredentials would skip it; the config reader
+	// must still return it so the UI can show what's there.
+	require.NoError(t, repo.UpsertCredentialsConfig(ctx, userID,
+		mustConfig(t, "", domain.AuthTypeBasic, "draftsecret", "", false)))
+
+	got, found, err := repo.GetCredentialsConfig(ctx, userID)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "", got.BaseURL)
+	assert.Equal(t, "draftsecret", got.AuthSecret)
+	assert.False(t, got.IsActive)
+}

--- a/backend/internal/integrations/onec/config_usecase.go
+++ b/backend/internal/integrations/onec/config_usecase.go
@@ -1,0 +1,265 @@
+package onec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/google/uuid"
+)
+
+// ConfigUseCase orchestrates the settings-UI management of a user's 1C
+// integration (#110): reading the masked config, sparse updates with
+// use-stored secret semantics, webhook-secret generation, connection testing
+// and mapping CRUD. It owns no persistence or HTTP detail — those are ports.
+type ConfigUseCase struct {
+	store   ConfigStore
+	mapping MappingConfigStore
+	tester  ConnectionTester
+	secrets SecretGenerator
+}
+
+// NewConfigUseCase wires the config usecase to its ports.
+func NewConfigUseCase(store ConfigStore, mapping MappingConfigStore, tester ConnectionTester, secrets SecretGenerator) *ConfigUseCase {
+	return &ConfigUseCase{store: store, mapping: mapping, tester: tester, secrets: secrets}
+}
+
+// ConfigView is the masked, read-side projection of a user's 1C config. Secrets
+// are never returned in the clear — only their masked tails — so the settings
+// API can be read without exposing credentials.
+type ConfigView struct {
+	BaseURL       string
+	AuthType      string
+	AuthSecret    string // masked
+	WebhookSecret string // masked
+	IsActive      bool
+}
+
+// ConfigUpdate is a sparse update: a nil pointer means "field absent, keep
+// stored". AuthSecret additionally honours use-stored semantics (empty or a
+// value equal to the masked form means keep the stored secret).
+type ConfigUpdate struct {
+	BaseURL    *string
+	AuthType   *string
+	AuthSecret *string
+	IsActive   *bool
+}
+
+// ConfigTestOverride lets the "test connection" action try unsaved values. A
+// nil field falls back to the stored config; a masked/empty AuthSecret falls
+// back to the stored secret.
+type ConfigTestOverride struct {
+	BaseURL    *string
+	AuthType   *string
+	AuthSecret *string
+}
+
+// MappingRuleView / MappingRuleInput are the DTO shapes the handler maps to/from
+// JSON, keeping the domain free of wire concerns.
+type MappingRuleView struct {
+	ExternalType string
+	Kind         string
+	EmailField   string
+	NameField    string
+	CompanyField string
+}
+
+type MappingRuleInput struct {
+	ExternalType string
+	Kind         string
+	EmailField   string
+	NameField    string
+	CompanyField string
+}
+
+// GetConfig returns the user's masked config, or defaults when no row exists.
+func (uc *ConfigUseCase) GetConfig(ctx context.Context, userID uuid.UUID) (*ConfigView, error) {
+	cfg, err := uc.loadOrDefault(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	return maskedView(cfg), nil
+}
+
+// UpdateConfig applies a sparse update over the stored config (read-merge-write
+// in this layer — no dynamic SQL), generating a webhook secret on first
+// activation, validating invariants via the domain factory before persisting,
+// and returning the re-masked result.
+func (uc *ConfigUseCase) UpdateConfig(ctx context.Context, userID uuid.UUID, in ConfigUpdate) (*ConfigView, error) {
+	stored, err := uc.loadOrDefault(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	baseURL := stored.BaseURL
+	if in.BaseURL != nil {
+		baseURL = *in.BaseURL
+	}
+	authType := string(stored.AuthType)
+	if in.AuthType != nil {
+		authType = *in.AuthType
+	}
+	authSecret := mergeSecret(in.AuthSecret, stored.AuthSecret)
+	webhookSecret := stored.WebhookSecret
+	isActive := stored.IsActive
+	if in.IsActive != nil {
+		isActive = *in.IsActive
+	}
+
+	// Activating with no webhook secret yet → generate one (256-bit random;
+	// collision is cryptographically negligible, so no retry loop).
+	if isActive && webhookSecret == "" {
+		webhookSecret, err = uc.secrets.WebhookSecret()
+		if err != nil {
+			return nil, fmt.Errorf("onec: generate webhook secret: %w", err)
+		}
+	}
+
+	merged, err := domain.NewCredentialsConfig(baseURL, domain.AuthType(authType), authSecret, webhookSecret, isActive)
+	if err != nil {
+		return nil, err
+	}
+	if err := uc.store.UpsertCredentialsConfig(ctx, userID, merged); err != nil {
+		return nil, fmt.Errorf("onec: save config: %w", err)
+	}
+	return maskedView(merged), nil
+}
+
+// RegenerateWebhook mints a fresh webhook secret, persists it, and returns the
+// full value ONCE so the operator can copy it into 1C. Subsequent GETs mask it.
+func (uc *ConfigUseCase) RegenerateWebhook(ctx context.Context, userID uuid.UUID) (string, error) {
+	stored, err := uc.loadOrDefault(ctx, userID)
+	if err != nil {
+		return "", err
+	}
+	secret, err := uc.secrets.WebhookSecret()
+	if err != nil {
+		return "", fmt.Errorf("onec: generate webhook secret: %w", err)
+	}
+	merged, err := domain.NewCredentialsConfig(stored.BaseURL, stored.AuthType, stored.AuthSecret, secret, stored.IsActive)
+	if err != nil {
+		return "", err
+	}
+	if err := uc.store.UpsertCredentialsConfig(ctx, userID, merged); err != nil {
+		return "", fmt.Errorf("onec: save config: %w", err)
+	}
+	return secret, nil
+}
+
+// TestConnection probes the 1C endpoint, using stored values for any field the
+// override leaves blank (and for a masked/empty secret). Returns
+// domain.ErrEmptyBaseURL when there is nothing to connect to.
+func (uc *ConfigUseCase) TestConnection(ctx context.Context, userID uuid.UUID, ov ConfigTestOverride) error {
+	stored, err := uc.loadOrDefault(ctx, userID)
+	if err != nil {
+		return err
+	}
+	baseURL := stored.BaseURL
+	if ov.BaseURL != nil {
+		baseURL = *ov.BaseURL
+	}
+	authType := stored.AuthType
+	if ov.AuthType != nil {
+		authType = domain.AuthType(*ov.AuthType)
+	}
+	authSecret := mergeSecret(ov.AuthSecret, stored.AuthSecret)
+
+	creds, err := domain.NewOutboundCredentials(baseURL, authType, authSecret)
+	if err != nil {
+		return err // ErrEmptyBaseURL / ErrInvalidAuthType
+	}
+	return uc.tester.TestConnection(ctx, creds)
+}
+
+// GetMapping returns the user's mapping rules (empty when none configured).
+func (uc *ConfigUseCase) GetMapping(ctx context.Context, userID uuid.UUID) ([]MappingRuleView, error) {
+	cfg, err := uc.mapping.GetMappingConfig(ctx, userID)
+	if errors.Is(err, ErrMappingNotFound) {
+		return []MappingRuleView{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	views := make([]MappingRuleView, len(cfg.Rules))
+	for i, r := range cfg.Rules {
+		views[i] = MappingRuleView{
+			ExternalType: r.ExternalType,
+			Kind:         r.Kind.String(),
+			EmailField:   r.EmailField,
+			NameField:    r.NameField,
+			CompanyField: r.CompanyField,
+		}
+	}
+	return views, nil
+}
+
+// UpdateMapping validates the rules through the domain factory and saves them as
+// the active config. Invalid input (empty rules, bad kind, dup external type)
+// returns the domain error unchanged for the handler to map to a 400.
+func (uc *ConfigUseCase) UpdateMapping(ctx context.Context, userID uuid.UUID, inputs []MappingRuleInput) error {
+	rules := make([]domain.MappingRule, 0, len(inputs))
+	for _, in := range inputs {
+		kind, err := domain.ParseEventKind(in.Kind)
+		if err != nil {
+			return err
+		}
+		rules = append(rules, domain.MappingRule{
+			ExternalType: in.ExternalType,
+			Kind:         kind,
+			EmailField:   in.EmailField,
+			NameField:    in.NameField,
+			CompanyField: in.CompanyField,
+		})
+	}
+	cfg, err := domain.NewMappingConfig(userID, rules)
+	if err != nil {
+		return err
+	}
+	return uc.mapping.SaveMappingConfig(ctx, cfg, true)
+}
+
+// loadOrDefault returns the stored config or an empty, valid default (the shape
+// a brand-new user sees) when no row exists.
+func (uc *ConfigUseCase) loadOrDefault(ctx context.Context, userID uuid.UUID) (*domain.CredentialsConfig, error) {
+	cfg, found, err := uc.store.GetCredentialsConfig(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("onec: load config: %w", err)
+	}
+	if !found {
+		return domain.NewCredentialsConfig("", "", "", "", false)
+	}
+	return cfg, nil
+}
+
+// mergeSecret implements use-stored semantics: a nil, empty, or masked-equal
+// input means "keep the stored secret"; anything else is a real new secret.
+func mergeSecret(in *string, stored string) string {
+	if in == nil || *in == "" || *in == maskSecret(stored) {
+		return stored
+	}
+	return *in
+}
+
+// maskedView projects a config to its masked wire view.
+func maskedView(c *domain.CredentialsConfig) *ConfigView {
+	return &ConfigView{
+		BaseURL:       c.BaseURL,
+		AuthType:      string(c.AuthType),
+		AuthSecret:    maskSecret(c.AuthSecret),
+		WebhookSecret: maskSecret(c.WebhookSecret),
+		IsActive:      c.IsActive,
+	}
+}
+
+// maskSecret reveals only the last 4 characters of a secret (mirrors the
+// settings package), so the read API never exposes a usable credential.
+func maskSecret(s string) string {
+	if s == "" {
+		return ""
+	}
+	if len(s) <= 4 {
+		return "..." + s
+	}
+	return "..." + s[len(s)-4:]
+}

--- a/backend/internal/integrations/onec/config_usecase.go
+++ b/backend/internal/integrations/onec/config_usecase.go
@@ -252,14 +252,16 @@ func maskedView(c *domain.CredentialsConfig) *ConfigView {
 	}
 }
 
-// maskSecret reveals only the last 4 characters of a secret (mirrors the
-// settings package), so the read API never exposes a usable credential.
+// maskSecret reveals only the last 4 characters of a secret so the read API
+// never exposes a usable credential. A secret too short to mask meaningfully
+// (≤4 chars) is replaced wholesale rather than leaked — stricter than the
+// settings package's copy, which returns the short value verbatim.
 func maskSecret(s string) string {
 	if s == "" {
 		return ""
 	}
 	if len(s) <= 4 {
-		return "..." + s
+		return "••••"
 	}
 	return "..." + s[len(s)-4:]
 }

--- a/backend/internal/integrations/onec/config_usecase_test.go
+++ b/backend/internal/integrations/onec/config_usecase_test.go
@@ -1,0 +1,284 @@
+package onec_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/daniil/floq/internal/integrations/onec"
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fakes ---
+
+type fakeConfigStore struct {
+	cfg         *domain.CredentialsConfig
+	found       bool
+	getErr      error
+	upserted    *domain.CredentialsConfig
+	upsertErr   error
+	upsertCalls int
+}
+
+func (f *fakeConfigStore) GetCredentialsConfig(_ context.Context, _ uuid.UUID) (*domain.CredentialsConfig, bool, error) {
+	return f.cfg, f.found, f.getErr
+}
+
+func (f *fakeConfigStore) UpsertCredentialsConfig(_ context.Context, _ uuid.UUID, cfg *domain.CredentialsConfig) error {
+	f.upsertCalls++
+	f.upserted = cfg
+	return f.upsertErr
+}
+
+type fakeMappingStore struct {
+	cfg         *domain.MappingConfig
+	getErr      error
+	saved       *domain.MappingConfig
+	savedActive bool
+	saveErr     error
+	saveCalls   int
+}
+
+func (f *fakeMappingStore) GetMappingConfig(_ context.Context, _ uuid.UUID) (*domain.MappingConfig, error) {
+	return f.cfg, f.getErr
+}
+
+func (f *fakeMappingStore) SaveMappingConfig(_ context.Context, cfg *domain.MappingConfig, isActive bool) error {
+	f.saveCalls++
+	f.saved = cfg
+	f.savedActive = isActive
+	return f.saveErr
+}
+
+type fakeTester struct {
+	gotCreds *domain.OutboundCredentials
+	err      error
+	calls    int
+}
+
+func (f *fakeTester) TestConnection(_ context.Context, creds *domain.OutboundCredentials) error {
+	f.calls++
+	f.gotCreds = creds
+	return f.err
+}
+
+type fakeSecretGen struct {
+	secret string
+	calls  int
+}
+
+func (f *fakeSecretGen) WebhookSecret() (string, error) {
+	f.calls++
+	return f.secret, nil
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func storedCfg(t *testing.T, baseURL string, at domain.AuthType, secret, webhook string, active bool) *domain.CredentialsConfig {
+	t.Helper()
+	c, err := domain.NewCredentialsConfig(baseURL, at, secret, webhook, active)
+	require.NoError(t, err)
+	return c
+}
+
+func newUC(store onec.ConfigStore, mapping onec.MappingConfigStore, tester onec.ConnectionTester, gen onec.SecretGenerator) *onec.ConfigUseCase {
+	return onec.NewConfigUseCase(store, mapping, tester, gen)
+}
+
+const validWebhook = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 64 hex
+
+// --- GetConfig ---
+
+func TestConfigUseCase_GetConfig_MasksSecrets(t *testing.T) {
+	store := &fakeConfigStore{found: true, cfg: storedCfg(t, "https://1c.example.com", domain.AuthTypeToken, "abcdef123456", validWebhook, true)}
+	uc := newUC(store, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{})
+
+	v, err := uc.GetConfig(context.Background(), uuid.New())
+	require.NoError(t, err)
+	assert.Equal(t, "https://1c.example.com", v.BaseURL)
+	assert.Equal(t, "token", v.AuthType)
+	assert.Equal(t, "...3456", v.AuthSecret, "secret masked to last 4")
+	assert.Equal(t, "...aaaa", v.WebhookSecret, "webhook masked")
+	assert.True(t, v.IsActive)
+	assert.NotContains(t, v.AuthSecret, "abcdef")
+}
+
+func TestConfigUseCase_GetConfig_DefaultsWhenNoRow(t *testing.T) {
+	store := &fakeConfigStore{found: false}
+	uc := newUC(store, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{})
+
+	v, err := uc.GetConfig(context.Background(), uuid.New())
+	require.NoError(t, err)
+	assert.Equal(t, "", v.BaseURL)
+	assert.Equal(t, "basic", v.AuthType)
+	assert.Equal(t, "", v.AuthSecret)
+	assert.Equal(t, "", v.WebhookSecret)
+	assert.False(t, v.IsActive)
+}
+
+// --- UpdateConfig: use-stored secret ---
+
+func TestConfigUseCase_UpdateConfig_UseStoredSecret(t *testing.T) {
+	cases := []struct {
+		name       string
+		authSecret *string
+		wantSecret string
+	}{
+		{"absent keeps stored", nil, "abcdef123456"},
+		{"empty keeps stored", ptr(""), "abcdef123456"},
+		{"masked value keeps stored", ptr("...3456"), "abcdef123456"},
+		{"new value replaces", ptr("brandnewsecret"), "brandnewsecret"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeConfigStore{found: true, cfg: storedCfg(t, "https://1c.example.com", domain.AuthTypeBasic, "abcdef123456", validWebhook, false)}
+			uc := newUC(store, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{})
+
+			_, err := uc.UpdateConfig(context.Background(), uuid.New(), onec.ConfigUpdate{AuthSecret: tc.authSecret})
+			require.NoError(t, err)
+			require.NotNil(t, store.upserted)
+			assert.Equal(t, tc.wantSecret, store.upserted.AuthSecret)
+		})
+	}
+}
+
+func TestConfigUseCase_UpdateConfig_AutoGenWebhookOnActivate(t *testing.T) {
+	store := &fakeConfigStore{found: true, cfg: storedCfg(t, "https://1c.example.com", domain.AuthTypeBasic, "s", "", false)}
+	gen := &fakeSecretGen{secret: validWebhook}
+	uc := newUC(store, &fakeMappingStore{}, &fakeTester{}, gen)
+
+	_, err := uc.UpdateConfig(context.Background(), uuid.New(), onec.ConfigUpdate{IsActive: ptr(true)})
+	require.NoError(t, err)
+	assert.Equal(t, 1, gen.calls, "webhook generated when activating with no secret")
+	assert.Equal(t, validWebhook, store.upserted.WebhookSecret)
+	assert.True(t, store.upserted.IsActive)
+}
+
+func TestConfigUseCase_UpdateConfig_ActiveRequiresBaseURL(t *testing.T) {
+	store := &fakeConfigStore{found: false}
+	uc := newUC(store, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{secret: validWebhook})
+
+	_, err := uc.UpdateConfig(context.Background(), uuid.New(), onec.ConfigUpdate{IsActive: ptr(true)})
+	assert.True(t, errors.Is(err, domain.ErrActiveRequiresBaseURL), "got %v", err)
+	assert.Equal(t, 0, store.upsertCalls, "invalid config must not be persisted")
+}
+
+func TestConfigUseCase_UpdateConfig_ToggleOffKeepsSecrets(t *testing.T) {
+	store := &fakeConfigStore{found: true, cfg: storedCfg(t, "https://1c.example.com", domain.AuthTypeToken, "mysecret", validWebhook, true)}
+	uc := newUC(store, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{})
+
+	_, err := uc.UpdateConfig(context.Background(), uuid.New(), onec.ConfigUpdate{IsActive: ptr(false)})
+	require.NoError(t, err)
+	assert.False(t, store.upserted.IsActive)
+	assert.Equal(t, "mysecret", store.upserted.AuthSecret, "auth secret retained")
+	assert.Equal(t, validWebhook, store.upserted.WebhookSecret, "webhook secret retained on disable")
+}
+
+func TestConfigUseCase_UpdateConfig_AuthTypeSwitchKeepsSecret(t *testing.T) {
+	store := &fakeConfigStore{found: true, cfg: storedCfg(t, "https://1c.example.com", domain.AuthTypeBasic, "mysecret", validWebhook, false)}
+	uc := newUC(store, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{})
+
+	_, err := uc.UpdateConfig(context.Background(), uuid.New(), onec.ConfigUpdate{AuthType: ptr("token")})
+	require.NoError(t, err)
+	assert.Equal(t, domain.AuthTypeToken, store.upserted.AuthType)
+	assert.Equal(t, "mysecret", store.upserted.AuthSecret)
+}
+
+// --- RegenerateWebhook ---
+
+func TestConfigUseCase_RegenerateWebhook_ReturnsFullAndPersists(t *testing.T) {
+	store := &fakeConfigStore{found: true, cfg: storedCfg(t, "https://1c.example.com", domain.AuthTypeBasic, "s", "", false)}
+	gen := &fakeSecretGen{secret: validWebhook}
+	uc := newUC(store, &fakeMappingStore{}, &fakeTester{}, gen)
+
+	full, err := uc.RegenerateWebhook(context.Background(), uuid.New())
+	require.NoError(t, err)
+	assert.Equal(t, validWebhook, full, "returns the full secret once")
+	assert.Equal(t, validWebhook, store.upserted.WebhookSecret, "persisted")
+}
+
+// --- TestConnection ---
+
+func TestConfigUseCase_TestConnection_UsesStoredWhenNoOverride(t *testing.T) {
+	store := &fakeConfigStore{found: true, cfg: storedCfg(t, "https://1c.example.com", domain.AuthTypeToken, "storedsecret", "", true)}
+	tester := &fakeTester{}
+	uc := newUC(store, &fakeMappingStore{}, tester, &fakeSecretGen{})
+
+	err := uc.TestConnection(context.Background(), uuid.New(), onec.ConfigTestOverride{})
+	require.NoError(t, err)
+	require.Equal(t, 1, tester.calls)
+	assert.Equal(t, "https://1c.example.com", tester.gotCreds.BaseURL)
+	assert.Equal(t, domain.AuthTypeToken, tester.gotCreds.AuthType)
+	assert.Equal(t, "storedsecret", tester.gotCreds.AuthSecret)
+}
+
+func TestConfigUseCase_TestConnection_EmptyBaseURLErrors(t *testing.T) {
+	store := &fakeConfigStore{found: false}
+	tester := &fakeTester{}
+	uc := newUC(store, &fakeMappingStore{}, tester, &fakeSecretGen{})
+
+	err := uc.TestConnection(context.Background(), uuid.New(), onec.ConfigTestOverride{})
+	assert.True(t, errors.Is(err, domain.ErrEmptyBaseURL), "got %v", err)
+	assert.Equal(t, 0, tester.calls, "no client call without a base url")
+}
+
+func TestConfigUseCase_TestConnection_OverrideUsesStoredSecretWhenMasked(t *testing.T) {
+	store := &fakeConfigStore{found: true, cfg: storedCfg(t, "https://old.example.com", domain.AuthTypeBasic, "storedsecret", "", false)}
+	tester := &fakeTester{}
+	uc := newUC(store, &fakeMappingStore{}, tester, &fakeSecretGen{})
+
+	err := uc.TestConnection(context.Background(), uuid.New(), onec.ConfigTestOverride{
+		BaseURL:    ptr("https://new.example.com"),
+		AuthSecret: ptr("...cret"), // masked → use stored
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://new.example.com", tester.gotCreds.BaseURL)
+	assert.Equal(t, "storedsecret", tester.gotCreds.AuthSecret)
+}
+
+// --- Mapping ---
+
+func TestConfigUseCase_GetMapping_EmptyWhenNotFound(t *testing.T) {
+	mapping := &fakeMappingStore{getErr: onec.ErrMappingNotFound}
+	uc := newUC(&fakeConfigStore{}, mapping, &fakeTester{}, &fakeSecretGen{})
+
+	rules, err := uc.GetMapping(context.Background(), uuid.New())
+	require.NoError(t, err)
+	assert.Empty(t, rules)
+}
+
+func TestConfigUseCase_UpdateMapping(t *testing.T) {
+	t.Run("valid rules saved active", func(t *testing.T) {
+		mapping := &fakeMappingStore{}
+		uc := newUC(&fakeConfigStore{}, mapping, &fakeTester{}, &fakeSecretGen{})
+		err := uc.UpdateMapping(context.Background(), uuid.New(), []onec.MappingRuleInput{
+			{ExternalType: "Документ.ОплатаПокупателя", Kind: "payment", EmailField: "email"},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, mapping.saveCalls)
+		assert.True(t, mapping.savedActive)
+		require.Len(t, mapping.saved.Rules, 1)
+		assert.Equal(t, domain.EventKindPayment, mapping.saved.Rules[0].Kind)
+	})
+
+	t.Run("invalid kind rejected, nothing saved", func(t *testing.T) {
+		mapping := &fakeMappingStore{}
+		uc := newUC(&fakeConfigStore{}, mapping, &fakeTester{}, &fakeSecretGen{})
+		err := uc.UpdateMapping(context.Background(), uuid.New(), []onec.MappingRuleInput{
+			{ExternalType: "X", Kind: "not_a_kind", EmailField: "email"},
+		})
+		assert.Error(t, err)
+		assert.Equal(t, 0, mapping.saveCalls)
+	})
+
+	t.Run("empty rules rejected", func(t *testing.T) {
+		mapping := &fakeMappingStore{}
+		uc := newUC(&fakeConfigStore{}, mapping, &fakeTester{}, &fakeSecretGen{})
+		err := uc.UpdateMapping(context.Background(), uuid.New(), nil)
+		assert.True(t, errors.Is(err, domain.ErrNoRules), "got %v", err)
+		assert.Equal(t, 0, mapping.saveCalls)
+	})
+}

--- a/backend/internal/integrations/onec/config_usecase_test.go
+++ b/backend/internal/integrations/onec/config_usecase_test.go
@@ -106,6 +106,18 @@ func TestConfigUseCase_GetConfig_MasksSecrets(t *testing.T) {
 	assert.NotContains(t, v.AuthSecret, "abcdef")
 }
 
+func TestConfigUseCase_GetConfig_MasksShortSecretFully(t *testing.T) {
+	// A short secret (≤4 chars) must not be revealed by the mask — return a
+	// fixed placeholder instead of leaking the whole value.
+	store := &fakeConfigStore{found: true, cfg: storedCfg(t, "https://1c.example.com", domain.AuthTypeBasic, "abc", "", false)}
+	uc := newUC(store, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{})
+
+	v, err := uc.GetConfig(context.Background(), uuid.New())
+	require.NoError(t, err)
+	assert.NotContains(t, v.AuthSecret, "abc", "short secret must not leak")
+	assert.NotEqual(t, "", v.AuthSecret, "but still indicates a secret is set")
+}
+
 func TestConfigUseCase_GetConfig_DefaultsWhenNoRow(t *testing.T) {
 	store := &fakeConfigStore{found: false}
 	uc := newUC(store, &fakeMappingStore{}, &fakeTester{}, &fakeSecretGen{})

--- a/backend/internal/integrations/onec/domain/credentials.go
+++ b/backend/internal/integrations/onec/domain/credentials.go
@@ -1,0 +1,80 @@
+package domain
+
+import (
+	"errors"
+	"strings"
+)
+
+// WebhookSecretBytes is the entropy of a webhook secret before hex-encoding.
+// 32 bytes (256 bits) is well past brute-force range for the sole credential
+// authenticating inbound 1C webhooks. The stored/wire form is the hex string,
+// so its length is twice this.
+const WebhookSecretBytes = 32
+
+// Config-layer domain errors (declared as vars so callers can errors.Is them).
+var (
+	// ErrActiveRequiresBaseURL rejects activating the integration with no 1C
+	// endpoint to talk to — an active-but-blank config is meaningless and would
+	// silently no-op every outbound push and reconcile pass.
+	ErrActiveRequiresBaseURL = errors.New("onec: cannot activate without a base url")
+	// ErrInvalidWebhookSecretFormat guards a stored/incoming webhook secret that
+	// is not the expected hex shape — defence against a hand-edited row.
+	ErrInvalidWebhookSecretFormat = errors.New("onec: invalid webhook secret format")
+)
+
+// CredentialsConfig is the editable per-user 1C connection as managed from the
+// settings UI (#110). Unlike OutboundCredentials — the read-model the outbound
+// flow consumes, which demands a usable endpoint — this VO represents a config
+// that may still be partial: a new user has everything blank and IsActive
+// false, which is valid. The single hard invariant is that you cannot activate
+// without a base URL. AuthType defaults to basic (matching the onec_credentials
+// DEFAULT and its CHECK, which forbids an empty string).
+type CredentialsConfig struct {
+	BaseURL       string
+	AuthType      AuthType
+	AuthSecret    string
+	WebhookSecret string
+	IsActive      bool
+}
+
+// NewCredentialsConfig validates and normalises an editable 1C config. BaseURL
+// is trimmed of spaces and a trailing slash (predictable path joins, mirroring
+// NewOutboundCredentials). An empty auth type defaults to basic; a non-empty
+// one must be valid. A non-empty webhook secret must be well-formed.
+func NewCredentialsConfig(baseURL string, authType AuthType, authSecret, webhookSecret string, isActive bool) (*CredentialsConfig, error) {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if authType == "" {
+		authType = AuthTypeBasic
+	}
+	if !authType.IsValid() {
+		return nil, ErrInvalidAuthType
+	}
+	if isActive && baseURL == "" {
+		return nil, ErrActiveRequiresBaseURL
+	}
+	if webhookSecret != "" && !IsValidWebhookSecretFormat(webhookSecret) {
+		return nil, ErrInvalidWebhookSecretFormat
+	}
+	return &CredentialsConfig{
+		BaseURL:       baseURL,
+		AuthType:      authType,
+		AuthSecret:    authSecret,
+		WebhookSecret: webhookSecret,
+		IsActive:      isActive,
+	}, nil
+}
+
+// IsValidWebhookSecretFormat reports whether s is the hex encoding of
+// WebhookSecretBytes random bytes: exactly 2×WebhookSecretBytes lowercase hex
+// characters (the shape hex.EncodeToString produces).
+func IsValidWebhookSecretFormat(s string) bool {
+	if len(s) != WebhookSecretBytes*2 {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/integrations/onec/domain/credentials_test.go
+++ b/backend/internal/integrations/onec/domain/credentials_test.go
@@ -1,0 +1,134 @@
+package domain_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/daniil/floq/internal/integrations/onec/domain"
+)
+
+func TestNewCredentialsConfig(t *testing.T) {
+	validSecret := strings.Repeat("a", domain.WebhookSecretBytes*2) // 64 lowercase-hex chars
+
+	tests := []struct {
+		name          string
+		baseURL       string
+		authType      domain.AuthType
+		authSecret    string
+		webhookSecret string
+		isActive      bool
+		wantErr       error
+		check         func(t *testing.T, c *domain.CredentialsConfig)
+	}{
+		{
+			name: "empty config is valid (defaults for a new user)",
+			check: func(t *testing.T, c *domain.CredentialsConfig) {
+				if c.BaseURL != "" || c.IsActive {
+					t.Fatalf("expected empty inactive config, got %+v", c)
+				}
+				if c.AuthType != domain.AuthTypeBasic {
+					t.Fatalf("empty auth type must default to basic, got %q", c.AuthType)
+				}
+			},
+		},
+		{
+			name:     "active requires a base url",
+			isActive: true,
+			authType: domain.AuthTypeBasic,
+			wantErr:  domain.ErrActiveRequiresBaseURL,
+		},
+		{
+			name:     "active with base url is ok",
+			baseURL:  "https://1c.example.com",
+			authType: domain.AuthTypeToken,
+			isActive: true,
+		},
+		{
+			name:     "invalid auth type rejected",
+			baseURL:  "https://1c.example.com",
+			authType: domain.AuthType("weird"),
+			wantErr:  domain.ErrInvalidAuthType,
+		},
+		{
+			name:     "empty auth type defaults to basic",
+			baseURL:  "https://1c.example.com",
+			authType: "",
+			check: func(t *testing.T, c *domain.CredentialsConfig) {
+				if c.AuthType != domain.AuthTypeBasic {
+					t.Fatalf("want basic, got %q", c.AuthType)
+				}
+			},
+		},
+		{
+			name:     "trailing slash and spaces trimmed from base url",
+			baseURL:  "  https://1c.example.com/  ",
+			authType: domain.AuthTypeBasic,
+			check: func(t *testing.T, c *domain.CredentialsConfig) {
+				if c.BaseURL != "https://1c.example.com" {
+					t.Fatalf("base url not normalised: %q", c.BaseURL)
+				}
+			},
+		},
+		{
+			name:          "malformed webhook secret rejected",
+			baseURL:       "https://1c.example.com",
+			authType:      domain.AuthTypeBasic,
+			webhookSecret: "too-short",
+			wantErr:       domain.ErrInvalidWebhookSecretFormat,
+		},
+		{
+			name:          "well-formed webhook secret accepted",
+			baseURL:       "https://1c.example.com",
+			authType:      domain.AuthTypeBasic,
+			webhookSecret: validSecret,
+			check: func(t *testing.T, c *domain.CredentialsConfig) {
+				if c.WebhookSecret != validSecret {
+					t.Fatalf("webhook secret not preserved")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := domain.NewCredentialsConfig(tc.baseURL, tc.authType, tc.authSecret, tc.webhookSecret, tc.isActive)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("want error %v, got %v", tc.wantErr, err)
+				}
+				if c != nil {
+					t.Fatalf("expected nil config on error, got %+v", c)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.check != nil {
+				tc.check(t, c)
+			}
+		})
+	}
+}
+
+func TestIsValidWebhookSecretFormat(t *testing.T) {
+	valid := strings.Repeat("0", domain.WebhookSecretBytes*2)
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{valid, true},
+		{strings.Repeat("a", domain.WebhookSecretBytes*2), true},
+		{"deadbeef" + strings.Repeat("0", 56), true},
+		{"", false},
+		{strings.Repeat("a", domain.WebhookSecretBytes*2-1), false}, // too short
+		{strings.Repeat("A", domain.WebhookSecretBytes*2), false},   // uppercase not hex.EncodeToString output
+		{strings.Repeat("g", domain.WebhookSecretBytes*2), false},   // non-hex char
+	}
+	for _, tc := range tests {
+		if got := domain.IsValidWebhookSecretFormat(tc.in); got != tc.want {
+			t.Errorf("IsValidWebhookSecretFormat(%q)=%v, want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/integrations/onec/ports.go
+++ b/backend/internal/integrations/onec/ports.go
@@ -75,6 +75,15 @@ type OneCClient interface {
 	CreateCounterparty(ctx context.Context, creds *domain.OutboundCredentials, draft *domain.CounterpartyDraft) (externalRef string, err error)
 }
 
+// ConnectionTester probes a tenant's 1C endpoint to verify reachability and
+// credentials for the settings "test connection" action (#110). Kept separate
+// from OneCClient (ISP): the config usecase depends only on the probe, and
+// adding it here doesn't disturb the outbound OneCClient fakes. The HTTP/OData
+// implementation (client.go) satisfies it.
+type ConnectionTester interface {
+	TestConnection(ctx context.Context, creds *domain.OutboundCredentials) error
+}
+
 // EventApplier performs the domain action for a resolved 1C event. Implemented
 // by a cross-context adapter (cmd/server/adapters.go) over leads/prospects —
 // onec never imports those contexts directly. Actions that target an existing

--- a/backend/internal/integrations/onec/ports.go
+++ b/backend/internal/integrations/onec/ports.go
@@ -75,6 +75,31 @@ type OneCClient interface {
 	CreateCounterparty(ctx context.Context, creds *domain.OutboundCredentials, draft *domain.CounterpartyDraft) (externalRef string, err error)
 }
 
+// ConfigStore persists a user's editable 1C credentials config (#110). The
+// postgres Repository satisfies it. GetCredentialsConfig returns found=false
+// when the user has no row yet (→ the usecase serves defaults); unlike
+// GetOutboundCredentials it returns the row regardless of is_active/base_url.
+type ConfigStore interface {
+	GetCredentialsConfig(ctx context.Context, userID uuid.UUID) (*domain.CredentialsConfig, bool, error)
+	UpsertCredentialsConfig(ctx context.Context, userID uuid.UUID, cfg *domain.CredentialsConfig) error
+}
+
+// MappingConfigStore reads/writes a user's full mapping config (active or not)
+// for the settings editor. Satisfied by the Repository via the existing
+// GetMappingConfig/SaveMappingConfig — distinct from inbound MappingStore,
+// which only loads the ACTIVE config.
+type MappingConfigStore interface {
+	GetMappingConfig(ctx context.Context, userID uuid.UUID) (*domain.MappingConfig, error)
+	SaveMappingConfig(ctx context.Context, cfg *domain.MappingConfig, isActive bool) error
+}
+
+// SecretGenerator produces a high-entropy webhook secret. The crypto/rand
+// implementation lives in cmd/server (infra), so generation stays out of the
+// usecase/domain and is fakeable in tests.
+type SecretGenerator interface {
+	WebhookSecret() (string, error)
+}
+
 // ConnectionTester probes a tenant's 1C endpoint to verify reachability and
 // credentials for the settings "test connection" action (#110). Kept separate
 // from OneCClient (ISP): the config usecase depends only on the probe, and

--- a/frontend/src/app/(dashboard)/settings/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.test.tsx
@@ -57,6 +57,12 @@ vi.mock("@/lib/api", () => ({
     testSMTP: vi.fn(),
     testResend: vi.fn(),
     tgAccountStatus: vi.fn(),
+    getOnecConfig: vi.fn(),
+    updateOnecConfig: vi.fn(),
+    regenerateOnecWebhook: vi.fn(),
+    testOnec: vi.fn(),
+    getOnecMapping: vi.fn(),
+    updateOnecMapping: vi.fn(),
   },
 }));
 
@@ -78,6 +84,10 @@ describe("SettingsPage", () => {
     vi.clearAllMocks();
     vi.mocked(api.getSettings).mockResolvedValue(mockSettings as UserSettings);
     vi.mocked(api.tgAccountStatus).mockResolvedValue({ connected: false, phone: "" });
+    vi.mocked(api.getOnecConfig).mockResolvedValue({
+      base_url: "", auth_type: "basic", auth_secret: "", webhook_secret: "", is_active: false,
+    });
+    vi.mocked(api.getOnecMapping).mockResolvedValue({ rules: [] });
   });
 
   it("renders settings page with header after loading", async () => {

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -106,7 +106,12 @@ export default function SettingsPage() {
               </div>
             </section>
             <AiProviderSection aiProvider={ai.provider} setAiProvider={ai.setProvider} aiModel={ai.model} setAiModel={ai.setModel} aiApiKey={ai.apiKey} setAiApiKey={ai.setApiKey} maskedKey={ai.maskedKey} showApiKey={ai.showKey} setShowApiKey={ai.setShowKey} active={ai.active} testing={ai.testing} testResult={ai.testResult} setTestResult={ai.setTestResult} hasKey={ai.hasKey} providerDefaults={PROVIDER_DEFAULTS} onTest={ai.test} />
-            {!onec.loading && (
+            {onec.loadError && (
+              <div role="alert" className="rounded-xl bg-red-50 px-6 py-4 text-sm font-medium text-red-600 ring-1 ring-red-200">
+                Не удалось загрузить настройки 1С: {onec.loadError}
+              </div>
+            )}
+            {!onec.loading && !onec.loadError && (
               <>
                 <OnecSection
                   baseURL={onec.baseURL} setBaseURL={onec.setBaseURL}

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -13,6 +13,9 @@ import { ResendSection } from "@/components/settings/ResendSection";
 import { SmtpSection } from "@/components/settings/SmtpSection";
 import { AiProviderSection } from "@/components/settings/AiProviderSection";
 import { InboxViewSection } from "@/components/settings/InboxViewSection";
+import { OnecSection } from "@/components/settings/OnecSection";
+import { OnecMappingEditor } from "@/components/settings/OnecMappingEditor";
+import { useOnecSettings } from "@/hooks/useOnecSettings";
 
 export default function SettingsPage() {
   const core = useSettingsCore();
@@ -22,6 +25,7 @@ export default function SettingsPage() {
   const resend = useResendSettings(core.settings, core.setSettings);
   const smtp = useSmtpSettings(core.settings, core.setSettings);
   const ai = useAiSettings(core.settings, core.setSettings);
+  const onec = useOnecSettings();
 
   const [notifyTg, setNotifyTg] = useState(true);
   const [notifyEmail, setNotifyEmail] = useState(false);
@@ -102,6 +106,24 @@ export default function SettingsPage() {
               </div>
             </section>
             <AiProviderSection aiProvider={ai.provider} setAiProvider={ai.setProvider} aiModel={ai.model} setAiModel={ai.setModel} aiApiKey={ai.apiKey} setAiApiKey={ai.setApiKey} maskedKey={ai.maskedKey} showApiKey={ai.showKey} setShowApiKey={ai.setShowKey} active={ai.active} testing={ai.testing} testResult={ai.testResult} setTestResult={ai.setTestResult} hasKey={ai.hasKey} providerDefaults={PROVIDER_DEFAULTS} onTest={ai.test} />
+            {!onec.loading && (
+              <>
+                <OnecSection
+                  baseURL={onec.baseURL} setBaseURL={onec.setBaseURL}
+                  authType={onec.authType} setAuthType={onec.setAuthType}
+                  authSecret={onec.authSecret} setAuthSecret={onec.setAuthSecret} maskedSecret={onec.maskedSecret}
+                  isActive={onec.isActive} setIsActive={onec.setIsActive}
+                  maskedWebhook={onec.maskedWebhook} fullWebhook={onec.fullWebhook}
+                  regenerating={onec.regenerating} onRegenerate={onec.regenerateWebhook}
+                  saving={onec.saving} saveResult={onec.saveResult} onSave={onec.save}
+                  testing={onec.testing} testResult={onec.testResult} setTestResult={onec.setTestResult} onTest={onec.test}
+                />
+                <OnecMappingEditor
+                  rules={onec.rules} addRule={onec.addRule} updateRule={onec.updateRule} removeRule={onec.removeRule}
+                  saving={onec.savingMapping} result={onec.mappingResult} setResult={onec.setMappingResult} onSave={onec.saveMapping}
+                />
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/components/settings/OnecMappingEditor.test.tsx
+++ b/frontend/src/components/settings/OnecMappingEditor.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { OnecMappingRule } from "@/lib/api";
+import { OnecMappingEditor } from "./OnecMappingEditor";
+
+function rule(over: Partial<OnecMappingRule> = {}): OnecMappingRule {
+  return {
+    external_type: over.external_type ?? "Документ.Оплата",
+    kind: over.kind ?? "payment",
+    email_field: over.email_field ?? "email",
+    name_field: over.name_field,
+    company_field: over.company_field,
+  };
+}
+
+function baseProps() {
+  return {
+    rules: [rule()],
+    addRule: vi.fn(),
+    updateRule: vi.fn(),
+    removeRule: vi.fn(),
+    saving: false,
+    result: null,
+    setResult: () => {},
+    onSave: vi.fn(),
+  };
+}
+
+describe("OnecMappingEditor", () => {
+  it("renders a row per rule with the kind selected", () => {
+    render(<OnecMappingEditor {...baseProps()} />);
+    const rows = screen.getAllByRole("row").filter((r) => within(r).queryAllByRole("textbox").length > 0);
+    expect(rows).toHaveLength(1);
+    const kind = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(kind.value).toBe("payment");
+  });
+
+  it("calls addRule when adding", async () => {
+    const props = baseProps();
+    render(<OnecMappingEditor {...props} />);
+    await userEvent.click(screen.getByRole("button", { name: /Добавить/i }));
+    expect(props.addRule).toHaveBeenCalled();
+  });
+
+  it("calls removeRule with the row index", async () => {
+    const props = { ...baseProps(), rules: [rule(), rule({ external_type: "Документ.Заказ", kind: "order_status" })] };
+    render(<OnecMappingEditor {...props} />);
+    const removeButtons = screen.getAllByRole("button", { name: /Удалить/i });
+    await userEvent.click(removeButtons[1]);
+    expect(props.removeRule).toHaveBeenCalledWith(1);
+  });
+
+  it("calls updateRule when the kind changes", async () => {
+    const props = baseProps();
+    render(<OnecMappingEditor {...props} />);
+    await userEvent.selectOptions(screen.getByRole("combobox"), "order_status");
+    expect(props.updateRule).toHaveBeenCalledWith(0, { kind: "order_status" });
+  });
+
+  it("calls onSave", async () => {
+    const props = baseProps();
+    render(<OnecMappingEditor {...props} />);
+    await userEvent.click(screen.getByRole("button", { name: /Сохранить маппинг/i }));
+    expect(props.onSave).toHaveBeenCalled();
+  });
+
+  it("shows an empty state when there are no rules", () => {
+    render(<OnecMappingEditor {...baseProps()} rules={[]} />);
+    expect(screen.getByText(/Нет правил/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/settings/OnecMappingEditor.tsx
+++ b/frontend/src/components/settings/OnecMappingEditor.tsx
@@ -1,0 +1,110 @@
+import { Plus, Trash2, Loader2, Save } from "lucide-react";
+import type { OnecEventKind, OnecMappingRule } from "@/lib/api";
+import { StatusBanner } from "./StatusBanner";
+
+type Result = { success: boolean; message?: string; error?: string } | null;
+
+interface OnecMappingEditorProps {
+  rules: OnecMappingRule[];
+  addRule: () => void;
+  updateRule: (index: number, patch: Partial<OnecMappingRule>) => void;
+  removeRule: (index: number) => void;
+  saving: boolean;
+  result: Result;
+  setResult: (v: Result) => void;
+  onSave: () => void;
+}
+
+// KIND_OPTIONS is the closed set of Floq event kinds a 1C document type can map
+// onto — mirrors the backend EventKind enum.
+const KIND_OPTIONS: { value: OnecEventKind; label: string }[] = [
+  { value: "payment", label: "Оплата" },
+  { value: "counterparty_created", label: "Новый контрагент" },
+  { value: "order_status", label: "Статус заказа" },
+  { value: "shipment", label: "Отгрузка" },
+];
+
+const cell = "rounded-md border-none bg-[#eff4ff] px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-[#004ac6]/20";
+
+export function OnecMappingEditor({ rules, addRule, updateRule, removeRule, saving, result, setResult, onSave }: OnecMappingEditorProps) {
+  return (
+    <section className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-[#c3c6d7]/10">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h3 className="text-xl font-bold text-[#0d1c2e]">Маппинг событий 1С</h3>
+          <p className="mt-1 text-sm text-[#434655]">
+            Сопоставьте типы объектов вашей конфигурации 1С с каноническими событиями Floq.
+          </p>
+        </div>
+        <button onClick={addRule}
+          className="flex items-center gap-1.5 rounded-lg bg-[#eff4ff] px-3 py-2 text-sm font-bold text-[#0d1c2e] transition-colors hover:bg-[#dce9ff]">
+          <Plus className="size-4" /> Добавить правило
+        </button>
+      </div>
+
+      {rules.length === 0 ? (
+        <p className="rounded-lg bg-[#eff4ff] px-4 py-6 text-center text-sm text-[#434655]">
+          Нет правил маппинга. Добавьте первое правило, чтобы события 1С начали попадать в Floq.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs font-bold uppercase tracking-wide text-[#434655]">
+                <th className="px-2 py-1">Тип объекта 1С</th>
+                <th className="px-2 py-1">Событие Floq</th>
+                <th className="px-2 py-1">Поле email</th>
+                <th className="px-2 py-1">Поле имени</th>
+                <th className="px-2 py-1">Поле компании</th>
+                <th className="px-2 py-1" />
+              </tr>
+            </thead>
+            <tbody>
+              {rules.map((r, i) => (
+                <tr key={i}>
+                  <td className="px-2 py-1">
+                    <input type="text" aria-label={`Тип объекта 1С, правило ${i + 1}`} placeholder="Документ.ОплатаПокупателя"
+                      value={r.external_type} onChange={(e) => updateRule(i, { external_type: e.target.value })} className={cell} />
+                  </td>
+                  <td className="px-2 py-1">
+                    <select aria-label={`Событие Floq, правило ${i + 1}`} value={r.kind}
+                      onChange={(e) => updateRule(i, { kind: e.target.value as OnecEventKind })} className={cell}>
+                      {KIND_OPTIONS.map((k) => (
+                        <option key={k.value} value={k.value}>{k.label}</option>
+                      ))}
+                    </select>
+                  </td>
+                  <td className="px-2 py-1">
+                    <input type="text" aria-label={`Поле email, правило ${i + 1}`} placeholder="email"
+                      value={r.email_field} onChange={(e) => updateRule(i, { email_field: e.target.value })} className={cell} />
+                  </td>
+                  <td className="px-2 py-1">
+                    <input type="text" aria-label={`Поле имени, правило ${i + 1}`} placeholder="name"
+                      value={r.name_field ?? ""} onChange={(e) => updateRule(i, { name_field: e.target.value })} className={cell} />
+                  </td>
+                  <td className="px-2 py-1">
+                    <input type="text" aria-label={`Поле компании, правило ${i + 1}`} placeholder="company"
+                      value={r.company_field ?? ""} onChange={(e) => updateRule(i, { company_field: e.target.value })} className={cell} />
+                  </td>
+                  <td className="px-2 py-1">
+                    <button onClick={() => removeRule(i)} aria-label={`Удалить правило ${i + 1}`}
+                      className="rounded-md p-2 text-[#ba1a1a] transition-colors hover:bg-[#ba1a1a]/10">
+                      <Trash2 className="size-4" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <button onClick={onSave} disabled={saving}
+        className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg bg-[#004ac6] py-3 text-sm font-bold text-white transition-colors hover:bg-[#0039a6] disabled:opacity-50">
+        {saving ? <Loader2 className="size-[18px] animate-spin" /> : <Save className="size-[18px]" />}
+        {saving ? "Сохраняем..." : "Сохранить маппинг"}
+      </button>
+      <StatusBanner result={result ? { ...result, message: result.success ? "Маппинг сохранён" : undefined } : null} onDismiss={() => setResult(null)} />
+    </section>
+  );
+}

--- a/frontend/src/components/settings/OnecSection.test.tsx
+++ b/frontend/src/components/settings/OnecSection.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { OnecSection } from "./OnecSection";
+
+function noop() {}
+
+function baseProps() {
+  return {
+    baseURL: "https://1c.example.com",
+    setBaseURL: vi.fn(),
+    authType: "basic" as const,
+    setAuthType: vi.fn(),
+    authSecret: "",
+    setAuthSecret: vi.fn(),
+    maskedSecret: "...e123",
+    isActive: false,
+    setIsActive: vi.fn(),
+    maskedWebhook: "...8de2",
+    fullWebhook: null as string | null,
+    regenerating: false,
+    onRegenerate: vi.fn(),
+    saving: false,
+    saveResult: null,
+    onSave: vi.fn(),
+    testing: false,
+    testResult: null,
+    setTestResult: noop,
+    onTest: vi.fn(),
+  };
+}
+
+describe("OnecSection", () => {
+  it("shows the masked secret as placeholder, never as a value", () => {
+    render(<OnecSection {...baseProps()} />);
+    const secret = screen.getByLabelText(/секрет/i) as HTMLInputElement;
+    expect(secret.value).toBe("");
+    expect(secret.placeholder).toContain("...e123");
+  });
+
+  it("calls onSave when the save button is clicked", async () => {
+    const props = baseProps();
+    render(<OnecSection {...props} />);
+    await userEvent.click(screen.getByRole("button", { name: /Сохранить/i }));
+    expect(props.onSave).toHaveBeenCalled();
+  });
+
+  it("calls onTest and renders the result banner", () => {
+    const props = { ...baseProps(), testResult: { success: false, error: "Не удалось подключиться" } };
+    render(<OnecSection {...props} />);
+    expect(screen.getByText("Не удалось подключиться")).toBeInTheDocument();
+  });
+
+  it("reveals the full webhook secret once after regeneration", () => {
+    const full = "a".repeat(64);
+    render(<OnecSection {...baseProps()} fullWebhook={full} />);
+    expect(screen.getByText(full)).toBeInTheDocument();
+  });
+
+  it("calls onRegenerate when the regenerate button is clicked", async () => {
+    const props = baseProps();
+    render(<OnecSection {...props} />);
+    await userEvent.click(screen.getByRole("button", { name: /Сгенерировать/i }));
+    expect(props.onRegenerate).toHaveBeenCalled();
+  });
+
+  it("toggles the active switch", async () => {
+    const props = baseProps();
+    render(<OnecSection {...props} />);
+    await userEvent.click(screen.getByRole("checkbox", { name: /Включить/i }));
+    expect(props.setIsActive).toHaveBeenCalledWith(true);
+  });
+});

--- a/frontend/src/components/settings/OnecSection.tsx
+++ b/frontend/src/components/settings/OnecSection.tsx
@@ -1,0 +1,127 @@
+import { Database, Shield, Loader2, RefreshCw, Save, AlertTriangle } from "lucide-react";
+import type { OnecAuthType } from "@/lib/api";
+import { ConnectionBadge } from "./ConnectionBadge";
+import { HintIcon } from "./HintIcon";
+import { StatusBanner } from "./StatusBanner";
+
+type TestResult = { success: boolean; error?: string } | null;
+
+interface OnecSectionProps {
+  baseURL: string;
+  setBaseURL: (v: string) => void;
+  authType: OnecAuthType;
+  setAuthType: (v: OnecAuthType) => void;
+  authSecret: string;
+  setAuthSecret: (v: string) => void;
+  maskedSecret: string;
+  isActive: boolean;
+  setIsActive: (v: boolean) => void;
+  maskedWebhook: string;
+  fullWebhook: string | null;
+  regenerating: boolean;
+  onRegenerate: () => void;
+  saving: boolean;
+  saveResult: "success" | "error" | null;
+  onSave: () => void;
+  testing: boolean;
+  testResult: TestResult;
+  setTestResult: (v: TestResult) => void;
+  onTest: () => void;
+}
+
+const inputClass =
+  "w-full rounded-lg border-none bg-[#eff4ff] px-4 py-3 text-sm outline-none transition-all focus:ring-2 focus:ring-[#004ac6]/20";
+const labelClass = "mb-2 block text-xs font-bold uppercase tracking-wide text-[#434655]";
+
+export function OnecSection(props: OnecSectionProps) {
+  const {
+    baseURL, setBaseURL, authType, setAuthType, authSecret, setAuthSecret, maskedSecret,
+    isActive, setIsActive, maskedWebhook, fullWebhook, regenerating, onRegenerate,
+    saving, saveResult, onSave, testing, testResult, setTestResult, onTest,
+  } = props;
+
+  const bannerResult = testResult
+    ? { success: testResult.success, message: testResult.success ? "Соединение с 1С установлено" : undefined, error: testResult.error }
+    : null;
+
+  return (
+    <section className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-[#c3c6d7]/10">
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Database className="size-5 text-[#004ac6]" />
+          <h3 className="text-xl font-bold text-[#0d1c2e]">Интеграция с 1С</h3>
+          <HintIcon text="Двусторонняя синхронизация с 1С. Адрес OData-сервиса и учётные данные для исходящих вызовов; webhook-секрет аутентифицирует входящие события из 1С. Секреты хранятся отдельно и не возвращаются в открытом виде." />
+        </div>
+        <ConnectionBadge active={isActive} />
+      </div>
+
+      <div className="grid grid-cols-12 gap-4">
+        <div className="col-span-8">
+          <label className={labelClass} htmlFor="onec-base-url">Адрес OData-сервиса 1С</label>
+          <input id="onec-base-url" type="text" placeholder="https://1c.example.com/odata/standard.odata"
+            value={baseURL} onChange={(e) => setBaseURL(e.target.value)} className={inputClass} />
+        </div>
+        <div className="col-span-4">
+          <label className={labelClass} htmlFor="onec-auth-type">Авторизация</label>
+          <select id="onec-auth-type" value={authType} onChange={(e) => setAuthType(e.target.value as OnecAuthType)} className={inputClass}>
+            <option value="basic">Basic</option>
+            <option value="token">Bearer-токен</option>
+          </select>
+        </div>
+        <div className="col-span-12">
+          <label className={labelClass} htmlFor="onec-secret">
+            {authType === "token" ? "Токен" : "Секрет (base64 user:pass)"}
+          </label>
+          <input id="onec-secret" type="password" aria-label="Секрет авторизации 1С"
+            placeholder={maskedSecret || "не задан"} value={authSecret}
+            onChange={(e) => setAuthSecret(e.target.value)} className={inputClass} />
+        </div>
+      </div>
+
+      <label className="mt-5 flex items-center gap-3 text-sm font-medium text-[#0d1c2e]">
+        <input type="checkbox" aria-label="Включить интеграцию" checked={isActive}
+          onChange={(e) => setIsActive(e.target.checked)} className="size-4 rounded accent-[#004ac6]" />
+        Включить приём и отправку событий 1С
+      </label>
+
+      <div className="mt-6 rounded-lg bg-[#eff4ff] p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <div className={labelClass + " mb-1"}>Webhook-секрет</div>
+            <div className="font-mono text-sm text-[#434655]">{maskedWebhook || "не сгенерирован"}</div>
+          </div>
+          <button onClick={onRegenerate} disabled={regenerating}
+            className="flex items-center gap-2 rounded-lg bg-white px-3 py-2 text-sm font-bold text-[#0d1c2e] transition-colors hover:bg-[#dce9ff] disabled:opacity-50">
+            {regenerating ? <Loader2 className="size-4 animate-spin" /> : <RefreshCw className="size-4" />}
+            Сгенерировать заново
+          </button>
+        </div>
+        {fullWebhook && (
+          <div className="mt-3 rounded-lg bg-amber-50 p-3 ring-1 ring-amber-200">
+            <div className="flex items-center gap-2 text-xs font-bold text-amber-700">
+              <AlertTriangle className="size-4" />
+              Скопируйте секрет сейчас — он показывается один раз.
+            </div>
+            <code className="mt-2 block break-all font-mono text-xs text-amber-900">{fullWebhook}</code>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-6 flex gap-3">
+        <button onClick={onTest} disabled={testing}
+          className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-[#eff4ff] py-3 text-sm font-bold text-[#0d1c2e] transition-colors hover:bg-[#dce9ff] disabled:opacity-50">
+          {testing ? <Loader2 className="size-[18px] animate-spin" /> : <Shield className="size-[18px]" />}
+          {testing ? "Проверяем..." : "Тест соединения"}
+        </button>
+        <button onClick={onSave} disabled={saving}
+          className={`flex flex-1 items-center justify-center gap-2 rounded-lg py-3 text-sm font-bold text-white transition-colors disabled:opacity-50 ${
+            saveResult === "success" ? "bg-green-600" : saveResult === "error" ? "bg-red-600" : "bg-[#004ac6] hover:bg-[#0039a6]"
+          }`}>
+          {saving ? <Loader2 className="size-[18px] animate-spin" /> : <Save className="size-[18px]" />}
+          {saving ? "Сохраняем..." : "Сохранить"}
+        </button>
+      </div>
+      <StatusBanner result={bannerResult} onDismiss={() => setTestResult(null)} />
+    </section>
+  );
+}

--- a/frontend/src/hooks/useOnecSettings.test.ts
+++ b/frontend/src/hooks/useOnecSettings.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { OnecConfig, OnecMapping } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getOnecConfig: vi.fn(),
+    updateOnecConfig: vi.fn(),
+    regenerateOnecWebhook: vi.fn(),
+    testOnec: vi.fn(),
+    getOnecMapping: vi.fn(),
+    updateOnecMapping: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { useOnecSettings } from "./useOnecSettings";
+
+function cfg(over: Partial<OnecConfig> = {}): OnecConfig {
+  return {
+    base_url: over.base_url ?? "https://1c.example.com",
+    auth_type: over.auth_type ?? "basic",
+    auth_secret: over.auth_secret ?? "...e123",
+    webhook_secret: over.webhook_secret ?? "...8de2",
+    is_active: over.is_active ?? false,
+  };
+}
+
+function mapping(over: Partial<OnecMapping> = {}): OnecMapping {
+  return { rules: over.rules ?? [{ external_type: "Документ.Оплата", kind: "payment", email_field: "email" }] };
+}
+
+describe("useOnecSettings", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(api.getOnecConfig).mockResolvedValue(cfg());
+    vi.mocked(api.getOnecMapping).mockResolvedValue(mapping());
+    vi.mocked(api.updateOnecConfig).mockImplementation(async () => cfg());
+    vi.mocked(api.updateOnecMapping).mockResolvedValue({ saved: true });
+    vi.mocked(api.testOnec).mockResolvedValue({ success: true });
+    vi.mocked(api.regenerateOnecWebhook).mockResolvedValue({ webhook_secret: "f".repeat(64) });
+  });
+
+  it("loads config and mapping on mount", async () => {
+    const { result } = renderHook(() => useOnecSettings());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(api.getOnecConfig).toHaveBeenCalledTimes(1);
+    expect(api.getOnecMapping).toHaveBeenCalledTimes(1);
+    expect(result.current.baseURL).toBe("https://1c.example.com");
+    expect(result.current.maskedSecret).toBe("...e123");
+    expect(result.current.rules).toHaveLength(1);
+  });
+
+  it("does not send a masked secret on save (use-stored)", async () => {
+    const { result } = renderHook(() => useOnecSettings());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // The secret input still holds the masked value the user never touched.
+    await act(async () => {
+      result.current.setAuthSecret("...e123");
+      await result.current.save();
+    });
+    const payload = vi.mocked(api.updateOnecConfig).mock.calls[0]![0];
+    expect(payload.auth_secret).toBeUndefined();
+  });
+
+  it("sends a freshly typed secret on save", async () => {
+    const { result } = renderHook(() => useOnecSettings());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      result.current.setAuthSecret("brand-new-secret");
+      await result.current.save();
+    });
+    const payload = vi.mocked(api.updateOnecConfig).mock.calls[0]![0];
+    expect(payload.auth_secret).toBe("brand-new-secret");
+  });
+
+  it("exposes the full webhook secret once after regenerate", async () => {
+    const { result } = renderHook(() => useOnecSettings());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.regenerateWebhook();
+    });
+    expect(result.current.fullWebhook).toBe("f".repeat(64));
+  });
+
+  it("adds, edits and removes mapping rules then saves them", async () => {
+    const { result } = renderHook(() => useOnecSettings());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => result.current.addRule());
+    expect(result.current.rules).toHaveLength(2);
+
+    await act(async () => result.current.updateRule(1, { external_type: "Документ.Заказ", kind: "order_status" }));
+    expect(result.current.rules[1].external_type).toBe("Документ.Заказ");
+
+    await act(async () => result.current.removeRule(0));
+    expect(result.current.rules).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.saveMapping();
+    });
+    expect(api.updateOnecMapping).toHaveBeenCalledWith(result.current.rules);
+  });
+
+  it("runs a connection test with the current form values", async () => {
+    const { result } = renderHook(() => useOnecSettings());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      result.current.setBaseURL("https://new.example.com");
+      await result.current.test();
+    });
+    const payload = vi.mocked(api.testOnec).mock.calls[0]![0];
+    expect(payload.base_url).toBe("https://new.example.com");
+    expect(result.current.testResult?.success).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useOnecSettings.test.ts
+++ b/frontend/src/hooks/useOnecSettings.test.ts
@@ -105,6 +105,13 @@ describe("useOnecSettings", () => {
     expect(api.updateOnecMapping).toHaveBeenCalledWith(result.current.rules);
   });
 
+  it("surfaces a load error instead of swallowing it", async () => {
+    vi.mocked(api.getOnecConfig).mockRejectedValueOnce(new Error("network"));
+    const { result } = renderHook(() => useOnecSettings());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.loadError).toBeTruthy();
+  });
+
   it("runs a connection test with the current form values", async () => {
     const { result } = renderHook(() => useOnecSettings());
     await waitFor(() => expect(result.current.loading).toBe(false));

--- a/frontend/src/hooks/useOnecSettings.test.ts
+++ b/frontend/src/hooks/useOnecSettings.test.ts
@@ -56,8 +56,8 @@ describe("useOnecSettings", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     // The secret input still holds the masked value the user never touched.
+    act(() => result.current.setAuthSecret("...e123"));
     await act(async () => {
-      result.current.setAuthSecret("...e123");
       await result.current.save();
     });
     const payload = vi.mocked(api.updateOnecConfig).mock.calls[0]![0];
@@ -68,8 +68,8 @@ describe("useOnecSettings", () => {
     const { result } = renderHook(() => useOnecSettings());
     await waitFor(() => expect(result.current.loading).toBe(false));
 
+    act(() => result.current.setAuthSecret("brand-new-secret"));
     await act(async () => {
-      result.current.setAuthSecret("brand-new-secret");
       await result.current.save();
     });
     const payload = vi.mocked(api.updateOnecConfig).mock.calls[0]![0];
@@ -109,8 +109,8 @@ describe("useOnecSettings", () => {
     const { result } = renderHook(() => useOnecSettings());
     await waitFor(() => expect(result.current.loading).toBe(false));
 
+    act(() => result.current.setBaseURL("https://new.example.com"));
     await act(async () => {
-      result.current.setBaseURL("https://new.example.com");
       await result.current.test();
     });
     const payload = vi.mocked(api.testOnec).mock.calls[0]![0];

--- a/frontend/src/hooks/useOnecSettings.ts
+++ b/frontend/src/hooks/useOnecSettings.ts
@@ -1,0 +1,186 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  api,
+  type OnecAuthType,
+  type OnecConfig,
+  type OnecConfigUpdate,
+  type OnecMappingRule,
+  type OnecTestResult,
+} from "@/lib/api";
+
+export type OnecTestState = OnecTestResult | null;
+export type SaveState = "success" | "error" | null;
+
+// isMaskedOrEmpty reports whether a secret field holds the masked placeholder
+// (or nothing) — i.e. the user never typed a replacement, so the backend should
+// keep the stored secret. Masked values come back as "...xxxx".
+function isMaskedOrEmpty(v: string): boolean {
+  return v === "" || v.startsWith("...");
+}
+
+const EMPTY_RULE: OnecMappingRule = { external_type: "", kind: "payment", email_field: "" };
+
+// useOnecSettings drives the /settings 1C section. Unlike the channel settings
+// sub-hooks it owns its own persistence (the 1C config is a separate endpoint,
+// not /api/settings). Secrets are never echoed back into the form — the form
+// holds only what the operator types; the masked stored value lives in `config`.
+export function useOnecSettings() {
+  const [config, setConfig] = useState<OnecConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Config form state (secrets start blank; the masked value is shown as a
+  // placeholder, never as a value).
+  const [baseURL, setBaseURL] = useState("");
+  const [authType, setAuthType] = useState<OnecAuthType>("basic");
+  const [authSecret, setAuthSecret] = useState("");
+  const [isActive, setIsActive] = useState(false);
+
+  const [saving, setSaving] = useState(false);
+  const [saveResult, setSaveResult] = useState<SaveState>(null);
+
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<OnecTestState>(null);
+
+  const [regenerating, setRegenerating] = useState(false);
+  const [fullWebhook, setFullWebhook] = useState<string | null>(null);
+
+  // Mapping state.
+  const [rules, setRules] = useState<OnecMappingRule[]>([]);
+  const [savingMapping, setSavingMapping] = useState(false);
+  const [mappingResult, setMappingResult] = useState<OnecTestState>(null);
+
+  const applyConfig = useCallback((c: OnecConfig) => {
+    setConfig(c);
+    setBaseURL(c.base_url);
+    setAuthType(c.auth_type);
+    setIsActive(c.is_active);
+    setAuthSecret(""); // never seed the secret input
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    Promise.all([api.getOnecConfig(), api.getOnecMapping()])
+      .then(([c, m]) => {
+        if (!alive) return;
+        applyConfig(c);
+        setRules(m.rules);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [applyConfig]);
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    setSaveResult(null);
+    try {
+      const update: OnecConfigUpdate = { base_url: baseURL, auth_type: authType, is_active: isActive };
+      if (!isMaskedOrEmpty(authSecret)) {
+        update.auth_secret = authSecret;
+      }
+      const updated = await api.updateOnecConfig(update);
+      applyConfig(updated);
+      setSaveResult("success");
+    } catch {
+      setSaveResult("error");
+    } finally {
+      setSaving(false);
+    }
+  }, [baseURL, authType, isActive, authSecret, applyConfig]);
+
+  const test = useCallback(async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const payload: { base_url?: string; auth_type?: string; auth_secret?: string } = {
+        base_url: baseURL || config?.base_url || "",
+        auth_type: authType,
+      };
+      if (!isMaskedOrEmpty(authSecret)) {
+        payload.auth_secret = authSecret;
+      }
+      setTestResult(await api.testOnec(payload));
+    } catch {
+      setTestResult({ success: false, error: "Ошибка запроса" });
+    } finally {
+      setTesting(false);
+    }
+  }, [baseURL, authType, authSecret, config]);
+
+  const regenerateWebhook = useCallback(async () => {
+    setRegenerating(true);
+    try {
+      const { webhook_secret } = await api.regenerateOnecWebhook();
+      setFullWebhook(webhook_secret);
+      // Refresh so the masked webhook tail updates too.
+      const c = await api.getOnecConfig();
+      applyConfig(c);
+    } catch {
+      // leave fullWebhook null; the section surfaces no secret on failure
+    } finally {
+      setRegenerating(false);
+    }
+  }, [applyConfig]);
+
+  const addRule = useCallback(() => setRules((rs) => [...rs, { ...EMPTY_RULE }]), []);
+  const updateRule = useCallback(
+    (index: number, patch: Partial<OnecMappingRule>) =>
+      setRules((rs) => rs.map((r, i) => (i === index ? { ...r, ...patch } : r))),
+    [],
+  );
+  const removeRule = useCallback((index: number) => setRules((rs) => rs.filter((_, i) => i !== index)), []);
+
+  const saveMapping = useCallback(async () => {
+    setSavingMapping(true);
+    setMappingResult(null);
+    try {
+      await api.updateOnecMapping(rules);
+      setMappingResult({ success: true });
+    } catch (err) {
+      setMappingResult({ success: false, error: err instanceof Error ? err.message : "Ошибка сохранения" });
+    } finally {
+      setSavingMapping(false);
+    }
+  }, [rules]);
+
+  return {
+    loading,
+    config,
+    // config form
+    baseURL,
+    setBaseURL,
+    authType,
+    setAuthType,
+    authSecret,
+    setAuthSecret,
+    isActive,
+    setIsActive,
+    maskedSecret: config?.auth_secret ?? "",
+    maskedWebhook: config?.webhook_secret ?? "",
+    fullWebhook,
+    saving,
+    saveResult,
+    save,
+    testing,
+    testResult,
+    setTestResult,
+    test,
+    regenerating,
+    regenerateWebhook,
+    // mapping
+    rules,
+    addRule,
+    updateRule,
+    removeRule,
+    savingMapping,
+    mappingResult,
+    setMappingResult,
+    saveMapping,
+  };
+}

--- a/frontend/src/hooks/useOnecSettings.ts
+++ b/frontend/src/hooks/useOnecSettings.ts
@@ -29,6 +29,7 @@ const EMPTY_RULE: OnecMappingRule = { external_type: "", kind: "payment", email_
 export function useOnecSettings() {
   const [config, setConfig] = useState<OnecConfig | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // Config form state (secrets start blank; the masked value is shown as a
   // placeholder, never as a value).
@@ -67,7 +68,10 @@ export function useOnecSettings() {
         applyConfig(c);
         setRules(m.rules);
       })
-      .catch(() => {})
+      .catch((e) => {
+        if (!alive) return;
+        setLoadError(e instanceof Error ? e.message : "Не удалось загрузить настройки 1С");
+      })
       .finally(() => {
         if (alive) setLoading(false);
       });
@@ -151,6 +155,7 @@ export function useOnecSettings() {
 
   return {
     loading,
+    loadError,
     config,
     // config form
     baseURL,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -380,6 +380,18 @@ export const api = {
   },
   getInboxAnalytics: (period: AnalyticsPeriod = "month") =>
     apiFetch<InboxFlowResponse>(`/api/analytics/inbox?period=${period}`),
+
+  // 1C integration settings
+  getOnecConfig: () => apiFetch<OnecConfig>("/api/onec/config"),
+  updateOnecConfig: (data: OnecConfigUpdate) =>
+    apiFetch<OnecConfig>("/api/onec/config", { method: "PUT", body: JSON.stringify(data) }),
+  regenerateOnecWebhook: () =>
+    apiFetch<{ webhook_secret: string }>("/api/onec/config/regenerate-webhook", { method: "POST" }),
+  testOnec: (data: { base_url?: string; auth_type?: string; auth_secret?: string }) =>
+    apiFetch<OnecTestResult>("/api/onec/test", { method: "POST", body: JSON.stringify(data) }),
+  getOnecMapping: () => apiFetch<OnecMapping>("/api/onec/mapping"),
+  updateOnecMapping: (rules: OnecMappingRule[]) =>
+    apiFetch<{ saved: boolean }>("/api/onec/mapping", { method: "PUT", body: JSON.stringify({ rules }) }),
   getCostSummary: (from: string, to: string) =>
     apiFetch<CostSummaryResponse>(`/api/audit/cost-summary?from=${from}&to=${to}`),
 };
@@ -706,6 +718,45 @@ export interface HotLeadsParams {
 export interface ScoreBucket {
   range: string;
   count: number;
+}
+
+// 1C integration. Secrets (auth_secret, webhook_secret) arrive MASKED from the
+// API — never the raw value. Send a new auth_secret only when replacing it; an
+// empty or masked value tells the backend to keep the stored one.
+export type OnecAuthType = "basic" | "token";
+
+export interface OnecConfig {
+  base_url: string;
+  auth_type: OnecAuthType;
+  auth_secret: string; // masked
+  webhook_secret: string; // masked
+  is_active: boolean;
+}
+
+export interface OnecConfigUpdate {
+  base_url?: string;
+  auth_type?: OnecAuthType;
+  auth_secret?: string;
+  is_active?: boolean;
+}
+
+export type OnecEventKind = "payment" | "counterparty_created" | "order_status" | "shipment";
+
+export interface OnecMappingRule {
+  external_type: string;
+  kind: OnecEventKind;
+  email_field: string;
+  name_field?: string;
+  company_field?: string;
+}
+
+export interface OnecMapping {
+  rules: OnecMappingRule[];
+}
+
+export interface OnecTestResult {
+  success: boolean;
+  error?: string;
 }
 
 // InboxFlowResponse is the View 3 (inbox flow) read model. by_channel /


### PR DESCRIPTION
## UI настроек 1С-интеграции + хранение/маскирование секретов (Closes #110, закрывает эпик 1С #105)

Последний sub-issue эпика #105 — слой управления 1С-интеграцией из интерфейса. Бэкенд-фундамент (#106-109) уже был; #110 добавляет config-management поверх существующих таблиц `onec_credentials`/`onec_mapping_configs` (миграция НЕ требуется). С ним эпик #105 закрыт полностью.

### Backend (bounded context `internal/integrations/onec`)
- **Новый domain VO `CredentialsConfig`** — фабрика `NewCredentialsConfig`, инвариант `IsActive ⇒ BaseURL≠''`, нормализация URL, формат webhook-секрета (`WebhookSecretBytes=32`). Генерация секрета (crypto/rand→hex) — в infra через порт `SecretGenerator`.
- **`ConfigUseCase`** — маскирование секретов на GET, use-stored семантика (masked/пустое значение не перезаписывает stored), авто-генерация webhook при активации, read-merge-write (без динамического SQL).
- **6 JWT-эндпоинтов** `/api/onec/*`: config GET/PUT, regenerate-webhook (полный секрет один раз), test (тест соединения), mapping GET/PUT.
- **`client.TestConnection`** — authenticated GET в корень OData, типизированные ошибки → русские строки.
- Узкий порт `ConnectionTester` (ISP) — не трогает существующие OneCClient-фейки.

### Frontend
- `useOnecSettings` (самостоятельная персистентность — отдельный эндпоинт), секрет НЕ сидится в инпут (только masked-placeholder).
- `OnecSection` (URL/auth/секрет/webhook/toggle/тест/сохранить) + `OnecMappingEditor` (структурные строки: external_type + kind-dropdown + email/name/company) — в `/settings`.

### Security
Live security-smoke (register→JWT→roundtrip) подтвердил end-to-end: GET маскирует `auth_secret` И `webhook_secret`; PUT masked-значения не затирают stored; regenerate отдаёт полный секрет ровно один раз (далее маскируется); tenant-scope по user_id из JWT; 401 без токена на всех 6 эндпоинтах.

### Осознанные решения
- Collision-retry webhook-секрета не реализован — 256 бит + UNIQUE index делают коллизию криптографически невозможной.
- Маппинг сохраняется с `is_active=true` (активация = сохранение).
- TestConnection бьёт в корень `base_url`, не `/$metadata` (пути 1С варьируются, #108 вне scope).

### Tests
- Backend: domain (table-driven инварианты), usecase (маскирование/use-stored/авто-ген/mapping — фейки), handler (6 эндпоинтов, 401, validation), repository (integration на реальной схеме), client (httptest). TDD RED→GREEN пары.
- Frontend: useOnecSettings (use-stored, regenerate, mapping, load-error) + OnecSection + OnecMappingEditor. 451 vitest зелёных, `next build` OK.
- Code-review (TDD/DDD/CA/Security/FE): 9/9/9/9/8, без blocker/major; оба actionable minor закрыты (≤4-char mask hardening, load-error surfacing).
